### PR TITLE
Pack docker

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,6 +50,7 @@ prebuild:
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
   script:
     - docker pull $CI_REGISTRY_IMAGE || true
+
     - docker build
       --cache-from $CI_REGISTRY_IMAGE
       --tag $CI_REGISTRY_IMAGE
@@ -65,6 +66,8 @@ include:
   stage: test
   extends: .dind
   image: $CI_REGISTRY_IMAGE
+  variables:
+    TARANTOOL_DOCKER_BUILD_ARGS: --cache-from cache-image
   script:
     - make lint test
 
@@ -74,33 +77,45 @@ test_enterprise-1.10:
     key: $BUNDLE_VERSION
     paths:
       - tmp/sdk-1.10
+      - tmp/cache-image.tar
   variables:
     TARANTOOL_DOWNLOAD_TOKEN: $DOWNLOAD_TOKEN
+    CACHE_IMAGE_TARGET: cache-base
   before_script:
     - docker info
     - make tmp/sdk-1.10
     - source tmp/sdk-1.10/env.sh
     - tarantool -V
     - make ci_prepare
+    - make tmp/cache-image.tar
+    - docker load -i tmp/cache-image.tar
 
 .test_opensource:
   extends: .test_template
+  cache:
+    key: ${TARANTOOL_VERSION}
+    paths:
+      - tmp/cache-image.tar
   before_script:
     - docker info
     - curl -s https://packagecloud.io/install/repositories/tarantool/$TARANTOOL_VERSION/script.rpm.sh | bash
     - yum -y install tarantool tarantool-devel
     - tarantool -V
     - make ci_prepare
+    - make tmp/cache-image.tar
+    - docker load -i tmp/cache-image.tar
 
 test_opensource-1.10:
   extends: .test_opensource
   variables:
     TARANTOOL_VERSION: '1_10'
+    CACHE_IMAGE_TARGET: cache-opensource-1.10
 
 test_opensource-2.2:
   extends: .test_opensource
   variables:
     TARANTOOL_VERSION: '2_2'
+    CACHE_IMAGE_TARGET: cache-opensource-2.2
 
 .e2e-opensource-1.10:
   stage: test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,10 +27,21 @@ variables:
     2x
     2_2
 
-prebuild:
-  stage: prebuild
+.dind:
   tags:
-    - shell
+    - molecule-dind
+  services:
+    - name: docker:dind
+      alias: localhost
+  image: docker
+  variables:
+    DOCKER_DRIVER: overlay2
+    DOCKER_TLS_CERTDIR: ''
+    DOCKER_HOST: tcp://docker:2375/
+
+prebuild:
+  extends: .dind
+  stage: prebuild
   only:
     changes:
       - Dockerfile
@@ -53,16 +64,8 @@ include:
 
 .test_template:
   stage: test
-  tags:
-    - molecule-dind
+  extends: .dind
   image: $CI_REGISTRY_IMAGE
-  services:
-    - name: docker:dind
-      alias: localhost
-  variables:
-    DOCKER_DRIVER: overlay2
-    DOCKER_TLS_CERTDIR: ''
-    DOCKER_HOST: tcp://docker:2375/
   script:
     - make lint test
 
@@ -129,12 +132,8 @@ test_opensource-2.2:
 pack:
   stage: pack
   when: manual
-  tags:
-    - molecule-dind
+  extends: .dind
   image: docker:git
-  services:
-    - name: docker:dind
-      alias: localhost
   variables:
     PRODUCT: cartridge-cli
   before_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,6 +25,11 @@ variables:
     2x
     2_2
 
+.docker_variables: &docker_variables
+  DOCKER_DRIVER: overlay2
+  DOCKER_TLS_CERTDIR: ''
+  DOCKER_HOST: tcp://docker:2375/
+
 prebuild:
   stage: prebuild
   tags:
@@ -80,10 +85,8 @@ test_enterprise-1.10:
     paths:
       - tmp/sdk-1.10
   variables:
+    <<: *docker_variables
     TARANTOOL_DOWNLOAD_TOKEN: $DOWNLOAD_TOKEN
-    DOCKER_DRIVER: overlay2
-    DOCKER_TLS_CERTDIR: ''
-    DOCKER_HOST: tcp://docker:2375/
   before_script:
     - docker info
     - yum -y install $INSTALL_PACKAGES
@@ -104,18 +107,14 @@ test_enterprise-1.10:
 test_opensource-1.10:
   <<: *test_opensource
   variables:
+    <<: *docker_variables
     TARANTOOL_VERSION: '1_10'
-    DOCKER_DRIVER: overlay2
-    DOCKER_TLS_CERTDIR: ''
-    DOCKER_HOST: tcp://docker:2375/
 
 test_opensource-2.2:
   <<: *test_opensource
   variables:
+    <<: *docker_variables
     TARANTOOL_VERSION: '2_2'
-    DOCKER_DRIVER: overlay2
-    DOCKER_TLS_CERTDIR: ''
-    DOCKER_HOST: tcp://docker:2375/
 
 .e2e-opensource-1.10:
   stage: test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ stages:
   - pack
   - deploy
 
