### PR TITLE
Fix RPM header for centos:8

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,6 +95,7 @@ test_enterprise-1.10:
     CACHE_IMAGE_TARGET: cache-base
   before_script:
     - docker info
+    - rpm --version
     - make tmp/sdk-1.10
     - source tmp/sdk-1.10/env.sh
     - tarantool -V
@@ -110,6 +111,7 @@ test_enterprise-1.10:
       - tmp/cache-image.tar
   before_script:
     - docker info
+    - rpm --version
     - curl -s https://packagecloud.io/install/repositories/tarantool/$TARANTOOL_VERSION/script.rpm.sh | bash
     - yum -y install tarantool tarantool-devel
     - tarantool -V

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Allow to pass `--version` in format `major.minor.patch[-count][-hash]`
 
+### Changed
+
+- RPM header: added `PAYLOADDIGEST` and `PAYLOADDIGESTALGO` flags,
+  removed `RPMVERSION`.
+
 ## [1.3.0] - 2020-01-13
 
 ### Added

--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -1556,6 +1556,8 @@ local HEADERIMMUTABLE=63
 -- But I didn't find documentation for some tags (PAYLOADDIGEST, PAYLOADDIGESTALGO),
 -- so, I got these values from the rpm repo:
 -- - https://github.com/rpm-software-management/rpm/blob/master/lib/rpmtag.h
+-- payload digest explanation can be found here:
+-- - https://github.com/rpm-software-management/rpm/issues/163
 --
 local SIGNATURE_TAG_TABLE = {
     SIG_SIZE = 1000,

--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -2019,7 +2019,6 @@ local function pack_rpm(source_dir, dest_dir, name, version, release, opts)
         {'FILELANGS', 'STRING_ARRAY', fileinfo.filelangs},
         {'FILEDIGESTS', 'STRING_ARRAY', fileinfo.filedigests},
         {'FILELINKTOS', 'STRING_ARRAY', fileinfo.filelinktos},
-        {'RPMVERSION', 'STRING', '4.11.3'},
         {'SIZE', 'INT32', payloadsize},
         {'PAYLOADDIGEST', 'STRING_ARRAY', {payloaddigest}},
         {'PAYLOADDIGESTALGO', 'INT32', payloaddigest_algo},

--- a/test/python/test_pack.py
+++ b/test/python/test_pack.py
@@ -295,3 +295,11 @@ def test_packing_with_wrong_filemodes(tmpdir):
     cmd = [os.path.join(basepath, "cartridge"), "pack", "rpm", project_path]
     process = subprocess.run(cmd, cwd=tmpdir)
     assert process.returncode == 1, "Packing project with invalid filemode must fail"
+
+
+def test_rpm_checksig(rpm_archive):
+    cmd = [
+        'rpm', '--checksig', '-v', rpm_archive['name']
+    ]
+    process = subprocess.run(cmd)
+    assert process.returncode == 0, "RPM signature isn't correct"

--- a/test/python/utils.py
+++ b/test/python/utils.py
@@ -148,10 +148,13 @@ def validate_version_file(project, distribution_dir):
 def assert_files_mode_and_owner_rpm(project, filename):
     DIRNAMES_TAG = 1118
     DIRINDEXES_TAG = 1116
+    PAYLOADDIGEST_TAG = 5092
+    PAYLOADDIGESTALGO_TAG = 5093
 
     expected_tags = [
         'basenames', DIRNAMES_TAG, DIRINDEXES_TAG, 'filemodes',
-        'fileusername', 'filegroupname'
+        'fileusername', 'filegroupname',
+        PAYLOADDIGEST_TAG, PAYLOADDIGESTALGO_TAG,
     ]
 
     with rpmfile.open(filename) as rpm:


### PR DESCRIPTION
The new (4.14.2) RPM version used in centos:8 image requires
PAYLOADDIGEST tag in package header.
This patch adds PAYLOADDIGEST and PAYLOADDIGESTALGO tags to package
header to prevent package signature check fail