### PR TITLE
Support deprecated packing flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `--from` option for `docker pack` command to specify base image Dockerfile path
 - `cartridge.pre-build` and `cartridge.post-build` hooks
   to be ran before and after `rocks make`
+- Deprecated build flow (`.cartridge.ignore` + `.cartridge.pre`) is supported
+  for all distribution types except `docker`
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ package.
 #### Special files
 
 You can place these files in your application root to control the application
-packing flow:
+packing flow (see [examples](#examples) below):
 
 * `cartridge.pre-build`: a script to be run before `tarantoolctl rocks make`.
   The main purpose of this script is to build some non-standard rocks modules
@@ -168,6 +168,32 @@ packing flow:
 *Note*: You can use any of these approaches (just take care not to mix them): `cartridge.pre-build` + `cartridge.post-build`  or deprecated `.cartridge.ignore` + `.cartridge.pre`.
 
 *Note*: Packing to docker image isn't compatible with the deprecated packing flow.
+
+##### Examples
+
+`cartridge.pre-build`:
+
+```bash
+#!/bin/sh
+
+# The main purpose of this script is to build some non-standard rocks modules.
+# It will be ran before `tarantoolctl rocks make` on application build
+
+tarantoolctl rocks make --chdir ./third_party/my-custom-rock-module
+```
+
+`cartridge.post-build`:
+
+```bash
+#!/bin/sh
+
+# The main purpose of this script is to remove build artifacts from result package.
+# It will be ran after `tarantoolctl rocks make` on application build
+
+rm -rf third_party
+rm -rf node_modules
+rm -rf doc
+```
 
 #### Application type-specific details
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,19 @@ packing flow:
 * `cartridge.post-build`: a script to be run after `tarantoolctl rocks make`.
   The main purpose of this script is to remove build artifacts from result package.
 
+* [DEPRECATED] `.cartridge.ignore`: here you can specify some files and directories to be
+  excluded from the package build. See the
+  [documentation](https://www.tarantool.io/ru/doc/1.10/book/cartridge/cartridge_dev/#using-cartridge-ignore-files)
+  for details.
+
+* [DEPRECATED] `.cartridge.pre`: a script to be run before `tarantoolctl rocks make`.
+  The main purpose of this script is to build some non-standard rocks modules
+  (for example, from a submodule).
+
+*Note*: You can use any of these approaches (just take care not to mix them): `cartridge.pre-build` + `cartridge.post-build`  or deprecated `.cartridge.ignore` + `.cartridge.pre`.
+
+*Note*: Packing to docker image isn't compatible with the deprecated packing flow.
+
 #### Application type-specific details
 
 ##### TGZ

--- a/templates/cartridge/cartridge.post-build
+++ b/templates/cartridge/cartridge.post-build
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Simple post-build script
-# Will be run after `tarantoolctl rocks make` on application build
+# Will be ran after `tarantoolctl rocks make` on application build
 # Could be useful to remove some build artifacts from result package
 
 # For example:

--- a/templates/cartridge/cartridge.pre-build
+++ b/templates/cartridge/cartridge.pre-build
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Simple pre-build script
-# Will be run before `tarantoolctl rocks make` on application build
+# Will be ran before `tarantoolctl rocks make` on application build
 # Could be useful to install non-standart rocks modules
 
 # For example:

--- a/test/python/test_docker_pack.py
+++ b/test/python/test_docker_pack.py
@@ -117,6 +117,16 @@ def test_invalid_base_dockerfile(project, module_tmpdir, tmpdir):
     assert process.returncode == 1
 
 
+def test_using_deprecated_files(deprecared_project, tmpdir):
+    cmd = [
+        os.path.join(basepath, "cartridge"),
+        "pack", "docker",
+        deprecared_project['path'],
+    ]
+    process = subprocess.run(cmd, cwd=tmpdir)
+    assert process.returncode == 1
+
+
 def test_docker_pack(project, docker_image, tmpdir, docker_client):
     image_name = docker_image['name']
     container = docker_client.containers.create(image_name)


### PR DESCRIPTION
Support deprecation flow and a new flow as well
On `cartridge pack` call check which flow is used, warn on deprecated
flow and check if only ine flow special filws are exists
Pass deprecated_build_flow flag to pack funtions
Deny using deprecated (`.cartridge.ignore` and `.cartridge.pre`) files for `pack docker`
Update README
Add deprecated_project fixture to test if it works correctly