-image: centos:7
+image: centos:8
 
 variables:
   BUNDLE_VERSION: 1.10.3-68-g618f48d

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,6 +5,8 @@ stages:
   - pack
   - deploy
 
+image: centos:7
+
 variables:
   INSTALL_PACKAGES: git gcc make cmake unzip python3-pip
   BUNDLE_VERSION: 1.10.3-68-g618f48d
@@ -25,11 +27,6 @@ variables:
     2x
     2_2
 
-.docker_variables: &docker_variables
-  DOCKER_DRIVER: overlay2
-  DOCKER_TLS_CERTDIR: ''
-  DOCKER_HOST: tcp://docker:2375/
-
 prebuild:
   stage: prebuild
   tags:
@@ -43,8 +40,7 @@ prebuild:
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
   script:
     - docker pull $CI_REGISTRY_IMAGE || true
-    - >
-      docker build
+    - docker build
       --cache-from $CI_REGISTRY_IMAGE
       --tag $CI_REGISTRY_IMAGE
       .
@@ -55,19 +51,7 @@ prebuild:
 include:
   remote: https://tarantool.github.io/rocks.tarantool.org/helpers/gitlab-publish-rockspec.yml
 
-.publish_template: &publish_template
-  image: centos:7
-  tags:
-    - docker
-    - mcs
-
-publish-scm-1-rockspec:
-  <<: *publish_template
-
-publish-tagged-rockspec:
-  <<: *publish_template
-
-.test_template: &test_template
+.test_template:
   stage: test
   tags:
     - molecule-dind
@@ -75,17 +59,20 @@ publish-tagged-rockspec:
   services:
     - name: docker:dind
       alias: localhost
+  variables:
+    DOCKER_DRIVER: overlay2
+    DOCKER_TLS_CERTDIR: ''
+    DOCKER_HOST: tcp://docker:2375/
   script:
     - make lint test
 
 test_enterprise-1.10:
-  <<: *test_template
+  extends: .test_template
   cache:
     key: $BUNDLE_VERSION
     paths:
       - tmp/sdk-1.10
   variables:
-    <<: *docker_variables
     TARANTOOL_DOWNLOAD_TOKEN: $DOWNLOAD_TOKEN
   before_script:
     - docker info
@@ -95,8 +82,8 @@ test_enterprise-1.10:
     - tarantool -V
     - make ci_prepare
 
-.test_opensource: &test_opensource
-  <<: *test_template
+.test_opensource:
+  extends: .test_template
   before_script:
     - docker info
     - curl -s https://packagecloud.io/install/repositories/tarantool/$TARANTOOL_VERSION/script.rpm.sh | bash
@@ -105,15 +92,13 @@ test_enterprise-1.10:
     - make ci_prepare
 
 test_opensource-1.10:
-  <<: *test_opensource
+  extends: .test_opensource
   variables:
-    <<: *docker_variables
     TARANTOOL_VERSION: '1_10'
 
 test_opensource-2.2:
-  <<: *test_opensource
+  extends: .test_opensource
   variables:
-    <<: *docker_variables
     TARANTOOL_VERSION: '2_2'
 
 .e2e-opensource-1.10:
@@ -173,7 +158,6 @@ deploy:
   when: manual
   tags:
     - docker
-    - mcs
   image:
     name: digitalocean/packagecloud
     entrypoint: ['']

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,11 +1,12 @@
 stages:
+  - prebuild
   - test
   - publish
   - pack
   - deploy
 
 variables:
-  INSTALL_PACKAGES: git gcc make cmake unzip python36-pip
+  INSTALL_PACKAGES: git gcc make cmake unzip python3-pip
   BUNDLE_VERSION: 1.10.3-68-g618f48d
   PACKAGE_TARGETS: |
     OS=el DIST=6
@@ -24,24 +25,51 @@ variables:
     2x
     2_2
 
-.job: &job
+prebuild:
+  stage: prebuild
+  tags:
+    - shell
+  only:
+    changes:
+      - Dockerfile
+      - wrapdocker
+      - .gitlab-ci.yml
+  before_script:
+    - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
+  script:
+    - docker pull $CI_REGISTRY_IMAGE || true
+    - >
+      docker build
+      --cache-from $CI_REGISTRY_IMAGE
+      --tag $CI_REGISTRY_IMAGE
+      .
+    - docker push $CI_REGISTRY_IMAGE
+  after_script:
+    - docker logout registry.gitlab.com
+
+include:
+  remote: https://tarantool.github.io/rocks.tarantool.org/helpers/gitlab-publish-rockspec.yml
+
+.publish_template: &publish_template
   image: centos:7
   tags:
     - docker
     - mcs
 
-include:
-  remote: https://tarantool.github.io/rocks.tarantool.org/helpers/gitlab-publish-rockspec.yml
-
 publish-scm-1-rockspec:
-  <<: *job
+  <<: *publish_template
 
 publish-tagged-rockspec:
