### PR TITLE
Fix modes and owners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 <!-- Please update cartridge-cli/VERSION.lua with new release -->
 
 ### Added
+
 - Packing to Docker image
+- Check filemodes before packing
 
 ## [1.2.1] - 2019-11-25
 

--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -876,13 +876,10 @@ RUN groupadd -r tarantool \
 ${install_tarantool}
 
 RUN echo 'd /var/run/tarantool 644 tarantool tarantool' > /usr/lib/tmpfiles.d/${name}.conf \
-    && chown root:root /usr/lib/tmpfiles.d/${name}.conf \
     && chmod 644 /usr/lib/tmpfiles.d/${name}.conf
 
 # copy application source code
 COPY ${name}/ ${dir}
-RUN chown -R root:root ${dir} \
-    && chmod -R 755 ${dir}
 
 WORKDIR ${dir}
 

--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -760,7 +760,7 @@ ${chown} tarantool:tarantool /var/run/tarantool 2>&1 || :
 
 local SET_OWNER_SCRIPT = [[
 ${chown} -R root:root /usr/share/tarantool/${name}
-${chmod} -R 555 /usr/share/tarantool/${name}
+${chmod} -R 755 /usr/share/tarantool/${name}
 ${chown} -R root:root /etc/systemd/system/${name}.service /etc/systemd/system/${name}@.service
 ${chmod} -R 644 /etc/systemd/system/${name}.service /etc/systemd/system/${name}@.service
 ${chown} root:root /usr/lib/tmpfiles.d/${name}.conf
@@ -884,7 +884,7 @@ RUN echo 'd /var/run/tarantool 644 tarantool tarantool' > /usr/lib/tmpfiles.d/${
 # copy application source code
 COPY ${name}/ ${dir}
 RUN chown -R root:root ${dir} \
-    && chmod -R 555 ${dir}
+    && chmod -R 755 ${dir}
 
 WORKDIR ${dir}
 
@@ -1612,7 +1612,7 @@ end
 
 local function rpm_get_file_mode(filename)
     if string.startswith(filename, '/usr/share/tarantool') then
-        return tonumber('555', 8)
+        return tonumber('755', 8)
     end
 
     return tonumber('644', 8)

--- a/test/python/test_pack.py
+++ b/test/python/test_pack.py
@@ -695,7 +695,7 @@ def test_docker_e2e(project_path, docker_image, tmpdir, docker_client):
     assert m is not None
     ip = m.groups()[0]
 
-    admin_api_url = 'http://127.0.0.1:8082/admin/api'
+    admin_api_url = 'http://localhost:8082/admin/api'
 
     # join instance
     query = '''


### PR DESCRIPTION
Check if application source code files has at least a+r (regular files) or a+rx (directiries) permissions on application packing
Set 644 root:root for /usr/lib/tmpfs/${name}.conf and
/etc/systemd/system/${name}[@].service
Refactor tests to check files modes and owners
Add docker e2e test