### PR TITLE
Fix rpm build on centos8 by correcting header structure

### DIFF
--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -1698,7 +1698,7 @@ local function pack_rpm(source_dir, dest_dir, name, release, version, opts)
         {'FILEMODES', 'INT16', fileinfo.filemodes},
         {'FILEINODES', 'INT32', fileinfo.fileinodes},
         {'FILEDEVICES', 'INT32', fileinfo.filedevices},
-        {'FILERDEVS', 'INT32', fileinfo.filerdevs},
+        {'FILERDEVS', 'INT16', fileinfo.filerdevs},
         {'FILEMTIMES', 'INT32', fileinfo.filemtimes},
         {'FILEFLAGS', 'INT32', fileinfo.fileflags},
         {'FILELANGS', 'STRING_ARRAY', fileinfo.filelangs},


### PR DESCRIPTION
Rpm prior to centos8 used to ignore wrong integer sizes in the header
structure. Latest rpm installer is stricter about this, and causes the
following error if installing packages made with cartridge-cli on
centos8:

error: demo-0.1.0-0.rpm: tag[23]: BAD, tag 1033 type 5 offset 15488 count 255 len 1020

This is because FILERDEVS structure (code 1033) is INT32 while the
spec says that it should be INT16.