### PR TITLE
Fix tarantool headers lookup

### DIFF
--- a/cartridge-cli-scm-1.rockspec
+++ b/cartridge-cli-scm-1.rockspec
@@ -9,6 +9,12 @@ dependencies = {
     'lua >= 5.1',
 }
 
+external_dependencies = {
+    TARANTOOL = {
+        header = 'tarantool/module.h',
+    },
+}
+
 build = {
     type = 'cmake',
 


### PR DESCRIPTION
When tarantool is installed outside /usr/local, cmake encounters
problems finding it. To determine the path it uses TARANTOOL_DIR hint,
which is passed from the rockspec external_dependencies.