### PR TITLE
Improve parsing commands args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 <!-- Please update cartridge-cli/VERSION.lua with new release -->
 
+### Changed
+
+- Improved arguments parsing:
+  * boolean flags `--flag` shouldn't be passed after all other options;
+  * Both `--long_opt` and `--long-opt` patterns can be used, it will be parsed
+    as `long_opt` option
+
 ## [1.4.0] - 2020-02-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Specific options:
 
 * `--tag` - resulting image tag;
 
-* `--download_token` (env `TARANTOOL_DOWNLOAD_TOKEN`) - download token for
+* `--download-token` (env `TARANTOOL_DOWNLOAD_TOKEN`) - download token for
   installing Tarantool Enterprise to the resulting image.
 
 The base image is `centos:8`. On this image, `cartridge` will install all
@@ -389,10 +389,10 @@ Options
                         or ./init.lua when running from the app's directory,
                         or :apps_path/:app_name/init.lua in a multi-app env.
 
-    --apps_path PATH    Path to apps directory when running in a multi-app env.
+    --apps-path PATH    Path to apps directory when running in a multi-app env.
                         Default to /usr/share/tarantool
 
-    --run_dir DIR       Directory with pid and sock files.
+    --run-dir DIR       Directory with pid and sock files.
                         Defaults to TARANTOOL_RUN_DIR or /var/run/tarantool
 
     --cfg FILE          Cartridge instances config file.
@@ -449,7 +449,7 @@ To stop one or more running instances, say:
 cartridge stop [APP_NAME[.INSTANCE_NAME]] [options]
 
 These options from `start` command are supported
