### PR TITLE
pack: fix rock pack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:8
 
 RUN yum -y update
-RUN yum install -y git gcc make cmake unzip python3-pip
+RUN yum install -y git gcc make cmake zip unzip python3-pip
 
 RUN yum install -y yum-utils device-mapper-persistent-data lvm2
 RUN yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo

--- a/Dockerfile.cache
+++ b/Dockerfile.cache
@@ -1,7 +1,7 @@
 FROM centos:8 as cache-base
 SHELL ["/bin/bash", "-c"]
 
-RUN yum install -y git gcc make cmake unzip
+RUN yum install -y git gcc make cmake zip unzip
 
 # create user and directories
 RUN groupadd -r tarantool \

--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -1518,7 +1518,10 @@ end
 local function get_rockspec_version(extended_version)
     local version, release = normalize_version(extended_version)
     release = tonumber(release:split('-', 1)[1]) or '0'
-    return version .. '-' .. release
+    local result = version .. '-' .. release
+    info('Version %s is transformed to %s to be compatible with luarocks format',
+        extended_version, result)
+    return result
 end
 
 local function pack_rock()

--- a/test/python/project.py
+++ b/test/python/project.py
@@ -135,7 +135,7 @@ def add_dependency_submodule(project):
         rockspec_lines = [
             "package = '{}'".format(SUBMODULE_NAME),
             "version = 'scm-1'",
-            "source  = { url = '/dev/null' }",
+            "source  = { url = 'file://.' }",
             "build = { type = 'none'}",
         ]
         f.write('\n'.join(rockspec_lines))
@@ -274,7 +274,7 @@ def remove_all_dependencies(project):
         f.write('''
                 package = '{}'
                 version = 'scm-1'
-                source  = {{ url = '/dev/null' }}
+                source  = {{ url = 'file://.' }}
                 dependencies = {{ 'tarantool' }}
                 build = {{ type = 'none' }}
             '''.format(project.name))

--- a/test/python/test_pack.py
+++ b/test/python/test_pack.py
@@ -287,12 +287,16 @@ def test_packing_with_git_file(project_with_git_file, tmpdir):
                          [
                              ('0.1.0', 'rpm', '0.1.0-0.rpm'),
                              ('0.1.0', 'deb', '0.1.0-0.deb'),
+                             ('0.1.0', 'rock', '0.1.0-0.src.rock'),
                              ('0.1.0-42', 'rpm', '0.1.0-42.rpm'),
                              ('0.1.0-42', 'deb', '0.1.0-42.deb'),
+                             ('0.1.0-42', 'rock', '0.1.0-42.src.rock'),
                              ('0.1.0-42-g8bce594e', 'rpm', '0.1.0-42-g8bce594e.rpm'),
                              ('0.1.0-42-g8bce594e', 'deb', '0.1.0-42-g8bce594e.deb'),
+                             ('0.1.0-42-g8bce594e', 'rock', '0.1.0-42.src.rock'),
                              ('0.1.0-g8bce594e', 'rpm', '0.1.0-g8bce594e.rpm'),
                              ('0.1.0-g8bce594e', 'deb', '0.1.0-g8bce594e.deb'),
+                             ('0.1.0-g8bce594e', 'rock', '0.1.0-0.src.rock'),
                          ])
 def test_packing_with_version(project_without_dependencies, tmpdir, version, pack_format, expected_postfix):
     project = project_without_dependencies

--- a/test/python/test_pack.py
+++ b/test/python/test_pack.py
@@ -149,6 +149,7 @@ def rock_archive(module_tmpdir, light_project):
     project = light_project
 
     # luarocks requires existence of source.url
+    # We use https://stackoverflow.com/a/20593644 to replace it in file
     with fileinput.FileInput(project.rockspec_path, inplace=True) as file:
         for line in file:
             print(line.replace('/dev/null', 'file://.'), end='')
@@ -156,7 +157,7 @@ def rock_archive(module_tmpdir, light_project):
     cmd = [os.path.join(basepath, "cartridge"), "pack", "rock", project.path]
     process = subprocess.run(cmd, cwd=module_tmpdir)
     assert process.returncode == 0, \
-        "Error during creating of rpm archive with project"
+        "Error during creating of rock archive with project"
 
     filepath = find_archive(module_tmpdir, project.name, 'rock')
     assert filepath is not None, "Rock archive isn't found in work directory"
@@ -253,7 +254,7 @@ def test_rock_pack(rock_archive):
         # Tarantool 1.10 and Tarantool 2.2 use Luarocks 2 and Luarocks 3 respectively
         # The content is this cases a bit different
         # This checks is quite simple but shows that rock-archive is not empty
-        assert 'init.lua' in files, \
+        assert 'init.lua' in files or './init.lua' in files, \
             'Rock archive content is not as expected'
 
 

--- a/test/python/test_pack.py
+++ b/test/python/test_pack.py
@@ -250,7 +250,10 @@ def test_rock_pack(rock_archive):
     assert zipfile.is_zipfile(rock_archive.filepath), 'rock should be a valid zip-archive'
     with zipfile.ZipFile(rock_archive.filepath, 'r') as zip_archive:
         files = zip_archive.namelist()
-        assert rock_archive.project.rockspec_name in files, \
+        # Tarantool 1.10 and Tarantool 2.2 use Luarocks 2 and Luarocks 3 respectively
+        # The content is this cases a bit different
+        # This checks is quite simple but shows that rock-archive is not empty
+        assert 'init.lua' in files, \
             'Rock archive content is not as expected'
 
 


### PR DESCRIPTION
This patch fixes pack into rock.

In some cases cartridge could return following error
```
Type mismatch on field version: invalid value
'1.5.6-284-g10a507e4' does not match '[%w.]+-[%d]+'
(using rockspec format 1.0)
```

Luarocks requires a specific type of version format.
We should cut 'git format' to simple '[%w.]+-[%d]+'.

Also luarocks requires existance of "source.url" path
and faild with non-informative error otherwise.
So '/dev/null' in tests was replaced to 'file://.'