-  <<: *job
+  <<: *publish_template
 
 .test_template: &test_template
-  <<: *job
   stage: test
+  tags:
+    - molecule-dind
+  image: $CI_REGISTRY_IMAGE
+  services:
+    - name: docker:dind
+      alias: localhost
   script:
     - make lint test
 
@@ -51,7 +79,13 @@ test_enterprise-1.10:
     key: $BUNDLE_VERSION
     paths:
       - tmp/sdk-1.10
+  variables:
+    TARANTOOL_DOWNLOAD_TOKEN: $DOWNLOAD_TOKEN
+    DOCKER_DRIVER: overlay2
+    DOCKER_TLS_CERTDIR: ''
+    DOCKER_HOST: tcp://docker:2375/
   before_script:
+    - docker info
     - yum -y install $INSTALL_PACKAGES
     - make tmp/sdk-1.10
     - source tmp/sdk-1.10/env.sh
@@ -61,6 +95,7 @@ test_enterprise-1.10:
 .test_opensource: &test_opensource
   <<: *test_template
   before_script:
+    - docker info
     - curl -s https://packagecloud.io/install/repositories/tarantool/$TARANTOOL_VERSION/script.rpm.sh | bash
     - yum -y install tarantool tarantool-devel $INSTALL_PACKAGES
     - tarantool -V
@@ -70,11 +105,17 @@ test_opensource-1.10:
   <<: *test_opensource
   variables:
     TARANTOOL_VERSION: '1_10'
+    DOCKER_DRIVER: overlay2
+    DOCKER_TLS_CERTDIR: ''
+    DOCKER_HOST: tcp://docker:2375/
 
 test_opensource-2.2:
   <<: *test_opensource
   variables:
     TARANTOOL_VERSION: '2_2'
+    DOCKER_DRIVER: overlay2
+    DOCKER_TLS_CERTDIR: ''
+    DOCKER_HOST: tcp://docker:2375/
 
 .e2e-opensource-1.10:
   stage: test
@@ -102,7 +143,6 @@ test_opensource-2.2:
     - vagrant destroy
 
 pack:
-  <<: *job
   stage: pack
   when: manual
   tags:
@@ -113,8 +153,6 @@ pack:
       alias: localhost
   variables:
     PRODUCT: cartridge-cli
-    DOCKER_DRIVER: overlay2
-    DOCKER_TLS_CERTDIR: ''
   before_script:
     - git describe --long
     - git clone https://github.com/packpack/packpack.git packpack
@@ -132,9 +170,11 @@ pack:
       - build/
 
 deploy:
-  <<: *job
   stage: deploy
   when: manual
+  tags:
+    - docker
+    - mcs
   image:
     name: digitalocean/packagecloud
     entrypoint: ['']

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,6 @@ stages:
 image: centos:7
 
 variables:
-  INSTALL_PACKAGES: git gcc make cmake unzip python3-pip
   BUNDLE_VERSION: 1.10.3-68-g618f48d
   PACKAGE_TARGETS: |
     OS=el DIST=6
@@ -42,6 +41,8 @@ variables:
 prebuild:
   extends: .dind
   stage: prebuild
+  variables:
+    INSTALL_PACKAGES: git gcc make cmake unzip python3-pip
   only:
     changes:
       - Dockerfile
@@ -51,9 +52,11 @@ prebuild:
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
   script:
     - docker pull $CI_REGISTRY_IMAGE || true
+    - echo $INSTALL_PACKAGES
     - docker build
       --cache-from $CI_REGISTRY_IMAGE
       --tag $CI_REGISTRY_IMAGE
+      --build-arg INSTALL_PACKAGES=$INSTALL_PACKAGES
       .
     - docker push $CI_REGISTRY_IMAGE
   after_script:
@@ -79,7 +82,6 @@ test_enterprise-1.10:
     TARANTOOL_DOWNLOAD_TOKEN: $DOWNLOAD_TOKEN
   before_script:
     - docker info
-    - yum -y install $INSTALL_PACKAGES
     - make tmp/sdk-1.10
     - source tmp/sdk-1.10/env.sh
     - tarantool -V
@@ -90,7 +92,7 @@ test_enterprise-1.10:
   before_script:
     - docker info
     - curl -s https://packagecloud.io/install/repositories/tarantool/$TARANTOOL_VERSION/script.rpm.sh | bash
-    - yum -y install tarantool tarantool-devel $INSTALL_PACKAGES
+    - yum -y install tarantool tarantool-devel
     - tarantool -V
     - make ci_prepare
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,8 +41,6 @@ variables:
 prebuild:
   extends: .dind
   stage: prebuild
-  variables:
-    INSTALL_PACKAGES: git gcc make cmake unzip python3-pip
   only:
     changes:
       - Dockerfile
@@ -52,11 +50,9 @@ prebuild:
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
   script:
     - docker pull $CI_REGISTRY_IMAGE || true
-    - echo $INSTALL_PACKAGES
     - docker build
       --cache-from $CI_REGISTRY_IMAGE
       --tag $CI_REGISTRY_IMAGE
