### PR TITLE
Do 'git clean' on submodules during packing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   to be ran before and after `rocks make`
 - Deprecated build flow (`.cartridge.ignore` + `.cartridge.pre`) is supported
   for all distribution types except `docker`
+- Recursively cleaning all submodules on application packing
 
 ### Changed
 

--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -1254,6 +1254,7 @@ local function form_distribution_dir(source_dir, dest_dir)
         -- Clean up all files explicitly ignored by git, to not accidentally
         -- ship development snaps, xlogs or other garbage to production.
         call("cd %q && %s clean -f -d -X", dest_dir, git)
+        call("cd %q && %s submodule foreach --recursive %s clean -f -d -X", dest_dir, git, git)
     else
         warn("git not found. It is possible that some of the extra files " ..
                  "normally ignored are shipped to the resulting package. ")

--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -1254,6 +1254,7 @@ local function form_distribution_dir(source_dir, dest_dir)
         -- Clean up all files explicitly ignored by git, to not accidentally
         -- ship development snaps, xlogs or other garbage to production.
         call("cd %q && %s clean -f -d -X", dest_dir, git)
+        -- Recursively cleanup all submodules
         call("cd %q && %s submodule foreach --recursive %s clean -f -d -X", dest_dir, git, git)
     else
         warn("git not found. It is possible that some of the extra files " ..


### PR DESCRIPTION
Currently if an app has submodules, the 'git clean' stage that we do
in cartridge-cli doesn't touch them, which leads to garbage
accumulating in the resulting package. Sometimes it may even lead to
failed compilation (e.g. when using CMake due to leftover
CMakeCache.txt).

This patch adds recursive cleaning of submodules during packing.