### PR TITLE
Fix project url in getting-started-app READMEs

### DIFF
--- a/examples/getting-started-app/README.md
+++ b/examples/getting-started-app/README.md
@@ -41,7 +41,7 @@ You can immediately see what you get at the end of this lesson: just clone
 the project from the repository and run the ready-made solution:
 
 ```bash
-you@yourmachine $ git clone https://github/tarantool/cartridge-cli
+you@yourmachine $ git clone https://github.com/tarantool/cartridge-cli
 you@yourmachine $ cd cartridge-cli/examples/getting-started-app
 ```
 

--- a/examples/getting-started-app/README_RUS.md
+++ b/examples/getting-started-app/README_RUS.md
@@ -39,7 +39,7 @@ you@yourmachine $ tarantoolctl rocks install cartridge-cli
 решение:
 
 ```bash
-you@yourmachine $ git clone https://github/tarantool/cartridge-cli
+you@yourmachine $ git clone https://github.com/tarantool/cartridge-cli
 you@yourmachine $ cd cartridge-cli/examples/getting-started-app
 ```
 


### PR DESCRIPTION
Fix project url in `git clone` commands in getting-started-app example
READMEs