-      --build-arg INSTALL_PACKAGES=$INSTALL_PACKAGES
       .
     - docker push $CI_REGISTRY_IMAGE
   after_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 <!-- Please update cartridge-cli/VERSION.lua with new release -->
 
+### Added
+- Packing to Docker image
+
 ## [1.2.1] - 2019-11-25
 
 - Fix building RPM package on CentOS 8

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM centos:8
 
+ARG INSTALL_PACKAGES
+
 RUN yum -y update
 RUN yum install -y yum-utils device-mapper-persistent-data lvm2
 RUN yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
@@ -12,6 +14,8 @@ ENV PORT=2375
 
 ADD wrapdocker /usr/local/bin/wrapdocker
 RUN chmod +x /usr/local/bin/wrapdocker
+
+RUN yum install -y $INSTALL_PACKAGES
 
 EXPOSE 2375
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
 FROM centos:8
 
-ARG INSTALL_PACKAGES
-
 RUN yum -y update
+RUN yum install -y git gcc make cmake unzip python3-pip
+
 RUN yum install -y yum-utils device-mapper-persistent-data lvm2
 RUN yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-
 RUN yum install -y docker-ce-18.09.1
 
 VOLUME /var/lib/docker
@@ -14,8 +13,6 @@ ENV PORT=2375
 
 ADD wrapdocker /usr/local/bin/wrapdocker
 RUN chmod +x /usr/local/bin/wrapdocker
-
-RUN yum install -y $INSTALL_PACKAGES
 
 EXPOSE 2375
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM centos:8
+
+RUN yum -y update
+RUN yum install -y yum-utils device-mapper-persistent-data lvm2
+RUN yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+
+RUN yum install -y docker-ce-18.09.1
+
+VOLUME /var/lib/docker
+
+ENV PORT=2375
+
+ADD wrapdocker /usr/local/bin/wrapdocker
+RUN chmod +x /usr/local/bin/wrapdocker
+
+EXPOSE 2375
+
+ENTRYPOINT [ "/usr/local/bin/wrapdocker" ]
+
+CMD ["/bin/bash" , "-l"]

--- a/Dockerfile.cache
+++ b/Dockerfile.cache
@@ -1,0 +1,26 @@
+FROM centos:8 as cache-base
+SHELL ["/bin/bash", "-c"]
+
+RUN yum install -y git gcc make cmake unzip
+
+# create user and directories
+RUN groupadd -r tarantool \
+    && useradd -M -N -g tarantool -r -d /var/lib/tarantool -s /sbin/nologin \
+        -c "Tarantool Server" tarantool \
+    &&  mkdir -p /var/lib/tarantool/ --mode 755 \
+    && chown tarantool:tarantool /var/lib/tarantool \
+    && mkdir -p /var/run/tarantool/ --mode 755 \
+    && chown tarantool:tarantool /var/run/tarantool
+
+FROM cache-base as cache-opensource-1.10
+
+RUN curl -s \
+        https://packagecloud.io/install/repositories/tarantool/1_10/script.rpm.sh | bash \
+    && yum -y install tarantool tarantool-devel
+
+
+FROM cache-base as cache-opensource-2.2
+
+RUN curl -s \
+        https://packagecloud.io/install/repositories/tarantool/2_2/script.rpm.sh | bash \
+    && yum -y install tarantool tarantool-devel

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ python_deps:
 
 .PHONY: pytest
 pytest: bootstrap
-	python3.6 -m pytest -vvls --durations=0
+	python3.6 -m pytest -vvl --durations=0
 
 .PHONY: test-getting-started
 test-getting-started: bootstrap

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,13 @@ tmp/sdk-1.10:
 	mv tmp/tarantool-enterprise tmp/sdk-1.10
 	rm -f tarantool-enterprise-bundle-${BUNDLE_VERSION}.tar.gz
 
+tmp/cache-image.tar:
+	docker build \
+		--tag cache-image \
+		--target ${CACHE_IMAGE_TARGET} \
+		- < Dockerfile.cache
+	docker save -o tmp/cache-image.tar cache-image
+
 .PHONY: lint
 lint: bootstrap
 	.rocks/bin/luacheck ./
@@ -27,7 +34,7 @@ python_deps:
 
 .PHONY: pytest
 pytest: bootstrap
-	python3.6 -m pytest -vvl
+	python3.6 -m pytest -vvls --durations=0
 
 .PHONY: test-getting-started
 test-getting-started: bootstrap

