### PR TITLE
refactoring: simplify detect_git_version function

### DIFF
--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -731,22 +731,14 @@ local function detect_git_version(source_dir)
         return nil
     end
 
-    local version, release, commit = string.match(
-        string.strip(raw_version), "^(.*)-(%d+)-(%g+)$")
-
+    local version, release = normalize_version(raw_version)
     if version == nil then
-        return nil
-    end
-
-    local normalized_version = normalize_version(version)
-    if normalized_version == nil then
-
         warn("Detected version '%s' ignored, " ..
               "because it doesn't look like proper " ..
-              "version (major.minor.patch)", version)
+              "version (major.minor.patch[-count][-commit])", version)
     end
 
-    return normalized_version, release, commit
+    return version, release
 end
 
 local function find_rockspec(source_dir)


### PR DESCRIPTION
After bed66e7234515eb06d192c4eff4cc04348022b03
cartridge-cli supports `git describe` version format.

Let's reuse `normalize_version` function and drop a piece of redundant code