### PR TITLE
pack: extend custom version with git commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 <!-- Please update cartridge-cli/VERSION.lua with new release -->
 
+### Added
+
+- Allow to pass `--version` in format `major.minor.patch[-count][-hash]`
+
 ## [1.3.0] - 2020-01-13
 
 ### Added

--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -692,6 +692,7 @@ local function normalize_version(str)
     local patterns = {
         "(%d+)%.(%d+)%.(%d+)-(%d+)-(%g+)",
         "(%d+)%.(%d+)%.(%d+)-(%d+)",
+        "(%d+)%.(%d+)%.(%d+)-(%g+)",
         "(%d+)%.(%d+)%.(%d+)",
         "(%d+)%.(%d+)",
         "(%d+)"
@@ -700,9 +701,13 @@ local function normalize_version(str)
     for _, pattern in ipairs(patterns) do
         local major, minor, patch, count, hash = string.match(str, pattern)
         if major ~= nil then
-            local release = count or '0'
-            if hash ~= nil then
-                release = string.format('%s-%s', release, hash)
+            local release = '0'
+            if count ~= nil and hash ~= nil then
+                release = string.format('%s-%s', count, hash)
+            elseif count ~= nil then
+                release = tostring(count)
+            elseif hash ~= nil then
+                release = tostring(hash)
             end
             return format_version(major, minor, patch), release
         end
@@ -778,7 +783,7 @@ local function detect_name_release_version(source_dir, raw_name, raw_version)
     if raw_version then
         version, release = normalize_version(raw_version)
         if version == nil then
-            die("Passed version '%s' should be semantic (major.minor.patch[-commit])",
+            die("Passed version '%s' should be semantic (major.minor.patch[-count][-commit])",
                 raw_version)
         end
         release = release or '0'

--- a/test/python/test_pack.py
+++ b/test/python/test_pack.py
@@ -244,7 +244,8 @@ def test_packing_without_git(project_without_dependencies, tmpdir):
     ]
     process = subprocess.run(cmd, cwd=tmpdir)
     assert process.returncode == 0
-    assert 'empty-project-0.1.0-0.rpm' in os.listdir(tmpdir)
+    project_name = project_without_dependencies['name']
+    assert '{}-0.1.0-0.rpm'.format(project_name) in os.listdir(tmpdir)
 
 
 @pytest.mark.parametrize('version,pack_format,expected_postfix',
@@ -255,6 +256,8 @@ def test_packing_without_git(project_without_dependencies, tmpdir):
                              ('0.1.0-42', 'deb', '0.1.0-42.deb'),
                              ('0.1.0-42-g8bce594e', 'rpm', '0.1.0-42-g8bce594e.rpm'),
                              ('0.1.0-42-g8bce594e', 'deb', '0.1.0-42-g8bce594e.deb'),
+                             ('0.1.0-g8bce594e', 'rpm', '0.1.0-g8bce594e.rpm'),
+                             ('0.1.0-g8bce594e', 'deb', '0.1.0-g8bce594e.deb'),
                          ])
 def test_packing_with_version(project_without_dependencies, tmpdir, version, pack_format, expected_postfix):
     # pass version explicitly

--- a/test/python/test_pack.py
+++ b/test/python/test_pack.py
@@ -245,7 +245,7 @@ def test_packing_without_git(tmpdir):
     process = subprocess.run(cmd, cwd=tmpdir)
     assert process.returncode == 1
 
-    # remove dependenciies to speed up test
+    # remove dependencies to speed up test
     rockspec_path = os.path.join(project_path, '{}-scm-1.rockspec'.format(project_name))
     with open(rockspec_path, 'w') as f:
         f.write('''
@@ -264,6 +264,31 @@ def test_packing_without_git(tmpdir):
         project_path,
     ]
     process = subprocess.run(cmd, cwd=tmpdir)
+    assert process.returncode == 0
+    assert 'test-project-0.1.0-0.rpm' in os.listdir(tmpdir)
+
+
+@pytest.mark.parametrize('version,pack_format,expected_postfix',
+                         [
+                             ('0.1.0', 'rpm', '0.1.0-0.rpm'),
+                             ('0.1.0', 'deb', '0.1.0-0.deb'),
+                             ('0.1.0-42', 'rpm', '0.1.0-42.rpm'),
+                             ('0.1.0-42', 'deb', '0.1.0-42.deb'),
+                             ('0.1.0-42-g8bce594e', 'rpm', '0.1.0-42-g8bce594e.rpm'),
+                             ('0.1.0-42-g8bce594e', 'deb', '0.1.0-42-g8bce594e.deb'),
+                         ])
+def test_packing_with_version(project, tmpdir, version, pack_format, expected_postfix):
+    # pass version explicitly
+    cmd = [
+        os.path.join(basepath, "cartridge"),
+        "pack", pack_format,
+        "--version", version,
+        project['path'],
+    ]
+    process = subprocess.run(cmd, cwd=tmpdir)
+    assert process.returncode == 0
+    expected_file = '{name}-{postfix}'.format(name=project['name'], postfix=expected_postfix)
+    assert expected_file in os.listdir(tmpdir)
 
 
 def test_packing_with_wrong_filemodes(tmpdir):

--- a/test/python/utils.py
+++ b/test/python/utils.py
@@ -67,7 +67,7 @@ def assert_dir_contents(files_list, exp_files_list, exp_rocks_content,
     without_rocks = {x for x in files_list if not x.startswith('.rocks')}
 
     if tarantool_enterprise_is_used() and not skip_tarantool_binaries:
-        assert without_rocks == exp_files_list.union(set(['tarantool', 'tarantoolctl']))
+        assert without_rocks == exp_files_list.union({'tarantool', 'tarantoolctl'})
     else:
         assert without_rocks == exp_files_list
 
@@ -90,11 +90,11 @@ def assert_filemode(project, filepath, filemode):
 
 
 def assert_filemodes(project, basedir):
-    known_dirs = set([
+    known_dirs = {
         'etc', 'etc/systemd', 'etc/systemd/system',
         'usr', 'usr/share', 'usr/share/tarantool',
         'usr/lib', 'usr/lib/tmpfiles.d'
-    ])
+    }
     filenames = recursive_listdir(basedir) - known_dirs
 
     for filename in filenames:


### PR DESCRIPTION
pack: extend custom version with git commit

This patch allows to pass version as "major.minor.patch-count-hash"
    
Now user can pass `cartridge pack rpm --version 1.2.3-1-g8bce594e` and get rpm with name `project-1.2.3-1-g8bce594e.rpm`
    
Also hash is an optional argument and could be omitted: `cartridge pack rpm --version 1.2.3-1` -> `project-1.2.3-1.rpm`
    
Closes #113