### PR TITLE
Fix rocks manifest error on packing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   firstly commandline options, then environment variables, then options from
   `.config.yml`, in the end default options. Options from `.config.yml` are
   overriden by corresponding to them environment variables.
+- Error on rocks manifest processing
 
 ## [1.2.1] - 2019-11-25
 

--- a/test/python/test_pack.py
+++ b/test/python/test_pack.py
@@ -353,19 +353,38 @@ def filter_archive_files(arch_files):
 
 def validate_version_file(distribution_dir):
     original_keys = [
+        'TARANTOOL',
         project_name,
+        # default app dependencies
+        'luatest',
+        'cartridge',
+        # known cartridge dependencies
+        'membership',
+        'checks',
+        'vshard',
+        'http',
+        'frontend-core',
     ]
+
     if tarantool_enterprise_is_used():
-        original_keys.append('TARANTOOL')
         original_keys.append('TARANTOOL_SDK')
 
     version_filepath = os.path.join(distribution_dir, 'VERSION')
     assert os.path.exists(version_filepath)
 
+    version_file_content = {}
     with open(version_filepath, 'r') as version_file:
-        version_content = version_file.read()
-        for key in original_keys:
-            assert '{}='.format(key) in version_content
+        file_lines = version_file.read().strip().split('\n')
+        print('LINES:', file_lines)
+        for l in file_lines:
+            m = re.match(r'^([^=]+)=([^=]+)$', l)
+            assert m is not None
+
+            key, version = m.groups()
+            version_file_content[key] = version
+
+    for key in original_keys:
+        assert key in version_file_content
 
 
 def recursive_listdir(root_dir):

--- a/test/python/test_pack.py
+++ b/test/python/test_pack.py
@@ -375,7 +375,6 @@ def validate_version_file(distribution_dir):
     version_file_content = {}
     with open(version_filepath, 'r') as version_file:
         file_lines = version_file.read().strip().split('\n')
-        print('LINES:', file_lines)
         for l in file_lines:
             m = re.match(r'^([^=]+)=([^=]+)$', l)
             assert m is not None


### PR DESCRIPTION
Don't use `luarocks` module to find and parse manifest file
Write Tarantool version for opensource
Improve tests
XXX: doesn't work for packing to docker

closes #80 