-    --run_dir DIR
+    --run-dir DIR
     --cfg FILE
 ```
 

--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -310,6 +310,9 @@ local function parse_command_args(args, schema)
                 'path',
             }
         }
+
+        Both `--long-opt OPT` and `--long_opt OPT` will be parsed as `{ long_opt = 'OPT' }`
+        You can't define option `long-opt` in schema, only `long_opt` pattern is allowed.
     --]]
 
     args = args or {}

--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -278,6 +278,110 @@ local function globtopattern(g)
     return p
 end
 
+-- * ------------------------ Arguments parsing ------------------------
+
+
+local function is_option_name(arg)
+    return string.startswith(arg, '-') and not string.find(arg, '=')
+end
+
+local function raw_option_name(arg)
+    assert(is_option_name(arg))
+    return arg:gsub('^%-%-?', '')
+end
+
+local BOOLEAN_VALUES = {'0', '1', 'true', 'false'}
+
+local function parse_command_args(args, schema)
+    --[[
+        <command> --name NAME --debug TYPE PATH
+
+        schema = {
+            opts = {
+                name = 'string',
+                debug = 'boolean',
+            },
+            args = {
+                'type',
+                'path',
+            }
+        }
+    --]]
+
+    schema = schema or {}
+    local schema_opts = schema.opts or {}
+    local schema_args = schema.args or {}
+
+    local passed_opts = {}
+
+    for _, arg in pairs(schema_args or {}) do
+        if schema_opts[arg] ~= nil then
+            return nil, string.format('Defined arg and option with the same name: %s', arg)
+        end
+    end
+
+    -- first, we need to move all flags to the end of args
+    local rearranged_args = {}
+    local flags = {}
+
+    for i, arg in ipairs(args or {}) do
+        if not is_option_name(arg) then
+            table.insert(rearranged_args, arg)
+        else
+            local option_name = raw_option_name(arg)
+
+            if passed_opts[option_name] then
+                return nil, string.format('Option %s passed more than one time', option_name)
+            end
+
+            passed_opts[option_name] = true
+
+            if schema_opts[option_name] == 'boolean' and
+                not array_contains(BOOLEAN_VALUES, args[i + 1]) then
+                    table.insert(flags, arg)
+
+            else
+                table.insert(rearranged_args, arg)
+            end
+        end
+    end
+
+    for _, flag in ipairs(flags) do
+        table.insert(rearranged_args, flag)
+    end
+
+    local argparse_opts = {}
+    for opt_name, opt_type in pairs(schema_opts) do
+        table.insert(argparse_opts, {opt_name, opt_type})
+    end
+
+    local ok, parsed_parameters = pcall(function()
+        return argparse(rearranged_args, argparse_opts)
+    end)
+
+    if not ok then
+        return nil, string.format('Failed to parse args: %s', parsed_parameters)
+    end
+
+    local res = {}
+    for i, arg_name in pairs(schema_args) do
+        if parsed_parameters[i] ~= nil then
+            res[arg_name] = parsed_parameters[i]
+            parsed_parameters[i] = nil
+        end
+    end
+
+    for opt_name, opt_value in pairs(parsed_parameters) do
+        if schema_opts[opt_name] ~= nil then
+            res[opt_name] = opt_value
+        else
+            return nil, string.format('Unknown option: %s', opt_name)
+        end
+    end
+
+    return res
+end
+
 -- * --------------------------- Color helpers ---------------------------
 
 local RESET_TERM = '\x1B[0m'
@@ -2979,31 +3083,31 @@ function cmd_pack.callback(args)
     info('Packing application succeded!')
 end
 
-function cmd_pack.parse(arg)
-    local args = {}
+function cmd_pack.parse(cmd_args)
+    local args_schema = {
+        args = {
+            'type',
+            'path',
+        },
+        opts = {
+            name = 'string',
+            version = 'string',
+            instantiated_unit_template = 'string',
+            unit_template = 'string',
+            download_token = 'string',
+            tag = 'string',
+            from = 'string',
+        }
+    }
 
-    local parameters = argparse(
-            arg, {
-                { 'name', 'string' },
-                { 'version', 'string' },
-                { 'instantiated_unit_template', 'string' },
-                { 'unit_template', 'string' },
-                { 'download_token', 'string'},
-                { 'tag', 'string' },
-                { 'from', 'string' },
-            }
-    )
+    local args, err = parse_command_args(cmd_args, args_schema)
 
-    args.name = parameters.name
-    args.version = parameters.version
-    args.unit_template = parameters.unit_template
-    args.instantiated_unit_template = parameters.instantiated_unit_template
-    args.download_token = parameters.download_token or os.getenv('TARANTOOL_DOWNLOAD_TOKEN')
+    if args == nil then
+        die("Failed to parse args: %s", err)
+    end
+
+    args.download_token = args.download_token or os.getenv('TARANTOOL_DOWNLOAD_TOKEN')
     args.docker_build_args = os.getenv('TARANTOOL_DOCKER_BUILD_ARGS') or ''
-    args.tag = parameters.tag
-    args.from = parameters.from
-    args.type = parameters[1]
-    args.path = parameters[2]
 
     if args.path == nil then
         args.path = fio.cwd()
@@ -3066,20 +3170,22 @@ local cmd_create = {
     ]=]):format(self_name),
 }
 
-function cmd_create.parse(arg)
-    local args = {}
+function cmd_create.parse(cmd_args)
+    local args_schema = {
+        args = {
+            'path'
+        },
+        opts = {
+            name = 'string',
+            template = 'string'
+        },
+    }
 
-    local parameters = argparse(
-        arg,
-        {
-            {'name',     'string'},
-            {'template', 'string'}
-        }
-    )
+    local args, err = parse_command_args(cmd_args, args_schema)
 
-    args.name = parameters.name
-    args.template = parameters.template
-    args.path = parameters[1]
+    if args == nil then
+        die('Failed to parse args: %s', err)
+    end
 
     return args
 end
@@ -3249,17 +3355,24 @@ local cmd_build = {
     ]=]):format(self_name),
 }
 
-function cmd_build.parse(args)
-    local parameters = argparse(args)
-    local result = {
-        path = parameters[1]
+function cmd_build.parse(cmd_args)
+    local args_schema = {
+        args = {
+            'path'
+        },
     }
 
-    if result.path == nil then
-        result.path = fio.cwd()
+    local args, err = parse_command_args(cmd_args, args_schema)
+
+    if args == nil then
+        die("Failed to parse args: %s", err)
     end
 
-    return result
+    if args.path == nil then
+        args.path = fio.cwd()
+    end
+
+    return args
 end
 
 function cmd_build.callback(args)
@@ -3360,22 +3473,35 @@ local function read_cartridge_defaults()
     return fun.chain(defaults, from_file, env_vars):tomap()
 end
 
-function cmd_start.parse(args)
-    local result = argparse(args, {
-        {'script', 'string'},
-        {'apps_path', 'string'},
-        {'run_dir', 'string'},
-        {'cfg', 'string'},
-        'daemonize', 'd',
-        'verbose', -- Do not close standard FDs for child process. Private flag for debugging.
-    })
+function cmd_start.parse(cmd_args)
+    local args_schema = {
+        opts = {
+            script = 'string',
+            apps_path = 'string',
+            run_dir = 'string',
+            cfg = 'string',
+            daemonize = 'boolean',
+            d = 'boolean',
+            verbose = 'boolean',
+        },
+        args = {
+            'instance_id',
+        }
+    }
+
+    local result, err = parse_command_args(cmd_args, args_schema)
+
+    if result == nil then
+        die("Failed to parse args: %s", err)
+    end
+
     if result.daemonize == nil then result.daemonize = result.d end
     local defaults = read_cartridge_defaults()
     for k, v in pairs(defaults) do
         result[k] = result[k] or v
     end
 
-    local instance_id = (result[1] or ''):split('.')
+    local instance_id = (result.instance_id or ''):split('.')
     local app_name = get_app_name_from_rockspec()
     result.app_name = #instance_id[1] > 0 and instance_id[1] or app_name
     assert(result.app_name and #result.app_name > 0, 'APP_NAME is required')
@@ -3823,5 +3949,6 @@ end
 
 return {
    matching = matching,
+   parse = parse_command_args,
    main = main
 }

--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -3001,10 +3001,10 @@ local cmd_pack = {
             --version VERSION         Application version
                                       By default, version is discovered by git
 
-            --unit_template PATH      Path to the template for systemd unit file
+            --unit-template PATH      Path to the template for systemd unit file
                                       Used for rpm and deb types
 
-            --instantiated_unit_template PATH    Path to the template for systemd
+            --instantiated-unit-template PATH    Path to the template for systemd
                                                  instantiated unit file
                                                  Used for rpm and deb types
 
@@ -3014,14 +3014,14 @@ local cmd_pack = {
             --from PATH               Path to the base image dockerfile
                                       Used for docker type
 
-            --download_token TOKEN    Tarantool Enterprise download token
+            --download-token TOKEN    Tarantool Enterprise download token
                                       Used for docker type
 
         Packing to docker:
             If you use Tarantool Enterprise, it's required to specify a
             Tarantool Enterprise download token. You can also specify it in
             TARANTOOL_DOWNLOAD_TOKEN environment variable (has lower priority
-            than --download_token option)
+            than --download-token option)
 
             You can pass additional arguments to `docker build` command using
             TARANTOOL_DOCKER_BUILD_ARGS env variable.
@@ -3459,10 +3459,10 @@ local cmd_start = {
                                 or ./init.lua when running from app's directory,
                                 or :apps_path/:app_name/init.lua in multi-app env.
 
-            --apps_path PATH    Path to apps direcrory when running in multi-app env.
+            --apps-path PATH    Path to apps direcrory when running in multi-app env.
                                 Default to /usr/share/tarantool
 
-            --run_dir DIR       Directory with pid and sock files
+            --run-dir DIR       Directory with pid and sock files
                                 Default to TARANTOOL_RUN_DIR or /var/run/tarantool
 
             --cfg FILE          Cartridge instances config file.
@@ -3868,7 +3868,7 @@ local cmd_stop = {
         defined instances.
 
         These options from `start` command are supported
-            --run_dir DIR
+            --run-dir DIR
             --cfg FILE
     ]=]):format(self_name),
     parse = cmd_start.parse,

--- a/test/integration/instance_management_test.lua
+++ b/test/integration/instance_management_test.lua
@@ -49,7 +49,7 @@ local function concat(...)
 end
 
 local RUN_DIR = 'tmp/test_run'
-local TEST_OPTS = {'--run_dir', RUN_DIR}
+local TEST_OPTS = {'--run-dir', RUN_DIR}
 local SIMPLE_INSTANCE_OPTS = concat({'--script', 'test/instances/init.lua'}, TEST_OPTS)
 
 g.before_each(function() fio.rmtree(RUN_DIR) end)
@@ -136,7 +136,7 @@ end
 
 g.test_start_stop_all_with_apps_path = function()
     assert_start_stop_all(
-        {'instances', '--cfg', 'test/instances/instances.yml', '--apps_path', fio.abspath('test')},
+        {'instances', '--cfg', 'test/instances/instances.yml', '--apps-path', fio.abspath('test')},
         {'instances.app_path_1', 'instances.app_path_2'}
     )
 end

--- a/test/python/test_pack.py
+++ b/test/python/test_pack.py
@@ -129,8 +129,8 @@ Alias=${name}
 
     process = subprocess.run([
             os.path.join(basepath, "cartridge"), "pack", "rpm",
-            "--unit_template", "unit_template.tmpl",
-            "--instantiated_unit_template", "instantiated_unit_template.tmpl",
+            "--unit-template", "unit_template.tmpl",
+            "--instantiated-unit-template", "instantiated_unit_template.tmpl",
             project.path
         ],
         cwd=tmpdir

--- a/test/unit/parse_command_args.lua
+++ b/test/unit/parse_command_args.lua
@@ -1,0 +1,199 @@
+local t = require('luatest')
+local app = require('cartridge-cli')
+
+local g = t.group('parse_command_args')
+
+local function split(msg)
+    return msg:split(' ')
+end
+
+g.test_parse_empty = function()
+    t.assert_equals(app.parse({}, {}), {})
+end
+
+g.test_simple_schema = function()
+    local schema = {
+        opts = {
+            name = 'string',
+            count = 'number',
+        },
+        args = {
+            'type',
+            'path',
+        }
+    }
+
+    t.assert_equals(app.parse({}, schema), {})
+    t.assert_equals(app.parse(split('--name NAME'), schema), { name = 'NAME' })
+    t.assert_equals(app.parse(split('TYPE'), schema), { type = 'TYPE' })
+    t.assert_equals(app.parse(split('--name NAME TYPE'), schema), { type = 'TYPE', name = 'NAME' })
+    t.assert_equals(
+        app.parse(split('--name NAME --count 1 TYPE'), schema),
+        { type = 'TYPE', name = 'NAME', count = 1 }
+    )
+    t.assert_equals(
+        app.parse(split('--name=NAME --count=1 TYPE'), schema),
+        { type = 'TYPE', name = 'NAME', count = 1 }
+    )
+    t.assert_equals(
+        app.parse(split('--name=NAME --count=1 TYPE PATH'), schema),
+        { path = 'PATH', name = 'NAME', count = 1, type = 'TYPE' }
+    )
+    t.assert_equals(
+        app.parse(split('--name=NAME --count=1 TYPE PATH'), schema),
+        { path = 'PATH', name = 'NAME', count = 1, type = 'TYPE' }
+    )
+    t.assert_equals(
+        app.parse(split('--name=NAME TYPE --count 1 PATH'), schema),
+        { path = 'PATH', name = 'NAME', count = 1, type = 'TYPE' }
+    )
+    t.assert_equals(
+        app.parse(split('TYPE PATH --name NAME --count 1'), schema),
+        { path = 'PATH', name = 'NAME', count = 1, type = 'TYPE' }
+    )
+
+    local res, err = app.parse(split('TYPE PATH UNKNOWN'), schema)
+    t.assert_equals(res, nil)
+    t.assert_str_icontains(err, 'unknown option')
+
+    local res, err = app.parse(split('--unknown UNKNOWN'), schema)
+    t.assert_equals(res, nil)
+    t.assert_str_icontains(err, 'unknown option')
+
+
+    local res, err = app.parse(split('--name NAME1 --name NAME2'), schema)
+    t.assert_equals(res, nil)
+    t.assert_str_icontains(err, 'option name passed more than one time')
+end
+
+
+g.test_schema_with_flag = function()
+    local schema = {
+        opts = {
+            name = 'string',
+            count = 'number',
+            flag = 'boolean',
+        },
+        args = {
+            'type',
+            'path',
+        }
+    }
+
+    t.assert_equals(app.parse(split('--flag'), schema), { flag = true })
+    t.assert_equals(app.parse(split('--flag=1'), schema), { flag = true })
+    t.assert_equals(app.parse(split('--flag=true'), schema), { flag = true })
+    t.assert_equals(app.parse(split('--flag 0'), schema), { flag = false })
+    t.assert_equals(app.parse(split('--flag false'), schema), { flag = false })
+
+    t.assert_equals(app.parse(split('--name NAME --flag'), schema), { name = 'NAME', flag = true })
+    t.assert_equals(
+        app.parse(split('--name NAME --flag TYPE'), schema),
+        { type = 'TYPE', name = 'NAME', flag = true }
+    )
+    t.assert_equals(
+        app.parse(split('--name NAME TYPE --flag'), schema),
+        { type = 'TYPE', name = 'NAME', flag = true }
+    )
+    t.assert_equals(
+        app.parse(split('--flag --name NAME TYPE'), schema),
+        { type = 'TYPE', name = 'NAME', flag = true }
+    )
+
+    t.assert_equals(
+        app.parse(split('--name NAME --flag false TYPE'), schema),
+        { type = 'TYPE', name = 'NAME', flag = false }
+    )
+    t.assert_equals(
+        app.parse(split('--name NAME TYPE --flag false'), schema),
+        { type = 'TYPE', name = 'NAME', flag = false }
+    )
+    t.assert_equals(
+        app.parse(split('--flag false --name NAME TYPE'), schema),
+        { type = 'TYPE', name = 'NAME', flag = false }
+    )
+
+    t.assert_equals(
+        app.parse(split('--flag TYPE PATH'), schema),
+        { type = 'TYPE', flag = true, path = 'PATH' }
+    )
+    t.assert_equals(
+        app.parse(split('TYPE --flag PATH'), schema),
+        { type = 'TYPE', flag = true, path = 'PATH' }
+    )
+    t.assert_equals(
+        app.parse(split('TYPE PATH --flag'), schema),
+        { type = 'TYPE', flag = true, path = 'PATH' }
+    )
+
+    t.assert_equals(
+        app.parse(split('--flag false TYPE PATH'), schema),
+        { type = 'TYPE', flag = false, path = 'PATH' }
+    )
+    t.assert_equals(
+        app.parse(split('TYPE --flag false PATH'), schema),
+        { type = 'TYPE', flag = false, path = 'PATH' }
+    )
+    t.assert_equals(
+        app.parse(split('TYPE PATH --flag false'), schema),
+        { type = 'TYPE', flag = false, path = 'PATH' }
+    )
+
+    t.assert_equals(
+        app.parse(split('true false --flag false'), schema),
+        { type = 'true', flag = false, path = 'false' }
+    )
+    t.assert_equals(
+        app.parse(split('true --flag false false'), schema),
+        { type = 'true', flag = false, path = 'false' }
+    )
+    t.assert_equals(
+        app.parse(split('--flag false true false'), schema),
+        { type = 'true', flag = false, path = 'false' }
+    )
+end
+
+
+g.test_schema_with_two_flags = function()
+    local schema = {
+        opts = {
+            name = 'string',
+            flag1 = 'boolean',
+            flag2 = 'boolean',
+        },
+        args = {
+            'type',
+            'path',
+        }
+    }
+
+    t.assert_equals(app.parse(split('--flag1'), schema), { flag1 = true })
+    t.assert_equals(app.parse(split('--flag1 --flag2'), schema), { flag1 = true, flag2 = true })
+    t.assert_equals(app.parse(split('--flag1 false --flag2'), schema), { flag1 = false, flag2 = true })
+    t.assert_equals(app.parse(split('--flag1 --flag2 false'), schema), { flag1 = true, flag2 = false })
+
+    t.assert_equals(
+        app.parse(split('TYPE --name NAME --flag1 --flag2'), schema),
+        { type = 'TYPE', name = 'NAME', flag1 = true, flag2 = true }
+    )
+    t.assert_equals(
+        app.parse(split('TYPE --flag1 --name NAME --flag2'), schema),
+        { type = 'TYPE', name = 'NAME', flag1 = true, flag2 = true }
+    )
+    t.assert_equals(
+        app.parse(split('TYPE --flag1 --flag2 --name NAME'), schema),
+        { type = 'TYPE', name = 'NAME', flag1 = true, flag2 = true }
+    )
+    t.assert_equals(
+        app.parse(split('--flag1 TYPE --flag2 --name NAME'), schema),
+        { type = 'TYPE', name = 'NAME', flag1 = true, flag2 = true }
+    )
+    t.assert_equals(
+        app.parse(split('--flag1 --flag2 TYPE --name NAME'), schema),
+        { type = 'TYPE', name = 'NAME', flag1 = true, flag2 = true }
+    )
+
+    local res, err = app.parse(split('--flag1 --flag1'), schema)
+    t.assert_equals(res, nil)
+    t.assert_str_icontains(err, 'option flag1 passed more than one time')
+end

--- a/test/unit/parse_command_args.lua
+++ b/test/unit/parse_command_args.lua
@@ -197,3 +197,31 @@ g.test_schema_with_two_flags = function()
     t.assert_equals(res, nil)
     t.assert_str_icontains(err, 'option flag1 passed more than one time')
 end
+
+g.test_prettifyed_opts = function()
+    local res, err = app.parse({}, { opts = { ['long-option'] = 'string' } })
+    t.assert_equals(res, nil)
+    t.assert_str_icontains (err, 'option name can not contain "-" symbol')
+
+    local schema = {
+        opts = {
+            long_option = 'string',
+        },
+    }
+
+    t.assert_equals(
+        app.parse(split('--long-option VALUE'), schema),
+        { long_option = 'VALUE' }
+    )
+    t.assert_equals(
+        app.parse(split('--long_option VALUE'), schema),
+        { long_option = 'VALUE' }
+    )
+
+    local res, err = app.parse(
+        split('--long_option VALUE --long-option VALUE'),
+        schema
+    )
+    t.assert_equals(res, nil)
+    t.assert_str_icontains (err, 'option long-option passed more than one time')
+end


### PR DESCRIPTION
This PR solves next problem: if you want to pass some boolean option (e.g. `daemonize`) to `cartridge` CLI, you should do it this way:

```bash
cartridge start --run_dir ${RUN_DIR} --daemonize  # OK
cartridge start --daemonize --run_dir ${RUN_DIR}  # FAIL
```

The second command (with boolean option passed not at the end of input) will fail because internal `argparse` module that is used in `cartridge-cli` doesn't support this feature.

Now, there is internal `argparse` wrapper that rearranges boolean options to be parsed correctly.

Moreover, is supports arguments schema, that allows to parse positional args as well as options.

```lua
parse_command_args('--name NAME --debug TYPE PATH', {
    opts = {
        name = 'string',
        debug = 'boolean',
    },
    args = {
        'type',
        'path',
    }
})
-- wil return
{
    name = 'NAME',
    debug = true,
    type = 'TYPE',
    path = 'PATH',
}
```

It also allows to use `--long-option` as well as `--long_option`. In both cases this is the `long_option`. 