### PR TITLE
New pack flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Packing to Docker image
 - Check filemodes before packing
 - `--from` option for `docker pack` command to specify base image Dockerfile path
+- `cartridge.pre-build` and `cartridge.post-build` hooks
+  to be ran before and after `rocks make`
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -123,8 +123,6 @@ On this stage, some files will be filtered out:
 * First, `git clean -X -d -f` will be called to remove all untracked and
   ignored files.
 * Then `.rocks` and `.git` directories will be removed.
-* Finally, files specified in a `.cartridge.ignore` file will be ignored
-  (see details below).
 
 *Note*: All application files should have at least `a+r` permissions
 (`a+rx` for directories).
@@ -140,26 +138,23 @@ For other package types, this stage is running on the local machine, so the
 resulting package will contain rocks modules and binaries specific for the local
 OS.
 
-To deliver all rocks dependencies specified in the rockspec,
-`tarantoolctl rocks make` command is run.
-It will form the `.rocks` directory that will be delivered in the resulting
+* First, `cartridge.pre-build` script is run (if it's present).
+* Then, `tarantoolctl rocks make` command is run to deliver all rocks dependencies specified in the rockspec.
+  It will form the `.rocks` directory that will be delivered in the resulting
 package.
-You can place the `.cartridge.pre` script in the project root to perform some
-actions before running `tarantoolctl rocks make` (see details below).
+* Finally, `cartridge.post-build` script is run (if it's present).
 
 #### Special files
 
 You can place these files in your application root to control the application
 packing flow:
 
-* `.cartridge.ignore`: here you can specify some files and directories to be
-  excluded from the package build. See the
-  [documentation](https://www.tarantool.io/ru/doc/1.10/book/cartridge/cartridge_dev/#using-cartridge-ignore-files)
-  for details.
-
-* `.cartridge.pre`: a script to be run before `tarantoolctl rocks make`.
+* `cartridge.pre-build`: a script to be run before `tarantoolctl rocks make`.
   The main purpose of this script is to build some non-standard rocks modules
   (for example, from a submodule).
+
+* `cartridge.post-build`: a script to be run after `tarantoolctl rocks make`.
+  The main purpose of this script is to remove build artifacts from result package.
 
 #### Application type-specific details
 

--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -791,6 +791,11 @@ local function detect_name_release_version(source_dir, raw_name, raw_version)
     return name, release, version
 end
 
+-- * ----------- Special filenames ------------
+
+local PREBUILD_SCRIPT_NAME = 'cartridge.pre-build'
+local POSTBUILD_SCRIPT_NAME = 'cartridge.post-build'
+
 -- * --------------- Preinstall ---------------
 
 local CREATE_USER_SCRIPT = [[
@@ -932,12 +937,16 @@ COPY . ${dir}
 
 WORKDIR ${dir}
 
-RUN if [ -f .cartridge.pre ]; then \
-       set -e && . .cartridge.pre && rm .cartridge.pre; \
+RUN if [ -f ${prebuild_script_name} ]; then \
+       set -e && . ${prebuild_script_name} && rm ${prebuild_script_name}; \
     fi
 
 RUN if ls *.rockspec 1> /dev/null 2>&1; then \
         tarantoolctl rocks make; \
+    fi
+
+RUN if [ -f ${postbuild_script_name} ]; then \
+        set -e && . ${postbuild_script_name} && rm ${postbuild_script_name}; \
     fi
 
 USER tarantool:tarantool
@@ -1068,39 +1077,6 @@ local function generate_version_file(source_dir, dest_dir, app_name, app_version
     version_file:close()
 end
 
-local function pattern_form(pattern)
-    if pattern == '' or-- blank line
-            string.startswith(pattern, '#') then -- comment
-        return nil, false
-    end
-
-    if string.startswith(pattern, '\\#') then -- escape #
-        pattern = pattern:sub(2, #pattern)
-    end
-     -- trim space
-    pattern = pattern:gsub("%s+", "")
-
-    local negative = false
-    if string.startswith(pattern, '!') then
-        pattern = pattern:sub(2, #pattern)
-        negative = true
-    end
-    return pattern, negative
-end
-
-local function path_form(path, destdir)
-    if string.startswith(path, './') then
-        path = path:sub(3, #path)
-    end
-    -- if this is a folder, then added to end /
-    if fio.path.is_dir(fio.pathjoin(destdir, path)) then
-        path = path .. '/'
-    end
-
-
-    return path
-end
-
 local function matching(str, pattern)
     -- case: pattern <simple>, str [<simple> | <simple/>]
     if not string.endswith(pattern, '/') and string.endswith(str, '/') then
@@ -1130,50 +1106,6 @@ local function remove_by_path(path)
         fio.rmtree(path)
     else
         fio.unlink(path)
-    end
-end
-
-local function remove_ignored(destdir)
-    local ignore = fio.pathjoin(destdir, '.cartridge.ignore')
-    if not fio.path.exists(ignore) then return end
-
-    local files = find_files(destdir, { include_dirs = true })
-
-    -- formatting all pattern and exclusion exception pattern
-    local patterns, exceptions  = {}, {}
-    for _, pattern in ipairs(string.split(read_file(ignore), '\n')) do
-        local pretty_pattern, negative = pattern_form(pattern)
-        if pretty_pattern then
-            if negative then
-                table.insert(exceptions, pretty_pattern)
-            else
-                table.insert(patterns, pretty_pattern)
-            end
-        end
-    end
-
-    local matched = {}
-    for _, file in ipairs(files) do
-        local pretty_file = path_form(file, destdir)
-        print(pretty_file)
-        for _, ignore_glob in ipairs(patterns) do
-            if matching(pretty_file, ignore_glob) then
-                local except = false
-                for _, e in ipairs(exceptions) do
-                    if matching(pretty_file, e) then
-                        except = true
-                        break
-                    end
-                end
-                if not except then
-                    table.insert(matched, pretty_file)
-                end
-            end
-        end
-    end
-
-    for _, f in ipairs(matched) do
-        remove_by_path(fio.pathjoin(destdir, f))
     end
 end
 
@@ -1222,6 +1154,7 @@ local function form_distribution_dir(source_dir, dest_dir)
     end
     local git = which('git')
     if git ~= nil and fio.path.exists(fio.pathjoin(dest_dir, '.git')) then
+        info('Running `git clean`')
         -- Clean up all files explicitly ignored by git, to not accidentally
         -- ship development snaps, xlogs or other garbage to production.
         call("cd %q && %s clean -f -d -X", dest_dir, git)
@@ -1230,47 +1163,63 @@ local function form_distribution_dir(source_dir, dest_dir)
                  "normally ignored are shipped to the resulting package. ")
     end
 
-    -- deleting files matching patterns from .cartridge.ignore
-    remove_ignored(dest_dir)
-
+    info('Remove .git directory')
     remove_by_path(fio.pathjoin(dest_dir, '.git'))
-    remove_by_path(fio.pathjoin(dest_dir, '.cartridge.ignore'))
 
     -- check application files mode
+    info('Check application file modes')
     check_filemodes(dest_dir)
 end
 
 local function build_application(dir)
-    if fio.path.exists(fio.pathjoin(dir, '.cartridge.pre')) then
-        info("Running .cartridge.pre")
+    -- pre build
+    if fio.path.exists(fio.pathjoin(dir, PREBUILD_SCRIPT_NAME)) then
+        info('Running %s', PREBUILD_SCRIPT_NAME)
         local ret = os.execute(
-            "set -e\n" ..
-            string.format("cd %q\n", dir) ..
-            ". ./.cartridge.pre"
+            'set -e\n' ..
+            string.format('cd %q\n', dir) ..
+            string.format('. ./%s', PREBUILD_SCRIPT_NAME)
         )
         if ret ~= 0 then
-            die("Failed to execute pre-build stage")
+            die('Failed to execute pre-build stage')
         end
+
+        remove_by_path(fio.pathjoin(dir, PREBUILD_SCRIPT_NAME))
     end
 
+    -- build
     local rockspec = find_rockspec(dir)
     if rockspec ~= nil then
-        info("Running tarantoolctl rocks make")
+        info('Running tarantoolctl rocks make')
         local ret = os.execute(
             string.format(
-                "cd %q; exec tarantoolctl rocks make %q",
+                'cd %q; exec tarantoolctl rocks make %q',
                 dir, rockspec
             )
         )
         if ret ~= 0 then
-            die("Failed to install rocks")
+            die('Failed to install rocks')
         end
     end
 
-    remove_by_path(fio.pathjoin(dir, '.cartridge.pre'))
+    -- post build
+    if fio.path.exists(fio.pathjoin(dir, POSTBUILD_SCRIPT_NAME)) then
+        info('Running %s', POSTBUILD_SCRIPT_NAME)
+        local ret = os.execute(
+            'set -e\n' ..
+            string.format('cd %q\n', dir) ..
+            string.format('. ./%s', POSTBUILD_SCRIPT_NAME)
+        )
+        if ret ~= 0 then
+            die('Failed to execute post-build stage')
+        end
+
+        remove_by_path(fio.pathjoin(dir, POSTBUILD_SCRIPT_NAME))
+    end
 end
 
 local function copy_taranool_binaries(dir)
+    info('Copy Tarantool Enterprise binaries')
     assert(tarantool_is_enterprise())
 
     local tarantool_dir = get_tarantool_dir()
@@ -1282,6 +1231,8 @@ end
 
 local function form_systemd_dir(base_dir, name, opts)
     opts = opts or {}
+    info('Form application systemd dir')
+
     local unit_template = opts.unit_template or SYSTEMD_UNIT_FILE
     local instantiated_unit_template = opts.instantiated_unit_template or SYSTEMD_INSTANTIATED_UNIT_FILE
 
@@ -1317,6 +1268,8 @@ local function form_systemd_dir(base_dir, name, opts)
 end
 
 local function write_tmpfiles_conf(base_dir, name)
+    info('Write application tmpfiles configuration')
+
     local tmpfiles_dir = fio.pathjoin(base_dir, '/usr/lib/tmpfiles.d')
     fio.mktree(tmpfiles_dir)
 
@@ -1351,7 +1304,7 @@ local function pack_tgz(source_dir, dest_dir, name, release, version)
 
     info("Packing tar.gz in: %s", tmpdir)
 
-    form_distribution_dir(source_dir, distribution_dir, name, version)
+    form_distribution_dir(source_dir, distribution_dir)
     build_application(distribution_dir)
     generate_version_file(source_dir, distribution_dir, name, version)
 
@@ -1364,7 +1317,7 @@ local function pack_tgz(source_dir, dest_dir, name, release, version)
 
     write_file(tgz_file_name, data)
 
-    print("Resulting tar.gz saved as: " .. tgz_file_name)
+    info("Resulting tar.gz saved as: %s", tgz_file_name)
 end
 
 -- * ---------------- ROCK packing ----------------
@@ -2077,7 +2030,7 @@ local function pack_deb(source_dir, dest_dir, name, release, version, opts)
     fio.mktree(data_dir)
 
     local distribution_dir = fio.pathjoin(data_dir, '/usr/share/tarantool/', name)
-    form_distribution_dir(source_dir, distribution_dir, name, version)
+    form_distribution_dir(source_dir, distribution_dir)
 
     build_application(distribution_dir)
     generate_version_file(source_dir, distribution_dir, name, version)
@@ -2129,6 +2082,8 @@ local function construct_dockerfile(filepath, appname, from)
         instance_name = '${"$"}{TARANTOOL_INSTANCE_NAME:-default}',
         workdir = fio.pathjoin('/var/lib/tarantool/', appname),
         dir = fio.pathjoin('/usr/share/tarantool/', appname),
+        prebuild_script_name = PREBUILD_SCRIPT_NAME,
+        postbuild_script_name = POSTBUILD_SCRIPT_NAME,
     }
 
     if tarantool_is_enterprise() then
@@ -2186,7 +2141,7 @@ local function pack_docker(source_dir, _, name, release, version, opts)
 
     local distribution_dir = fio.pathjoin(tmpdir, name)
 
-    form_distribution_dir(source_dir, distribution_dir, name, version)
+    form_distribution_dir(source_dir, distribution_dir)
     generate_version_file(source_dir, distribution_dir, name, version)
 
     local dockerfile_path = fio.pathjoin(tmpdir, 'Dockerfile')
@@ -2210,8 +2165,9 @@ local function pack_docker(source_dir, _, name, release, version, opts)
         distribution_dir, image_fullname, dockerfile_path, download_token_arg, opts.docker_build_args
     )))
 
-    print('Resulting image tagged as: ' .. image_fullname)
+    info('Resulting image tagged as: %s', image_fullname)
 end
+
 
 local function app_pack(args)
     local name, release, version = detect_name_release_version(args.path, args.name, args.version)

--- a/templates/cartridge/.cartridge.ignore
+++ b/templates/cartridge/.cartridge.ignore
@@ -1,4 +1,0 @@
-# simple cartridge-ignore file
-
-# deps.sh
-# !init.lua

--- a/templates/cartridge/cartridge.post-build
+++ b/templates/cartridge/cartridge.post-build
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Simple post-build script
+# Will be run after `tarantoolctl rocks make` on application build
+# Could be useful to remove some build artifacts from result package
+
+# For example:
+# rm -rf third_party
+# rm -rf node_modules
+# rm -rf doc

--- a/templates/cartridge/cartridge.pre-build
+++ b/templates/cartridge/cartridge.pre-build
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Simple pre-build script
+# Will be run before `tarantoolctl rocks make` on application build
+# Could be useful to install non-standart rocks modules
+
+# For example:
+# tarantoolctl rocks make --chdir ./third_party/my-custom-rock-module

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -16,99 +16,14 @@ def module_tmpdir(request):
 
 @pytest.fixture(scope="module")
 def project_path(module_tmpdir):
-    return create_project(module_tmpdir, project_name, 'cartridge')
+    path = create_project(module_tmpdir, project_name, 'cartridge')
 
+    # add cartridge.post-build file to remove test/ and tmp/ contents
+    with open(os.path.join(path, 'cartridge.post-build'), 'w') as f:
+        f.write('''
+        #!/bin/sh
 
-ignored_data = [
-    {
-        'dir': '',
-        'file': 'ignored.txt'
-    },
-    {
-        'dir': '',
-        'file': 'asterisk'
-    },
-    {
-        'dir': '',
-        'file': 'ignored.lua'
-    },
-    {
-        'dir': '',
-        'file': 'ignored_by.format'
-    },
-    {
-        'dir': 'ignored',
-        'file': 'sample.txt'
-    },
-    {
-        'dir': 'ignored/folder',
-        'file': 'sample.txt'
-    },
-    {
-        'dir': 'ignored/asterisk',
-        'file': 'star.txt'
-    },
-    {
-        'dir': 'ignored/asterisk',
-        'file': 'simple'
-    },
-    {
-        'dir': 'ignored/sample',
-        'file': 'test'
-    },
-    {
-        'dir': 'ignored',
-        'file': '#test'
-    }
-]
-
-
-patterns = [
-    # patterns that match the patterns from whitelist
-    '.rocks/share/tarantool/rocks/**',
-    '*.lua',
-    'deps.sh',
-    # whitelist
-    '!*.sh',
-    '!.rocks/**',
-    '!init.lua',
-    '!app/roles/custom.lua',
-    '!asterisk/',
-    # for ignore
-    'ignored.txt',
-    '*.format',
-    'ignored/*.txt',
-    'ignored/folder/',
-    '**/*.txt',
-    'simple',
-    'sample',
-    'asterisk',
-    # comment example
-    '# /scm-1',
-    # escaping \#
-    '\\#test'
-]
-
-
-cartridge_ignore_text = '\n'.join(patterns)
-
-
-@pytest.fixture(scope="module")
-def prepare_ignore(project_path):
-    """function creates files and directories
-    to check the work .cartridge.ignore"""
-
-    def create_file(path, text=None):
-        with open(path, 'w') as f:
-            if text:
-                f.write(text)
-
-    for item in ignored_data:
-        directory = os.path.join(project_path, item['dir'])
-        if not os.path.exists(directory):
-            os.makedirs(directory)
-        create_file(os.path.join(directory, item['file']))
-
-    create_file(
-        os.path.join(project_path, ".cartridge.ignore"),
-        cartridge_ignore_text)
+        rm -rf test
+        rm -rf tmp
+        ''')
+    return path

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -2,8 +2,8 @@ import py
 import os
 import pytest
 import tempfile
+import re
 
-from utils import project_name
 from utils import create_project
 
 
@@ -14,16 +14,94 @@ def module_tmpdir(request):
     return str(dir)
 
 
+def get_distribution_files(project_name):
+    return set([
+        'Dockerfile.cartridge',
+        '.cartridge.yml',
+        '.editorconfig',
+        '.gitignore',
+        '.luacheckrc',
+        'deps.sh',
+        'init.lua',
+        'instances.yml',
+        'app',
+        'app/roles',
+        'app/roles/custom.lua',
+        project_name + '-scm-1.rockspec',
+        'VERSION',
+    ])
+
+
+def get_rocks_content(project_name):
+    return set([
+        '.rocks',
+        '.rocks/share/tarantool/rocks/manifest',
+        '.rocks/share/tarantool/rocks/' + project_name,
+        '.rocks/share/tarantool/rocks/' + project_name + '/scm-1',
+        '.rocks/share/tarantool/rocks/' + project_name + '/scm-1/rock_manifest',
+        '.rocks/share/tarantool/rocks/' + project_name + '/scm-1/' + project_name + '-scm-1.rockspec',
+
+        '.rocks/bin/luatest',
+        '.rocks/share/tarantool/checks.lua',
+        '.rocks/share/tarantool/luarocks/test/luatest.lua',
+        '.rocks/share/tarantool/luatest',
+        '.rocks/share/tarantool/rocks/checks',
+        '.rocks/share/tarantool/rocks/luatest',
+    ])
+
+
 @pytest.fixture(scope="module")
-def project_path(module_tmpdir):
-    path = create_project(module_tmpdir, project_name, 'cartridge')
+def project(module_tmpdir):
+    project_name = 'original-project'
+    project_path = create_project(module_tmpdir, project_name, 'cartridge')
+
+    # add third-party module dependency to the rockspec
+    current_rockspec = None
+    with open(os.path.join(project_path, '{}-scm-1.rockspec'.format(project_name)), 'r') as f:
+        current_rockspec = f.read()
+
+    with open(os.path.join(project_path, '{}-scm-1.rockspec'.format(project_name)), 'w') as f:
+        f.write(re.sub(
+            r"dependencies = {",
+            "dependencies = {\n    'custom-module == scm-1',",
+            current_rockspec
+        ))
+
+    # create custom-module itself
+    dependency_module_path = os.path.join(project_path, 'third_party', 'custom-module')
+    os.makedirs(dependency_module_path)
+    with open(os.path.join(dependency_module_path, 'custom-module-scm-1.rockspec'), 'w') as f:
+        rockspec_lines = [
+            "package = 'custom-module'",
+            "version = 'scm-1'",
+            "source  = { url = '/dev/null' }",
+            "build = { type = 'none'}",
+        ]
+        f.write('\n'.join(rockspec_lines))
+
+    # add cartridge.pre-build file to install custom-module dependency
+    with open(os.path.join(project_path, 'cartridge.pre-build'), 'w') as f:
+        prebuild_script_lines = [
+            "#!/bin/sh",
+            "tarantoolctl rocks make --chdir ./third_party/custom-module",
+        ]
+        f.write('\n'.join(prebuild_script_lines))
 
     # add cartridge.post-build file to remove test/ and tmp/ contents
-    with open(os.path.join(path, 'cartridge.post-build'), 'w') as f:
-        f.write('''
-        #!/bin/sh
+    with open(os.path.join(project_path, 'cartridge.post-build'), 'w') as f:
+        postbuild_script_lines = [
+            "#!/bin/sh",
+            "rm -rf test tmp third_party"
+        ]
+        f.write('\n'.join(postbuild_script_lines))
 
-        rm -rf test
-        rm -rf tmp
-        ''')
-    return path
+    # add custom-module to rocks content
+    rocks_content = get_rocks_content(project_name)
+    rocks_content.add('.rocks/share/tarantool/rocks/custom-module')
+
+    return {
+        'name': project_name,
+        'path': project_path,
+        'distribution_files_list': get_distribution_files(project_name),
+        'rocks_content': rocks_content,
+    }

--- a/test/python/test_docker_pack.py
+++ b/test/python/test_docker_pack.py
@@ -64,7 +64,7 @@ def docker_client():
 
 
 @pytest.fixture(scope="module")
-def docker_image(module_tmpdir, project_path, prepare_ignore, request, docker_client):
+def docker_image(module_tmpdir, project_path, request, docker_client):
     cmd = [os.path.join(basepath, "cartridge"), "pack", "docker", project_path]
     process = subprocess.run(cmd, cwd=module_tmpdir)
     assert process.returncode == 0, \

--- a/test/python/test_pack.py
+++ b/test/python/test_pack.py
@@ -6,7 +6,6 @@ import subprocess
 import tarfile
 import shutil
 
-from utils import project_name
 from utils import basepath
 from utils import tarantool_enterprise_is_used
 from utils import find_archive
@@ -24,46 +23,46 @@ from utils import assert_tarantool_dependency_rpm
 # Fixtures
 # ########
 @pytest.fixture(scope="module")
-def tgz_archive(module_tmpdir, project_path):
-    cmd = [os.path.join(basepath, "cartridge"), "pack", "tgz", project_path]
+def tgz_archive(module_tmpdir, project):
+    cmd = [os.path.join(basepath, "cartridge"), "pack", "tgz", project['path']]
     process = subprocess.run(cmd, cwd=module_tmpdir)
     assert process.returncode == 0, \
         "Error during creating of tgz archive with project"
 
-    archive_name = find_archive(module_tmpdir, 'tar.gz')
-    assert archive_name is not None, "TGZ archive isn't founded in work directory"
+    archive_name = find_archive(module_tmpdir, project['name'], 'tar.gz')
+    assert archive_name is not None, "TGZ archive isn't found in work directory"
 
     return {'name': archive_name}
 
 
 @pytest.fixture(scope="module")
-def rpm_archive(module_tmpdir, project_path):
-    cmd = [os.path.join(basepath, "cartridge"), "pack", "rpm", project_path]
+def rpm_archive(module_tmpdir, project):
+    cmd = [os.path.join(basepath, "cartridge"), "pack", "rpm", project['path']]
     process = subprocess.run(cmd, cwd=module_tmpdir)
     assert process.returncode == 0, \
         "Error during creating of rpm archive with project"
 
-    archive_name = find_archive(module_tmpdir, 'rpm')
-    assert archive_name is not None, "RPM archive isn't founded in work directory"
+    archive_name = find_archive(module_tmpdir, project['name'], 'rpm')
+    assert archive_name is not None, "RPM archive isn't found in work directory"
 
     return {'name': archive_name}
 
 
 @pytest.fixture(scope="module")
-def deb_archive(module_tmpdir, project_path):
-    cmd = [os.path.join(basepath, "cartridge"), "pack", "deb", project_path]
+def deb_archive(module_tmpdir, project):
+    cmd = [os.path.join(basepath, "cartridge"), "pack", "deb", project['path']]
     process = subprocess.run(cmd, cwd=module_tmpdir)
     assert process.returncode == 0, \
         "Error during creating of deb archive with project"
 
-    archive_name = find_archive(module_tmpdir, 'deb')
+    archive_name = find_archive(module_tmpdir, project['name'], 'deb')
     assert archive_name is not None, "DEB archive isn't found in work directory"
 
     return {'name': archive_name}
 
 
 @pytest.fixture(scope="module")
-def rpm_archive_with_custom_units(module_tmpdir, project_path):
+def rpm_archive_with_custom_units(module_tmpdir, project):
     unit_template = '''
 [Unit]
 Description=Tarantool service: ${name}
@@ -113,33 +112,40 @@ Alias=${name}
             os.path.join(basepath, "cartridge"), "pack", "rpm",
             "--unit_template", "unit_template.tmpl",
             "--instantiated_unit_template", "instantiated_unit_template.tmpl",
-            project_path
+            project['path']
         ],
         cwd=module_tmpdir
     )
     assert process.returncode == 0, \
         "Error during creating of rpm archive with project"
 
-    archive_name = find_archive(module_tmpdir, 'rpm')
+    archive_name = find_archive(module_tmpdir, project['name'], 'rpm')
     assert archive_name is not None, "RPM archive isn't founded in work directory"
 
     return {'name': archive_name}
 
 
-def test_tgz_pack(project_path, tgz_archive, tmpdir):
+# #####
+# Tests
+# #####
+def test_tgz_pack(project, tgz_archive, tmpdir):
     with tarfile.open(name=tgz_archive['name']) as tgz_arch:
         # usr/share/tarantool is added to coorectly run assert_filemodes
-        distribution_dir = os.path.join(tmpdir, 'usr/share/tarantool', project_name)
+        distribution_dir = os.path.join(tmpdir, 'usr/share/tarantool', project['name'])
         os.makedirs(distribution_dir, exist_ok=True)
 
         tgz_arch.extractall(path=os.path.join(tmpdir, 'usr/share/tarantool'))
-        assert_dir_contents(recursive_listdir(distribution_dir))
+        assert_dir_contents(
+            files_list=recursive_listdir(distribution_dir),
+            exp_files_list=project['distribution_files_list'],
+            exp_rocks_content=project['rocks_content']
+        )
 
-        validate_version_file(distribution_dir)
-        assert_filemodes(tmpdir)
+        validate_version_file(project, distribution_dir)
+        assert_filemodes(project, tmpdir)
 
 
-def test_rpm_pack(project_path, rpm_archive, tmpdir):
+def test_rpm_pack(project, rpm_archive, tmpdir):
     ps = subprocess.Popen(
         ['rpm2cpio', rpm_archive['name']], stdout=subprocess.PIPE)
     subprocess.check_output(['cpio', '-idmv'], stdin=ps.stdout, cwd=tmpdir)
@@ -149,11 +155,11 @@ def test_rpm_pack(project_path, rpm_archive, tmpdir):
     if not tarantool_enterprise_is_used():
         assert_tarantool_dependency_rpm(rpm_archive['name'])
 
-    check_package_files(tmpdir, project_path)
-    assert_files_mode_and_owner_rpm(rpm_archive['name'])
+    check_package_files(project, tmpdir)
+    assert_files_mode_and_owner_rpm(project, rpm_archive['name'])
 
 
-def test_deb_pack(project_path, deb_archive, tmpdir):
+def test_deb_pack(project, deb_archive, tmpdir):
     # unpack ar
     process = subprocess.run([
             'ar', 'x', deb_archive['name']
@@ -173,8 +179,8 @@ def test_deb_pack(project_path, deb_archive, tmpdir):
     with tarfile.open(name=os.path.join(tmpdir, 'data.tar.xz')) as data_arch:
         data_dir = os.path.join(tmpdir, 'data')
         data_arch.extractall(path=data_dir)
-        check_package_files(data_dir, project_path)
-        assert_filemodes(data_dir)
+        check_package_files(project, data_dir)
+        assert_filemodes(project, data_dir)
 
     # check control.tar.xz
     with tarfile.open(name=os.path.join(tmpdir, 'control.tar.xz')) as control_arch:
@@ -190,33 +196,35 @@ def test_deb_pack(project_path, deb_archive, tmpdir):
         # check if postinst script set owners correctly
         with open(os.path.join(control_dir, 'postinst')) as postinst_script_file:
             postinst_script = postinst_script_file.read()
-            assert 'chown -R root:root /usr/share/tarantool/{}'.format(project_name) in postinst_script
-            assert 'chown root:root /etc/systemd/system/{}.service'.format(project_name) in postinst_script
-            assert 'chown root:root /etc/systemd/system/{}@.service'.format(project_name) in postinst_script
-            assert 'chown root:root /usr/lib/tmpfiles.d/{}.conf'.format(project_name) in postinst_script
+            assert 'chown -R root:root /usr/share/tarantool/{}'.format(project['name']) in postinst_script
+            assert 'chown root:root /etc/systemd/system/{}.service'.format(project['name']) in postinst_script
+            assert 'chown root:root /etc/systemd/system/{}@.service'.format(project['name']) in postinst_script
+            assert 'chown root:root /usr/lib/tmpfiles.d/{}.conf'.format(project['name']) in postinst_script
 
 
-def test_systemd_units(project_path, rpm_archive_with_custom_units, tmpdir):
+def test_systemd_units(project, rpm_archive_with_custom_units, tmpdir):
     ps = subprocess.Popen(
         ['rpm2cpio', rpm_archive_with_custom_units['name']], stdout=subprocess.PIPE)
     subprocess.check_output(['cpio', '-idmv'], stdin=ps.stdout, cwd=tmpdir)
     ps.wait()
     assert ps.returncode == 0, "Error during extracting files from rpm archive"
 
-    project_unit_file = os.path.join(tmpdir, 'etc/systemd/system', "%s.service" % project_name)
+    project_unit_file = os.path.join(tmpdir, 'etc/systemd/system', "%s.service" % project['name'])
     with open(project_unit_file) as f:
         assert f.read().find('SIMPLE_UNIT_TEMPLATE') != -1
 
-    project_inst_file = os.path.join(tmpdir, 'etc/systemd/system', "%s@.service" % project_name)
+    project_inst_file = os.path.join(tmpdir, 'etc/systemd/system', "%s@.service" % project['name'])
     with open(project_inst_file) as f:
         assert f.read().find('INSTANTIATED_UNIT_TEMPLATE') != -1
 
-    project_tmpfiles_conf_file = os.path.join(tmpdir, 'usr/lib/tmpfiles.d', '%s.conf' % project_name)
+    project_tmpfiles_conf_file = os.path.join(tmpdir, 'usr/lib/tmpfiles.d', '%s.conf' % project['name'])
     with open(project_tmpfiles_conf_file) as f:
         assert f.read().find('d /var/run/tarantool') != -1
 
 
 def test_packing_without_git(tmpdir):
+    project_name = 'test-project'
+
     # create project and remove .git
     cmd = [
         os.path.join(basepath, "cartridge"), "create",

--- a/test/python/test_pack.py
+++ b/test/python/test_pack.py
@@ -24,7 +24,7 @@ from utils import assert_tarantool_dependency_rpm
 # Fixtures
 # ########
 @pytest.fixture(scope="module")
-def tgz_archive(module_tmpdir, project_path, prepare_ignore):
+def tgz_archive(module_tmpdir, project_path):
     cmd = [os.path.join(basepath, "cartridge"), "pack", "tgz", project_path]
     process = subprocess.run(cmd, cwd=module_tmpdir)
     assert process.returncode == 0, \
@@ -37,7 +37,7 @@ def tgz_archive(module_tmpdir, project_path, prepare_ignore):
 
 
 @pytest.fixture(scope="module")
-def rpm_archive(module_tmpdir, project_path, prepare_ignore):
+def rpm_archive(module_tmpdir, project_path):
     cmd = [os.path.join(basepath, "cartridge"), "pack", "rpm", project_path]
     process = subprocess.run(cmd, cwd=module_tmpdir)
     assert process.returncode == 0, \
@@ -50,7 +50,7 @@ def rpm_archive(module_tmpdir, project_path, prepare_ignore):
 
 
 @pytest.fixture(scope="module")
-def deb_archive(module_tmpdir, project_path, prepare_ignore):
+def deb_archive(module_tmpdir, project_path):
     cmd = [os.path.join(basepath, "cartridge"), "pack", "deb", project_path]
     process = subprocess.run(cmd, cwd=module_tmpdir)
     assert process.returncode == 0, \
@@ -63,7 +63,7 @@ def deb_archive(module_tmpdir, project_path, prepare_ignore):
 
 
 @pytest.fixture(scope="module")
-def rpm_archive_with_custom_units(module_tmpdir, project_path, prepare_ignore):
+def rpm_archive_with_custom_units(module_tmpdir, project_path):
     unit_template = '''
 [Unit]
 Description=Tarantool service: ${name}
@@ -128,7 +128,7 @@ Alias=${name}
 
 def test_tgz_pack(project_path, tgz_archive, tmpdir):
     with tarfile.open(name=tgz_archive['name']) as tgz_arch:
-        # usr/share/tarantool is added to coorectly run assert_file_modes
+        # usr/share/tarantool is added to coorectly run assert_filemodes
         distribution_dir = os.path.join(tmpdir, 'usr/share/tarantool', project_name)
         os.makedirs(distribution_dir, exist_ok=True)
 

--- a/test/python/test_pack.py
+++ b/test/python/test_pack.py
@@ -120,7 +120,7 @@ Alias=${name}
         "Error during creating of rpm archive with project"
 
     archive_name = find_archive(module_tmpdir, project['name'], 'rpm')
-    assert archive_name is not None, "RPM archive isn't founded in work directory"
+    assert archive_name is not None, "RPM archive isn't found in work directory"
 
     return {'name': archive_name}
 

--- a/test/python/utils.py
+++ b/test/python/utils.py
@@ -76,18 +76,10 @@ original_file_tree = set([
     'app',
     'app/roles',
     'app/roles/custom.lua',
-    'test',
-    'test/helper',
-    'test/integration',
-    'test/unit',
-    'tmp',
-    'tmp/.keep',
     project_name + '-scm-1.rockspec',
     'tarantool',
     'tarantoolctl',
     'VERSION',
-    'ignored',  # special folder for test work cartridge ignore
-    'ignored/asterisk'
 ])
 
 original_rocks_content = set([


### PR DESCRIPTION
Fix backward compatible with `.cartridge.ignore + .cartridge.pre` 
Support new  Use `cartridge.pre-build` and `cartridge.post-build` files to specify additional actions to be done before and after `tarantoolctl rocks make`
Separate docker packing tests
Use parametrized `project` fixture to test both original and deprecated flows
Use coloured error, warn and log messages

Closes #86 