### PR TITLE
Add default path to cartridge pack command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - By default, temporary directory for application building is created in
   `~/.cartridge/tmp`
 - Commands usage messages are prettified
+- `path` argument for `cartridge pack` command isn't required.
+  By default, current directory is used.
 
 ## [1.3.2] - 2020-01-23
 

--- a/README.md
+++ b/README.md
@@ -124,12 +124,14 @@ These steps will be performed on running this command:
 
 ### Application packing details
 
-An application can be packed by running the `cartridge pack <type> <path>` command.
+An application can be packed by running the `cartridge pack <type> [<path>]` command.
 
-These types of distributables are supported: `rpm`, `deb`, `tgz`, `rock`, and
+These types of packages are supported: `rpm`, `deb`, `tgz`, `rock`, and
 `docker`.
 
-For `rmp`, `deb`, and `tgz`, we also deliver rocks modules and executables
+If `path` isn't specified, current directory is used by default.
+
+For `rpm`, `deb`, and `tgz`, we also deliver rocks modules and executables
 specific for the system where the `cartridge pack` command is running.
 
 For `docker`, the resulting image will contain rocks modules and executables

--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -2833,7 +2833,7 @@ local cmd_pack = {
     name = 'pack',
     doc = 'Pack application into a distributable bundle',
     usage = remove_leading_spaces([=[
-        %s pack [options] [<type>] [<path>]
+        %s pack [options] <type> [<path>]
 
         Arguments
             type                      Distribution type to create

--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -2840,6 +2840,7 @@ local cmd_pack = {
                                       Allowed types: %s
 
             path                      Path to application
+                                      Default to current directory
 
         Options
             --name NAME               Application name
@@ -3239,7 +3240,7 @@ local cmd_build = {
 
         Arguments
             path                      Path to application
-                                      Default to `.`
+                                      Default to current directory
     ]=]):format(self_name),
 }
 

--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -2999,6 +2999,14 @@ function cmd_pack.parse(arg)
     args.type = parameters[1]
     args.path = parameters[2]
 
+    if args.path == nil then
+        args.path = '.'
+    end
+
+    if args.type == nil then
+        die('Package type is required')
+    end
+
     if not array_contains(available_distribution_types, args.type) then
         die("Package type should be one of: %s",
                 table.concat(available_distribution_types, ', '))
@@ -3027,10 +3035,6 @@ function cmd_pack.parse(arg)
                 args.from = default_dockerfile_path
             end
         end
-    end
-
-    if args.path == nil then
-        die("Path to application is required")
     end
 
     return args

--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -2896,7 +2896,7 @@ function cmd_pack.callback(args)
     app_state.version_release = string.format('%s-%s', version, release)
 
     -- collect pack-specific application info
-    app_state.dest_dir = fio.abspath('.')
+    app_state.dest_dir = fio.cwd()
     app_state.from = args.from
     app_state.download_token = args.download_token
     app_state.docker_build_args = args.docker_build_args
@@ -3001,7 +3001,7 @@ function cmd_pack.parse(arg)
     args.path = parameters[2]
 
     if args.path == nil then
-        args.path = '.'
+        args.path = fio.cwd()
     end
 
     if args.type == nil then
@@ -3190,7 +3190,7 @@ local function create_app_directory_and_init_git(dest_dir, template, name)
 end
 
 function cmd_create.callback(args)
-    local path = args.path or "."
+    local path = args.path and fio.abspath(args.path) or fio.cwd()
 
     if not fio.path.exists(path) then
         die("Directory doesn't exist: '%s'", path)
@@ -3251,7 +3251,7 @@ function cmd_build.parse(args)
     }
 
     if result.path == nil then
-        result.path = '.'
+        result.path = fio.cwd()
     end
 
     return result

--- a/test/python/test_build.py
+++ b/test/python/test_build.py
@@ -54,3 +54,20 @@ def test_using_both_flows(project_without_dependencies, tmpdir):
     process = subprocess.run(cmd, cwd=tmpdir)
     assert process.returncode == 1, \
         "Building project with both flow files shouldn't work"
+
+
+def test_building_without_path_specifying(project_without_dependencies, tmpdir):
+    project = project_without_dependencies
+
+    # say `cartridge build` in project directory
+    cmd = [
+        os.path.join(basepath, "cartridge"),
+        "build",
+    ]
+    process = subprocess.run(cmd, cwd=project.path)
+    assert process.returncode == 0, 'Building project failed'
+
+    # check that all expected rocks was installed
+    files = recursive_listdir(project.path)
+    assert '.rocks' in files
+    assert all([rock in files for rock in project.rocks_content])

--- a/test/python/test_pack.py
+++ b/test/python/test_pack.py
@@ -392,3 +392,18 @@ def test_builddir(project_without_dependencies, tmpdir):
     process_output = subprocess.check_output(cmd, cwd=tmpdir, env=env)
     process_output = process_output.decode()
     assert re.search(r'[Bb]uild directory .+{}'.format(builddir), process_output) is not None
+
+
+def test_packing_without_path_specifying(project_without_dependencies, tmpdir):
+    project = project_without_dependencies
+
+    # say `cartridge pack rpm` in project directory
+    cmd = [
+        os.path.join(basepath, "cartridge"),
+        "pack", "rpm",
+    ]
+    process = subprocess.run(cmd, cwd=project.path)
+    assert process.returncode == 0, 'Packing application failed'
+
+    filepath = find_archive(project.path, project.name, 'rpm')
+    assert filepath is not None,  'Package not found'


### PR DESCRIPTION
Allow to run `cartridge pack <type>` in the project directory without specifying path `.`.