### PR TITLE
Support Dockerfile from option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Packing to Docker image
 - Check filemodes before packing
+- `--from` option for `docker pack` command to specify base image Dockerfile path
 
 ## [1.2.1] - 2019-11-25
 

--- a/README.md
+++ b/README.md
@@ -101,8 +101,6 @@ specific for the system where the `cartridge pack` command is running.
 For `docker`, the resulting image will contain rocks modules and executables
 specific for the base image (`centos:8`).
 
-The result package will be named
-
 Common options:
 
 - `--name`: name of the app to pack;
@@ -116,7 +114,7 @@ By default, application name is detected from rockspec, application version is d
 
 The package creating is performed in a temporarily directory, so it doesn't affect your application dir contents.
 
-The package build flow can be represented as theese steps:
+The package build flow can be represented as these steps:
 
 ##### 1. Forming distribution dir
 
@@ -140,7 +138,7 @@ You can place `.cartridge.pre` script in the project root to perform some action
 
 #### Special files
 
-You can use place theese files in your application root to control application packing flow:
+You can use place these files in your application root to control application packing flow:
 
 - `.cartridge.ignore`: here you can specify some files and directories to be excluded from the package build.
   The full explanation of the file format you can find in the [documentation](https://www.tarantool.io/ru/doc/1.10/book/cartridge/cartridge_dev/#using-cartridge-ignore-files).

--- a/README.md
+++ b/README.md
@@ -103,48 +103,63 @@ specific for the base image (`centos:8`).
 
 Common options:
 
-- `--name`: name of the app to pack;
+* `--name`: name of the app to pack;
+* `--version`: application version.
 
-- `--version`: application version.
-
-The result would be named as `<name>-<version>.<type>`.
-By default, application name is detected from rockspec, application version is detected from `git describe`.
+The result will be named as `<name>-<version>.<type>`.
+By default, the application name is detected from the rockspec, and
+the application version is detected from `git describe`.
 
 #### General packing flow and options
 
-The package creating is performed in a temporarily directory, so it doesn't affect your application dir contents.
+A package is first created in a temporarily directory, so the packaging process
+doesn't affect the contents of your application directory.
 
-The package build flow can be represented as these steps:
+A package build comprises these steps:
 
-##### 1. Forming distribution dir
+##### 1. Forming the distribution directory
 
-On this stage some files will be filtered out.
-First, `git clean -X -d -f` will be called to remove all untracked and ignored files.
-Then `.rocks` and `.git` directories will be removed.
-And, finally, files specified in a `.cartridge.ignore` file will be ignored (see details below).
+On this stage, some files will be filtered out:
+* First, `git clean -X -d -f` will be called to remove all untracked and
+  ignored files.
+* Then `.rocks` and `.git` directories will be removed.
+* Finally, files specified in a `.cartridge.ignore` file will be ignored
+  (see details below).
 
-*Note*, that all application files should have at least `a+r` permissions (`a+rx` for directories).
+*Note*: All application files should have at least `a+r` permissions
+(`a+rx` for directories).
 Otherwise, `cartridge pack` command raises an error.
-Files permissions would be keeped "as is", code files owner would be set to `root:root` in the result package.
+Files permissions will be kept "as they are", and the code files owner will be
+set to `root:root` in the resulting package.
 
 ##### 2. Building an application
 
-*Note*, that for packing in docker this stage is running on container itself, so all rocks dependencies will be installed correctly.
-For other package types building an application is running on the local machine, so the result package would contain rocks modules and binaries specific for the local OS.
+*Note*: When packing in docker, this stage is running in the container itself,
+so all rocks dependencies will be installed correctly.
+For other package types, this stage is running on the local machine, so the
+resulting package will contain rocks modules and binaries specific for the local
+OS.
 
-To deliver all rocks dependencies specified in rockspec, `tarantoolctl rocks make` command is run.
-It will form `.rocks` directory that will be delivered in the result package.
-You can place `.cartridge.pre` script in the project root to perform some actions before running `tarantoolctl rocks make` (see details below).
+To deliver all rocks dependencies specified in the rockspec,
+`tarantoolctl rocks make` command is run.
+It will form the `.rocks` directory that will be delivered in the resulting
+package.
+You can place the `.cartridge.pre` script in the project root to perform some
+actions before running `tarantoolctl rocks make` (see details below).
 
 #### Special files
 
-You can use place these files in your application root to control application packing flow:
+You can place these files in your application root to control the application
+packing flow:
 
-- `.cartridge.ignore`: here you can specify some files and directories to be excluded from the package build.
-  The full explanation of the file format you can find in the [documentation](https://www.tarantool.io/ru/doc/1.10/book/cartridge/cartridge_dev/#using-cartridge-ignore-files).
+* `.cartridge.ignore`: here you can specify some files and directories to be
+  excluded from the package build. See the
+  [documentation](https://www.tarantool.io/ru/doc/1.10/book/cartridge/cartridge_dev/#using-cartridge-ignore-files)
+  for details.
 
-- `.cartridge.pre`: a script to be runned before `tarantoolctl rocks make`.
-  The main idea of this script is to build some non-standart rocks modules (for exmaple, from submodule).
+* `.cartridge.pre`: a script to be run before `tarantoolctl rocks make`.
+  The main purpose of this script is to build some non-standard rocks modules
+  (for example, from a submodule).
 
 #### Application type-specific details
 
@@ -198,20 +213,26 @@ across all sections of the YAML file(s) stored in `/etc/tarantool/conf.d/*`.
 
 Specific options:
 
-- `--from` - path to the base image dockerfile.
+* `--from` - path to the base image dockerfile;
 
-- `--tag` - result image tag;
+* `--tag` - resulting image tag;
 
-- `--download_token` (env `TARANTOOL_DOWNLOAD_TOKEN`) - download token for installing Tarantool Enterprise on the result image;
+* `--download_token` (env `TARANTOOL_DOWNLOAD_TOKEN`) - download token for
+  installing Tarantool Enterprise to the resulting image.
 
-The base image is the `centos:8` .
-Packages, required for default application, would be installed on this image.
+The base image is `centos:8`. On this image, `cartridge` will install all
+packages required for `cartridge` rocks and for the default `cartridge`
+application (i.e. the one created with `cartridge create`).
 
-If your application requires some other applications, you can specify your own base image.
-The base image dockerfile should be specified in `Dockerfile.cartridge` file in the project root.
-Or you can pass a path to the other Dockerfile by passing `--from path/to/dockerfile` option.
+If your application requires some other applications, you can specify your own
+base image.
+The base image dockerfile should be specified in the `Dockerfile.cartridge` file
+in the project root.
+Or you can pass a path to another dockerfile via the `--from path/to/dockerfile`
+option.
 
-The base image dockerfile should be started with the `FROM centos:8` line (except comments).
+The base image dockerfile should be started with the `FROM centos:8` line
+(except comments).
 
 Example Dockerfile:
 
@@ -220,7 +241,8 @@ FROM centos:8
 RUN yum install -y zip
 ```
 
-Of course, opensource Tarantool would be installed on the image, if required.
+Of course, an opensource Tarantool version will be installed to the image,
+if required.
 
 The image is tagged as follows:
 * `<name>:<detected_version>`: by default;
@@ -228,7 +250,7 @@ The image is tagged as follows:
 * `<tag>`: if the `--tag` parameter is specified.
 
 `<name>` can be specified in the `--name` parameter, otherwise it will be
-auto-detected from application rockspec.
+auto-detected from the application rockspec.
 
 For Tarantool Enterprise, you should specify a download token using the
 `--download_token` parameter or the `TARANTOOL_DOWNLOAD_TOKEN` environment
@@ -238,7 +260,7 @@ If you want the `docker build` command to be run with custom arguments, you can
 specify them using the `TARANTOOL_DOCKER_BUILD_ARGS` environment variable.
 For example, `TARANTOOL_DOCKER_BUILD_ARGS='--no-cache --quiet'`
 
-The Application code will be placed in the `/usr/share/tarantool/${app_name}`
+The application code will be placed in the `/usr/share/tarantool/${app_name}`
 directory. An opensource version of Tarantool will be installed to the image.
 
 The run directory is `/var/run/tarantool/${app_name}`,

--- a/README.md
+++ b/README.md
@@ -101,12 +101,61 @@ specific for the system where the `cartridge pack` command is running.
 For `docker`, the resulting image will contain rocks modules and executables
 specific for the base image (`centos:8`).
 
-#### TGZ
+The result package will be named
+
+Common options:
+
+- `--name`: name of the app to pack;
+
+- `--version`: application version.
+
+The result would be named as `<name>-<version>.<type>`.
+By default, application name is detected from rockspec, application version is detected from `git describe`.
+
+#### General packing flow and options
+
+The package creating is performed in a temporarily directory, so it doesn't affect your application dir contents.
+
+The package build flow can be represented as theese steps:
+
+##### 1. Forming distribution dir
+
+On this stage some files will be filtered out.
+First, `git clean -X -d -f` will be called to remove all untracked and ignored files.
+Then `.rocks` and `.git` directories will be removed.
+And, finally, files specified in a `.cartridge.ignore` file will be ignored (see details below).
+
+*Note*, that all application files should have at least `a+r` permissions (`a+rx` for directories).
+Otherwise, `cartridge pack` command raises an error.
+Files permissions would be keeped "as is", code files owner would be set to `root:root` in the result package.
+
+##### 2. Building an application
+
+*Note*, that for packing in docker this stage is running on container itself, so all rocks dependencies will be installed correctly.
+For other package types building an application is running on the local machine, so the result package would contain rocks modules and binaries specific for the local OS.
+
+To deliver all rocks dependencies specified in rockspec, `tarantoolctl rocks make` command is run.
+It will form `.rocks` directory that will be delivered in the result package.
+You can place `.cartridge.pre` script in the project root to perform some actions before running `tarantoolctl rocks make` (see details below).
+
+#### Special files
+
+You can use place theese files in your application root to control application packing flow:
+
+- `.cartridge.ignore`: here you can specify some files and directories to be excluded from the package build.
+  The full explanation of the file format you can find in the [documentation](https://www.tarantool.io/ru/doc/1.10/book/cartridge/cartridge_dev/#using-cartridge-ignore-files).
+
+- `.cartridge.pre`: a script to be runned before `tarantoolctl rocks make`.
+  The main idea of this script is to build some non-standart rocks modules (for exmaple, from submodule).
+
+#### Application type-specific details
+
+##### TGZ
 
 `cartridge pack tgz ./myapp` will create a .tgz archive containing the application
 source code and rocks modules described in the application rockspec.
 
-#### RPM and DEB
+##### RPM and DEB
 
 `cartridge pack rpm|deb ./myapp` will create an RPM or DEB package.
 
@@ -145,9 +194,35 @@ This instance will look for its
 [configuration](https://www.tarantool.io/en/doc/2.2/book/cartridge/cartridge_dev/#configuring-instances)
 across all sections of the YAML file(s) stored in `/etc/tarantool/conf.d/*`.
 
-#### Docker
+##### Docker
 
 `cartridge pack docker ./myapp` will build a docker image.
+
+Specific options:
+
+- `--from` - path to the base image dockerfile.
+
+- `--tag` - result image tag;
+
+- `--download_token` (env `TARANTOOL_DOWNLOAD_TOKEN`) - download token for installing Tarantool Enterprise on the result image;
+
+The base image is the `centos:8` .
+Packages, required for default application, would be installed on this image.
+
+If your application requires some other applications, you can specify your own base image.
+The base image dockerfile should be specified in `Dockerfile.cartridge` file in the project root.
+Or you can pass a path to the other Dockerfile by passing `--from path/to/dockerfile` option.
+
+The base image dockerfile should be started with the `FROM centos:8` line (except comments).
+
+Example Dockerfile:
+
+```dockerfile
+FROM centos:8
+RUN yum install -y zip
+```
+
+Of course, opensource Tarantool would be installed on the image, if required.
 
 The image is tagged as follows:
 * `<name>:<detected_version>`: by default;

--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -2031,7 +2031,7 @@ local function validate_from_dockerfile(dockerfile_content)
         die('Base Dockerfile should be started with `FROM centos:8`')
     end
 
-    if not from_line:lower() == 'from centos:8' then
+    if from_line:lower() ~= 'from centos:8' then
         die('The base image must be centos:8')
     end
 end

--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -2015,7 +2015,9 @@ local function validate_from_dockerfile(dockerfile_content)
     local from_line
 
     for _, line in ipairs(dockerfile_content:split('\n')) do
-        if not line:strip():startswith('#') then
+        line = line:strip()
+        -- skip comments and empty lines
+        if not (line == '' or line:startswith('#')) then
             if not line:strip():lower():startswith('from') then
                 die('Base Dockerfile should be started with `FROM centos:8`')
             end
@@ -2207,6 +2209,13 @@ local function app_pack_parse(arg)
                 'You can specify only one of --version and --tag options. ' ..
                 'Run `cartridge pack --help` for details.'
             )
+        end
+
+        if args.from == nil then
+            local default_dockerfile_path = fio.pathjoin(args.path, 'Dockerfile.cartridge')
+            if fio.path.exists(default_dockerfile_path) then
+                args.from = default_dockerfile_path
+            end
         end
     end
 

--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -858,8 +858,10 @@ d /var/run/tarantool 0755 tarantool tarantool
 
 -- * ------------------- Dockerfile -------------------
 
+local DOCKERFILE_FROM_DEFAULT = 'FROM centos:8'
+
 local DOCKERFILE_TEMPLATE = [[
-FROM centos:8
+${from}
 SHELL ["/bin/bash", "-c"]
 
 RUN yum install -y git gcc make cmake unzip
@@ -2009,8 +2011,32 @@ local function pack_deb(source_dir, dest_dir, name, release, version, opts)
     fio.copyfile(fio.pathjoin(tmpdir, deb_file_name), dest_dir)
 end
 
-local function construct_dockerfile(filepath, appname)
+local function validate_from_dockerfile(dockerfile_content)
+    local from_line
+
+    for _, line in ipairs(dockerfile_content:split('\n')) do
+        if not line:strip():startswith('#') then
+            if not line:strip():lower():startswith('from') then
+                die('Base Dockerfile should be started with `FROM centos:8`')
+            end
+
+            from_line = line:strip()
+            break
+        end
+    end
+
+    if from_line == nil then
+        die('Base Dockerfile should be started with `FROM centos:8`')
+    end
+
+    if not from_line:lower() == 'from centos:8' then
+        die('The base image must be centos:8')
+    end
+end
+
+local function construct_dockerfile(filepath, appname, from)
     local expand_params = {
+        from = from,
         name = appname,
         instance_name = '${"$"}{TARANTOOL_INSTANCE_NAME:-default}',
         workdir = fio.pathjoin('/var/lib/tarantool/', appname),
@@ -2050,6 +2076,21 @@ local function pack_docker(source_dir, _, name, release, version, opts)
         die("docker binary is required to pack docker image")
     end
 
+    local from = DOCKERFILE_FROM_DEFAULT
+    if opts.from ~= nil then
+        if not fio.path.exists(opts.from) then
+            die('Specified base dockerfile does not exists: %s', opts.from)
+        end
+
+        print(string.format('Detected base Dockerfile %s ...', opts.from))
+
+        local dockerfile_content = fio.open(opts.from):read()
+        validate_from_dockerfile(dockerfile_content)
+
+        print('Base Dockerfile is OK')
+        from = dockerfile_content
+    end
+
     local tmpdir = fio.tempdir()
     print("Packing docker in: " .. tmpdir)
 
@@ -2058,7 +2099,7 @@ local function pack_docker(source_dir, _, name, release, version, opts)
     form_distribution_dir(source_dir, distribution_dir, name, version)
     generate_version_file(source_dir, distribution_dir, name, version)
 
-    construct_dockerfile(fio.pathjoin(tmpdir, 'Dockerfile'), name)
+    construct_dockerfile(fio.pathjoin(tmpdir, 'Dockerfile'), name, from)
 
     local image_fullname
     if opts.tag ~= nil then
@@ -2110,6 +2151,7 @@ local function app_pack(args)
     elseif args.type == 'docker' then
         pack_docker(args.path, '.', name, release, version, {
             tag = args.tag,
+            from = args.from,
             download_token = args.download_token,
             docker_build_args = args.docker_build_args,
         })
@@ -2129,6 +2171,7 @@ local function app_pack_parse(arg)
                 { 'unit_template', 'string' },
                 { 'download_token', 'string'},
                 { 'tag', 'string' },
+                { 'from', 'string' },
             }
     )
 
@@ -2139,6 +2182,7 @@ local function app_pack_parse(arg)
     args.download_token = parameters.download_token or os.getenv('TARANTOOL_DOWNLOAD_TOKEN')
     args.docker_build_args = os.getenv('TARANTOOL_DOCKER_BUILD_ARGS') or ''
     args.tag = parameters.tag
+    args.from = parameters.from
     args.type = parameters[1]
     args.path = parameters[2]
 

--- a/templates/cartridge/Dockerfile.cartridge
+++ b/templates/cartridge/Dockerfile.cartridge
@@ -1,0 +1,13 @@
+# Simple base Dockerfile
+
+# The base image must be centos:8
+FROM centos:8
+
+# Here you can install some packages required for your application
+#
+# For example, if you need to install some python packages,
+#   you can do it this way:
+#
+# COPY requirements.txt /tmp
+# RUN yum install -y python3-pip
+# RUN pip3 install -r /requirements.txt

--- a/templates/cartridge/Dockerfile.cartridge
+++ b/templates/cartridge/Dockerfile.cartridge
@@ -1,4 +1,5 @@
-# Simple base Dockerfile
+# Simple Dockerfile
+# Used by `pack docker` command as a base image
 
 # The base image must be centos:8
 FROM centos:8
@@ -10,4 +11,4 @@ FROM centos:8
 #
 # COPY requirements.txt /tmp
 # RUN yum install -y python3-pip
-# RUN pip3 install -r /requirements.txt
+# RUN pip3 install -r /tmp/requirements.txt

--- a/test/python/test_pack.py
+++ b/test/python/test_pack.py
@@ -769,3 +769,21 @@ def test_systemd_units(project_path, rpm_archive_with_custom_units, tmpdir):
 
     project_tmpfiles_conf_file = os.path.join(tmpdir, 'usr/lib/tmpfiles.d', '%s.conf' % project_name )
     assert open(project_tmpfiles_conf_file).read().find('d /var/run/tarantool') != -1
+
+
+def test_invalid_base_dockerfile(project_path, module_tmpdir, tmpdir):
+    invalid_dockerfile_path = os.path.join(tmpdir, 'Dockerfile')
+    with open(invalid_dockerfile_path, 'w') as f:
+        f.write('''
+            # Invalid dockerfile
+            FROM ubuntu:xenial
+        ''')
+
+    cmd = [
+        os.path.join(basepath, "cartridge"),
+        "pack", "docker",
+        "--from", invalid_dockerfile_path,
+        project_path,
+    ]
+    process = subprocess.run(cmd, cwd=module_tmpdir)
+    assert process.returncode == 1

--- a/test/python/test_pack.py
+++ b/test/python/test_pack.py
@@ -19,6 +19,7 @@ from utils import tarantool_enterprise_is_used
 project_name = "test_proj"
 
 original_file_tree = set([
+    'Dockerfile.cartridge',
     '.cartridge.yml',
     '.editorconfig',
     '.gitignore',


### PR DESCRIPTION
Implemented `--from` option for `docker pack` command (by default `Dockerfile.cartridge` is used)
It allows to install some application-specific tools on the result image
Added `Dockerfile.cartridge` to the `cartridge` template 