--- a/README.md
+++ b/README.md
@@ -131,7 +131,14 @@ This instance will look up its [configuration](https://www.tarantool.io/en/doc/2
 
 #### Docker
 
-`cartridge pack docker ./myapp` will build docker image and tag it as `myapp:<version>-<patch>`.
+`cartridge pack docker ./myapp` will build docker image.
+
+Image is tagged:
+* `<name>:<detected_version>`: by default;
+* `<name>:<version>`: if `--version` parameter is specified;
+* `<tag>`: if `--tag` parameter is specified;
+
+`<name>` can be specified in `--name` parameter, otherwise it will be auto-detected from application rockspec.
 
 For Tarantool Enterprise you should specify download token using `--download_token` parameter or `TARANTOOL_DOWNLOAD_TOKEN` environment variable.
 It's needed to download SDK on result image.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ This instance will look up its [configuration](https://www.tarantool.io/en/doc/2
 For Tarantool Enterprise you should specify download token using `--download_token` parameter or `TARANTOOL_DOWNLOAD_TOKEN` environment variable.
 It's needed to download SDK on result image.
 
+If you want `docker build` command to be runned with custom arguments, you can specify them using `TARANTOOL_DOCKER_BUILD_ARGS` environment variable.
+For example, `TARANTOOL_DOCKER_BUILD_ARGS='--no-cache --quiet'`
+
 Application code will be placed in `/usr/share/tarantool/${app_name}` directory.
 Opensource Tarantool will be installed on image.
 

--- a/README.md
+++ b/README.md
@@ -85,8 +85,93 @@ cartridge create --name myapp
 Pack an application into a distributable:
 
 ```sh
-cartridge pack rpm myapp
+cartridge pack rpm ./myapp
 ```
+
+### Application packing details
+
+Application can be packed by running `cartridge pack <type> <path>` command.
+Now `rpm`, `deb`, `tgz`, `rock` and `docker` types of distributables are supported.
+
+There is one important detail about `rmp`, `deb` and `tgz` packing: for this types of packages rocks modules and executables specific for the system where `cartridge pack` command is running will be delivered.
+If you use `docker` packing, the result image will contain rocks modules and executables specific for the base image (`centos:8`).
+
+#### TGZ
+
+`cartridge pack tgz ./myapp` will create .tgz archive contains application source code and rocks modules described in application rockspec.
+
+#### RPM and DEB
+
+`cartridge pack rpm|deb ./myapp` will create RPM or DEB package.
+
+In case of opensource Tarantool package has `tarantool` dependency (version >= `<major>.<minor>` and < `<major+1>`, where `<major>.<minor>` is version of Tarantool used for application packing).
+You should enable Tarantool repo to allow your package manager install this dependency correctly.
+
+After package installation:
+
+* application code and rocks modules described in application rockspec will be placed in `/usr/share/tarantool/<app_name>` directory (for Tarantool Enterprise this directory will contain also `tarantool` and `tarantoolctl` binaries);
+
+* unit files for running application as a `systemd` service will be delivered in `/etc/systemd/system`;
+
+This directories will be created:
+
+* `/etc/tarantool/conf.d/` - directory for instances configuration;
+* `/var/lib/tarantool/` - directory to store instances snapshots;
+* `/var/run/tarantool/` - directory to store PID-files and console sockets.
+
+Read the [doc](https://www.tarantool.io/en/doc/2.2/book/cartridge/cartridge_dev/#deploying-an-application) to learn more about Tarantool Cartridge application deployment.
+
+To start the `instance-1` instance of the `myapp` service:
+
+```bash
+systemctl start myapp@instance-1
+```
+
+This instance will look up its [configuration](https://www.tarantool.io/en/doc/2.2/book/cartridge/cartridge_dev/#configuring-instances) across all sections of the YAML file(s) stored in /etc/tarantool/conf.d/*.
+
+#### Docker
+
+`cartridge pack docker ./myapp` will build docker image and tag it as `myapp:<version>-<patch>`.
+
+For Tarantool Enterprise you should specify download token using `--download_token` parameter or `TARANTOOL_DOWNLOAD_TOKEN` environment variable.
+It's needed to download SDK on result image.
+
+Application code will be placed in `/usr/share/tarantool/${app_name}` directory.
+Opensource Tarantool will be installed on image.
+
+Run directory is `/var/run/tarantool/${app_name}`, workdir is `/var/lib/tarantool/${app_name}`.
+
+To start the `instance-1` instance of the `myapp` application:
+
+```bash
+docker run -d --env-file env.instance-1 \
+                --name instance-1 \
+                myapp:1.0.0
+```
+
+File `env.instance-1` contains instance configuration (see the [doc](https://www.tarantool.io/en/doc/2.2/book/cartridge/cartridge_dev/#configuring-instances)):
+
+```bash
+TARANTOOL_INSTANCE_NAME=instance-1
+TARANTOOL_ADVERTISE_URI=3302
+TARANTOOL_CLUSTER_COOKIE=secret
+TARANTOOL_HTTP_PORT=8082
+```
+
+By default, `TARANTOOL_INSTANCE_NAME` is set to `default`.
+
+To check instance logs:
+
+```bash
+docker logs instance-1
+```
+
+It's user responsibility to set up right advertise URI (`<host>:<port>`) if containers are deployed on different machines.
+
+If user specifies only port, cartridge will use auto-detected IP, so user have to configure docker networks to set up instances communication.
+
+You can use docker volumes to store instance snaps and xlogs on host machine.
+To start image with a new application code just stop the old container and start a new one using new image.
 
 ### Managing instances
 

--- a/README.md
+++ b/README.md
@@ -147,18 +147,13 @@ Run directory is `/var/run/tarantool/${app_name}`, workdir is `/var/lib/tarantoo
 To start the `instance-1` instance of the `myapp` application:
 
 ```bash
-docker run -d --env-file env.instance-1 \
+docker run -d \
                 --name instance-1 \
+                -e TARANTOOL_INSTANCE_NAME=instance-1 \
+                -e TARANTOOL_ADVERTISE_URI=3302 \
+                -e TARANTOOL_CLUSTER_COOKIE=secret \
+                -e TARANTOOL_HTTP_PORT=8082 \
                 myapp:1.0.0
-```
-
-File `env.instance-1` contains instance configuration (see the [doc](https://www.tarantool.io/en/doc/2.2/book/cartridge/cartridge_dev/#configuring-instances)):
-
-```bash
-TARANTOOL_INSTANCE_NAME=instance-1
-TARANTOOL_ADVERTISE_URI=3302
-TARANTOOL_CLUSTER_COOKIE=secret
-TARANTOOL_HTTP_PORT=8082
 ```
 
 By default, `TARANTOOL_INSTANCE_NAME` is set to `default`.

--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -1105,7 +1105,7 @@ local function form_distribution_dir(source_dir, destdir, app_name, app_version,
                  "normally ignored are shipped to the resulting package. ")
     end
 
-    if opts.build_rocks then
+    if not opts.skip_build then
         if tarantool_is_enterprise() then
             local tarantool_dir = get_tarantool_dir()
             assert(fio.copyfile(fio.pathjoin(tarantool_dir, 'tarantool'),
@@ -1958,7 +1958,7 @@ local function pack_docker(source_dir, _, name, release, version, opts)
     print("Packing docker in: " .. tmpdir)
 
     local distribution_dir = fio.pathjoin(tmpdir, name)
-    form_distribution_dir(source_dir, distribution_dir, name, version, {build_rocks = false})
+    form_distribution_dir(source_dir, distribution_dir, name, version, {skip_build = true})
 
     local expand_params = {
         name = name,

--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -2004,9 +2004,14 @@ local function pack_docker(source_dir, _, name, release, version, opts)
         die("docker binary is required to pack docker image")
     end
 
+    local download_token_arg = ''
+    if tarantool_is_enterprise() then
+        download_token_arg = string.format('--build-arg DOWNLOAD_TOKEN=%s', opts.download_token)
+    end
+
     print(call(string.format(
-        "cd %s && docker build -t %s --build-arg DOWNLOAD_TOKEN=%s %s . 1>&2",
-        tmpdir, image_fullname, opts.download_token or '', opts.docker_build_args
+        "cd %s && docker build -t %s %s %s . 1>&2",
+        tmpdir, image_fullname, download_token_arg, opts.docker_build_args
     )))
 
     print('Resulting image tagged as: ' .. image_fullname)

--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -1142,6 +1142,7 @@ local function build_application(dir)
 end
 
 local function copy_taranool_binaries(dir)
+    assert(tarantool_is_enterprise())
     local tarantool_dir = get_tarantool_dir()
     assert(fio.copyfile(fio.pathjoin(tarantool_dir, 'tarantool'),
                         fio.pathjoin(dir, 'tarantool')))

--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -893,6 +893,8 @@ RUN chown -R tarantool:tarantool ${dir}
 
 RUN echo 'd /var/run/tarantool 0755 tarantool tarantool' > /usr/lib/tmpfiles.d/${name}.conf
 
+USER tarantool:tarantool
+
 CMD TARANTOOL_WORKDIR=${workdir}.${instance_name} \
     TARANTOOL_PID_FILE=/var/run/tarantool/${name}.${instance_name}.pid \
     TARANTOOL_CONSOLE_SOCK=/var/run/tarantool/${name}.${instance_name}.control \

--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -1975,6 +1975,11 @@ end
 local function pack_docker(source_dir, _, name, release, version, opts)
     opts = opts or {}
 
+    local docker = which('docker')
+    if docker == nil then
+        die("docker binary is required to pack docker image")
+    end
+
     local tmpdir = fio.tempdir()
     print("Packing docker in: " .. tmpdir)
 
@@ -2017,11 +2022,6 @@ local function pack_docker(source_dir, _, name, release, version, opts)
 
     local image_fullname = string.format('%s:%s-%s', name, table.concat(version, '.'), release)
     print(string.format('Building docker image: %s', image_fullname))
-
-    local docker = which('docker')
-    if docker == nil then
-        die("docker binary is required to pack docker image")
-    end
 
     local download_token_arg = ''
     if tarantool_is_enterprise() then

--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -1107,7 +1107,7 @@ local function form_distribution_dir(source_dir, destdir, app_name, app_version,
                  "normally ignored are shipped to the resulting package. ")
     end
 
-    if not opts.skip_build then
+    if not opts.skip_tarantool_binaries then
         if tarantool_is_enterprise() then
             local tarantool_dir = get_tarantool_dir()
             assert(fio.copyfile(fio.pathjoin(tarantool_dir, 'tarantool'),
@@ -1115,7 +1115,9 @@ local function form_distribution_dir(source_dir, destdir, app_name, app_version,
             assert(fio.copyfile(fio.pathjoin(tarantool_dir, 'tarantoolctl'),
                                 fio.pathjoin(destdir, 'tarantoolctl')))
         end
+    end
 
+    if not opts.skip_build then
         if fio.path.exists(fio.pathjoin(destdir, '.cartridge.pre')) then
             print("Running .cartridge.pre")
             local ret = os.execute(
@@ -1955,12 +1957,14 @@ end
 local function pack_docker(source_dir, _, name, release, version, opts)
     opts = opts or {}
 
-    -- local tmpdir = fio.tempdir() -- XXX
-    local tmpdir = './tmp'
+    local tmpdir = fio.tempdir()
     print("Packing docker in: " .. tmpdir)
 
     local distribution_dir = fio.pathjoin(tmpdir, name)
-    form_distribution_dir(source_dir, distribution_dir, name, version, {skip_build = true})
+    form_distribution_dir(source_dir, distribution_dir, name, version, {
+        skip_tarantool_binaries = true,
+        skip_build = true,
+    })
 
     local expand_params = {
         name = name,

--- a/test/python/requirements.txt
+++ b/test/python/requirements.txt
@@ -2,3 +2,4 @@ pytest
 tarantool
 requests
 rpmfile==0.1.4
+docker

--- a/test/python/test_create.py
+++ b/test/python/test_create.py
@@ -9,9 +9,6 @@ from utils import tarantool_enterprise_is_used
 
 @pytest.fixture(scope="module", params=['cartridge'])
 def project_path(request, module_tmpdir):
-    if request.param == 'cartridge' and not tarantool_enterprise_is_used():
-        pytest.skip('Skip cartridge template test for Opensource Tarantool')
-
     return create_project(module_tmpdir, 'project-'+request.param, request.param)
 
 def test_project(project_path):

--- a/test/python/test_pack.py
+++ b/test/python/test_pack.py
@@ -465,7 +465,8 @@ def run_command_on_image(docker_client, image_name, command):
     return output.decode("utf-8").strip()
 
 
-def test_pack_docker(project_path, docker_image, tmpdir, docker_client):
+@pytest.mark.skip(reason="no way of currently testing this on Gitlab CI")
+def test_docker_pack(project_path, docker_image, tmpdir, docker_client):
     image_name = docker_image['name']
 
     # check /usr/share/tarantool/${project_name} contents

--- a/test/python/test_pack.py
+++ b/test/python/test_pack.py
@@ -460,12 +460,11 @@ def run_command_on_image(docker_client, image_name, command):
     output = docker_client.containers.run(
         image_name,
         command,
-        auto_remove=True
+        remove=True
     )
     return output.decode("utf-8").strip()
 
 
-@pytest.mark.skip(reason="no way of currently testing this on Gitlab CI")
 def test_docker_pack(project_path, docker_image, tmpdir, docker_client):
     image_name = docker_image['name']
 

--- a/wrapdocker
+++ b/wrapdocker
@@ -46,7 +46,7 @@ do
         # "name=foo". This shouldn't have any adverse effect.
         echo $SUBSYS | grep -q ^name= && {
                 NAME=$(echo $SUBSYS | sed s/^name=//)
-                ln -s $SUBSYS $CGROUP/$NAME || true
+                ln -s $SUBSYS $CGROUP/$NAME >/dev/null 2>&1 || true
         }
 
         # Likewise, on at least one system, it has been reported that

--- a/wrapdocker
+++ b/wrapdocker
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+# Ensure that all nodes in /dev/mapper correspond to mapped devices currently loaded by the device-mapper kernel driver
+dmsetup mknodes
+
+# First, make sure that cgroups are mounted correctly.
+CGROUP=/sys/fs/cgroup
+: {LOG:=stdio}
+
+[ -d $CGROUP ] ||
+	mkdir $CGROUP
+
+mountpoint -q $CGROUP ||
+	mount -n -t tmpfs -o uid=0,gid=0,mode=0755 cgroup $CGROUP || {
+		echo "Could not make a tmpfs mount. Did you use --privileged?"
+		exit 1
+	}
+
+if [ -d /sys/kernel/security ] && ! mountpoint -q /sys/kernel/security
+then
+    mount -t securityfs none /sys/kernel/security || {
+        echo "Could not mount /sys/kernel/security."
+        echo "AppArmor detection and --privileged mode might break."
+    }
+fi
+
+# Mount the cgroup hierarchies exactly as they are in the parent system.
+for SUBSYS in $(cut -d: -f2 /proc/1/cgroup)
+do
+        [ -d $CGROUP/$SUBSYS ] || mkdir $CGROUP/$SUBSYS
+        mountpoint -q $CGROUP/$SUBSYS ||
+                mount -n -t cgroup -o $SUBSYS cgroup $CGROUP/$SUBSYS
+
+        # The two following sections address a bug which manifests itself
+        # by a cryptic "lxc-start: no ns_cgroup option specified" when
+        # trying to start containers withina container.
+        # The bug seems to appear when the cgroup hierarchies are not
+        # mounted on the exact same directories in the host, and in the
+        # container.
+
+        # Named, control-less cgroups are mounted with "-o name=foo"
+        # (and appear as such under /proc/<pid>/cgroup) but are usually
+        # mounted on a directory named "foo" (without the "name=" prefix).
+        # Systemd and OpenRC (and possibly others) both create such a
+        # cgroup. To avoid the aforementioned bug, we symlink "foo" to
+        # "name=foo". This shouldn't have any adverse effect.
+        echo $SUBSYS | grep -q ^name= && {
+                NAME=$(echo $SUBSYS | sed s/^name=//)
+                ln -s $SUBSYS $CGROUP/$NAME || true
+        }
+
+        # Likewise, on at least one system, it has been reported that
+        # systemd would mount the CPU and CPU accounting controllers
+        # (respectively "cpu" and "cpuacct") with "-o cpuacct,cpu"
+        # but on a directory called "cpu,cpuacct" (note the inversion
+        # in the order of the groups). This tries to work around it.
+        [ $SUBSYS = cpuacct,cpu ] && ln -s $SUBSYS $CGROUP/cpu,cpuacct
+done
+
+# Note: as I write those lines, the LXC userland tools cannot setup
+# a "sub-container" properly if the "devices" cgroup is not in its
+# own hierarchy. Let's detect this and issue a warning.
+grep -q :devices: /proc/1/cgroup ||
+	echo "WARNING: the 'devices' cgroup should be in its own hierarchy."
+grep -qw devices /proc/1/cgroup ||
+	echo "WARNING: it looks like the 'devices' cgroup is not mounted."
+
+# Now, close extraneous file descriptors.
+pushd /proc/self/fd >/dev/null
+for FD in *
+do
+	case "$FD" in
+	# Keep stdin/stdout/stderr
+	[012])
+		;;
+	# Nuke everything else
+	*)
+		eval exec "$FD>&-"
+		;;
+	esac
+done
+popd >/dev/null
+
+
+# If a pidfile is still around (for example after a container restart),
+# delete it so that docker can start.
+rm -rf /var/run/docker.pid
+
+# If we were given a PORT environment variable, start as a simple daemon;
+# otherwise, spawn a shell as well
+if [ "$PORT" ]
+then
+	exec dockerd -H 0.0.0.0:$PORT -H unix:///var/run/docker.sock \
+		$DOCKER_DAEMON_ARGS &>/var/log/docker.log &
+else
+	if [ "$LOG" == "file" ]
+	then
+		dockerd $DOCKER_DAEMON_ARGS &>/var/log/docker.log &
+	else
+		dockerd $DOCKER_DAEMON_ARGS &
+	fi
+	(( timeout = 60 + SECONDS ))
+	until docker info >/dev/null 2>&1
+	do
+		if (( SECONDS >= timeout )); then
+			echo 'Timed out trying to connect to internal docker host.' >&2
+			break
+		fi
+		sleep 1
+	done
+	#[[ $1 ]] && exec "$@"
+	#exec bash --login
+fi
+
+[[ $1 ]] && exec "$@"

--- a/wrapdocker
+++ b/wrapdocker
@@ -54,7 +54,7 @@ do
         # (respectively "cpu" and "cpuacct") with "-o cpuacct,cpu"
         # but on a directory called "cpu,cpuacct" (note the inversion
         # in the order of the groups). This tries to work around it.
-        [ $SUBSYS = cpuacct,cpu ] && ln -s $SUBSYS $CGROUP/cpu,cpuacct
+        [ $SUBSYS = cpuacct,cpu ] && ln -s $SUBSYS $CGROUP/cpu,cpuacct >/dev/null 2>&1 || true
 done
 
 # Note: as I write those lines, the LXC userland tools cannot setup


### PR DESCRIPTION
* `cartridge pack docker ./myapp` provides docker image (more details in #18)
* Build (`.cartridge.pre` + `rocks make`) is performed inside the container.
* For Tarantool Enterprise `--download_token` argument or `TARANTOOL_DOWNLOAD_TOKEN` env variable is required to download SDK (and I have no idea how to run tests correctly in this case, now it requires setting `TARANTOOL_DOWNLOAD_TOKEN` env variable to run tests for Enterprise).
* Tarantool (or bundle) version is detected from environment.
* Tarantool enterprise bundle is placed in `/usr/share/tarantool-enterprise` directory (added to `PATH`).
* Gitlab CI tests are running in centos-dind image stored on Gitlab Registry and built on `prebuild` stage.
* `TARANTOOL_DOCKER_BUILD_ARGS` is added to specify `docker build` options for  `docker build` command.
* Project-independent layers of test images are cached in Gitlab CI for different Tarantool versions to speed up `test_docker_pack` test.
* Added `--tag` parameter for `pack docker` command to override result image tag.