### PR TITLE
Check if .git is a directory

### DIFF
--- a/test/python/project.py
+++ b/test/python/project.py
@@ -267,3 +267,14 @@ def use_deprecated_files(project):
         'ignored',  # special folder for test work cartridge ignore
         'ignored/asterisk',
     })
+
+
+def remove_all_dependencies(project):
+    with open(project.rockspec_path, 'w') as f:
+        f.write('''
+                package = '{}'
+                version = 'scm-1'
+                source  = {{ url = '/dev/null' }}
+                dependencies = {{ 'tarantool' }}
+                build = {{ type = 'none' }}
+            '''.format(project.name))


### PR DESCRIPTION
This patch fixes an error in case when there is `.git` file in the project root, and it's not a directory.

