### PR TITLE
Add --build-from option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Packing in docker. Added a new option `--use-docker` for `cartridge pack` command.
   This option allows to build application in docker image.
 
+- Option `--build-from` to specify build image base layers.
+
 ### Changed
 
 - Improved arguments parsing:

--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -3308,7 +3308,7 @@ function cmd_pack.callback(args)
         end
 
         app_state.build_base_dockerfile_layers = get_dockerfile_base_layers(
-            args.build_base, DEFAULT_BUILD_BASE_DOCKERFILE_LAYERS
+            args.build_from, DEFAULT_BUILD_BASE_DOCKERFILE_LAYERS
         )
     end
 
@@ -3395,7 +3395,7 @@ function cmd_pack.parse(cmd_args)
             download_token = 'string',
             tag = 'string',
             from = 'string',
-            build_base = 'string',
+            build_from = 'string',
             use_docker = 'boolean',
         }
     }
@@ -3432,23 +3432,23 @@ function cmd_pack.parse(cmd_args)
         end
     end
 
-    if args.build_base == nil then
+    if args.build_from == nil then
         local default_build_base_dockerfile_path = fio.pathjoin(
             args.path,
             DEFAULT_BUILD_BASE_DOCKERFILE_NAME
         )
         if fio.path.exists(default_build_base_dockerfile_path) then
-            args.build_base = default_build_base_dockerfile_path
+            args.build_from = default_build_base_dockerfile_path
         end
     end
 
     if args.from == nil then
-        local default_from_dockerfile_path = fio.pathjoin(
+        local default_runtime_base_dockerfile_path = fio.pathjoin(
             args.path,
             DEFAULT_RUNTIME_BASE_DOCKERFILE_NAME
         )
-        if fio.path.exists(default_from_dockerfile_path) then
-            args.from = default_from_dockerfile_path
+        if fio.path.exists(default_runtime_base_dockerfile_path) then
+            args.from = default_runtime_base_dockerfile_path
         end
     end
 

--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -1744,9 +1744,10 @@ local function construct_build_image_dockerfile()
     --            and creating tarantool user and directories
     -- - install_tarantool: install Tarantool on image
 
-    if app_state.build_base_dockerfile_layers == nil then
-        return nil, 'Build base dockerfile should be set'
-    end
+    assert(
+        app_state.build_base_dockerfile_layers ~= nil,
+        'Build base dockerfile layers should be set'
+    )
 
     local instal_tarantool_part, err = construct_install_tarantool_dockerfile_part()
     if instal_tarantool_part == nil then
@@ -1775,9 +1776,10 @@ local function construct_runtime_image_dockerfile()
     -- - set_path: set PATH for Tarantool Enterprise
     -- - runtime: tmpfiles configuration, CMS and USER directives
 
-    if app_state.runtime_base_dockerfile_layers == nil then
-        return nil, 'Runtime base dockerfile should be set'
-    end
+    assert(
+        app_state.runtime_base_dockerfile_layers ~= nil,
+        'Runtime base dockerfile layers should be set'
+    )
 
     -- Dockerfile parts
     local dockerfile_parts = {

--- a/templates/cartridge/Dockerfile.build.cartridge
+++ b/templates/cartridge/Dockerfile.build.cartridge
@@ -1,0 +1,14 @@
+# Simple Dockerfile
+# Used by `pack` command as a base for build image
+# when --use-dcoker option is specified
+
+# The base image must be centos:8
+FROM centos:8
+
+# Here you can install some packages required
+#   for your application build
+
+# RUN set -x \
+#    && curl -sL https://rpm.nodesource.com/setup_8.x | bash - \
+#    && yum -y install nodejs
+

--- a/templates/cartridge/Dockerfile.build.cartridge
+++ b/templates/cartridge/Dockerfile.build.cartridge
@@ -9,6 +9,5 @@ FROM centos:8
 #   for your application build
 
 # RUN set -x \
-#    && curl -sL https://rpm.nodesource.com/setup_8.x | bash - \
+#    && curl -sL https://rpm.nodesource.com/setup_10.x | bash - \
 #    && yum -y install nodejs
-

--- a/templates/cartridge/Dockerfile.cartridge
+++ b/templates/cartridge/Dockerfile.cartridge
@@ -1,10 +1,11 @@
 # Simple Dockerfile
-# Used by `pack docker` command as a base image
+# Used by `pack docker` command as a base for runtime image
 
 # The base image must be centos:8
 FROM centos:8
 
-# Here you can install some packages required for your application
+# Here you can install some packages required
+#   for your application in runtime
 #
 # For example, if you need to install some python packages,
 #   you can do it this way:

--- a/test/python/test_docker_pack.py
+++ b/test/python/test_docker_pack.py
@@ -201,7 +201,7 @@ def test_invalid_base_runtime_dockerfile(project_without_dependencies, module_tm
         os.path.join(basepath, "cartridge"),
         "pack", "docker",
         "--use-docker",
-        "--build-from", invalid_dockerfile_path,
+        "--from", invalid_dockerfile_path,
         project_without_dependencies.path,
     ]
 

--- a/test/python/test_docker_pack.py
+++ b/test/python/test_docker_pack.py
@@ -201,7 +201,7 @@ def test_invalid_base_runtime_dockerfile(project_without_dependencies, module_tm
         os.path.join(basepath, "cartridge"),
         "pack", "docker",
         "--use-docker",
-        "--build-base", invalid_dockerfile_path,
+        "--build-from", invalid_dockerfile_path,
         project_without_dependencies.path,
     ]
 

--- a/test/python/test_docker_pack.py
+++ b/test/python/test_docker_pack.py
@@ -211,6 +211,22 @@ def test_invalid_base_runtime_dockerfile(project_without_dependencies, module_tm
     assert 'base image must be centos:8' in output
 
 
+def test_project_witout_runtime_dockerfile(project_without_dependencies, tmpdir):
+    project = project_without_dependencies
+
+    os.remove(os.path.join(project.path, 'Dockerfile.cartridge'))
+
+    cmd = [
+        os.path.join(basepath, "cartridge"),
+        "pack", "docker",
+        "--use-docker",
+        project.path,
+    ]
+
+    process = subprocess.run(cmd, cwd=tmpdir)
+    assert process.returncode == 0
+
+
 def test_e2e(docker_image, tmpdir, docker_client):
     image_name = docker_image.name
     project = docker_image.project

--- a/test/python/test_pack.py
+++ b/test/python/test_pack.py
@@ -491,7 +491,7 @@ def test_invalid_base_build_dockerfile(project_without_dependencies, module_tmpd
         os.path.join(basepath, "cartridge"),
         "pack", pack_format,
         "--use-docker",
-        "--build-base", invalid_dockerfile_path,
+        "--build-from", invalid_dockerfile_path,
         project_without_dependencies.path,
     ]
 
@@ -523,7 +523,7 @@ def test_base_build_dockerfile_with_env_vars(project_without_dependencies, modul
         os.path.join(basepath, "cartridge"),
         "pack", pack_format,
         "--use-docker",
-        "--build-base", dockerfile_with_env_path,
+        "--build-from", dockerfile_with_env_path,
         project_without_dependencies.path,
     ]
     rc, output = run_command_and_get_output(cmd, cwd=module_tmpdir)

--- a/test/unit/dockerfile_constructors.lua
+++ b/test/unit/dockerfile_constructors.lua
@@ -182,9 +182,9 @@ g.test_build_image_dockerfile_constructor = function()
     _G.app_state.sdk_version = nil
     _G.app_state.tarantool_version = '2.1.42'
     _G.app_state.build_base_dockerfile_layers = nil
-    local res, err = constructor()
-    t.assert_equals(res, nil)
-    t.assert_str_icontains(err, 'build base dockerfile should be set')
+    local ok, err = pcall(constructor)
+    t.assert_equals(ok, false)
+    t.assert_str_icontains(err, 'build base dockerfile layers should be set')
 end
 
 g.test_runtime_image_dockerfile_constructor = function()
@@ -236,7 +236,7 @@ g.test_runtime_image_dockerfile_constructor = function()
     _G.app_state.sdk_version = nil
     _G.app_state.tarantool_version = '2.1.42'
     _G.app_state.runtime_base_dockerfile_layers = nil
-    local res, err = constructor()
-    t.assert_equals(res, nil)
-    t.assert_str_icontains(err, 'runtime base dockerfile should be set')
+    local ok, err = pcall(constructor)
+    t.assert_equals(ok, false)
+    t.assert_str_icontains(err, 'runtime base dockerfile layers should be set')
 end

--- a/test/unit/dockerfile_constructors.lua
+++ b/test/unit/dockerfile_constructors.lua
@@ -144,7 +144,7 @@ g.test_build_image_dockerfile_constructor = function()
     local constructor = app.dockerfile_constructors.build
     local sdk_version = 'SDK_VERSION'
 
-    local dockerfile_base_layers = remove_leading_spaces([=[
+    local build_base_dockerfile_layers = remove_leading_spaces([=[
         ### Base layers
         FROM centos:8
         RUN yum install -y zip
@@ -153,10 +153,10 @@ g.test_build_image_dockerfile_constructor = function()
     -- Tarantool Enterprise
     _G.app_state.tarantool_is_enterprise = true
     _G.app_state.sdk_version = sdk_version
-    _G.app_state.dockerfile_base_layers = dockerfile_base_layers
+    _G.app_state.build_base_dockerfile_layers = build_base_dockerfile_layers
 
     local expected_dockerfile = table.concat({
-        dockerfile_base_layers,
+        build_base_dockerfile_layers,
         get_prepare_layers(),
         get_install_tarantool_enterprise_layers(sdk_version)
     }, '\n')
@@ -167,15 +167,24 @@ g.test_build_image_dockerfile_constructor = function()
     _G.app_state.tarantool_is_enterprise = false
     _G.app_state.sdk_version = nil
     _G.app_state.tarantool_version = '2.1.42'
-    _G.app_state.dockerfile_base_layers = dockerfile_base_layers
+    _G.app_state.build_base_dockerfile_layers = build_base_dockerfile_layers
 
     local expected_dockerfile = table.concat({
-        dockerfile_base_layers,
+        build_base_dockerfile_layers,
         get_prepare_layers(),
         get_install_tarantool_opensource_layers('2x')
     }, '\n')
 
     assert_lines_are_equal(constructor(), expected_dockerfile)
+
+    -- app_state.build_base_dockerfile_layers is required
+    _G.app_state.tarantool_is_enterprise = false
+    _G.app_state.sdk_version = nil
+    _G.app_state.tarantool_version = '2.1.42'
+    _G.app_state.build_base_dockerfile_layers = nil
+    local res, err = constructor()
+    t.assert_equals(res, nil)
+    t.assert_str_icontains(err, 'build base dockerfile should be set')
 end
 
 g.test_runtime_image_dockerfile_constructor = function()
@@ -183,20 +192,20 @@ g.test_runtime_image_dockerfile_constructor = function()
     local sdk_version = 'SDK_VERSION'
     local app_name = 'myapp'
 
-    local dockerfile_base_layers = remove_leading_spaces([=[
+    local runtime_base_dockerfile_layers = remove_leading_spaces([=[
         ### Base layers
         FROM centos:8
-        RUN yum install -y zip
+        RUN yum install -y unzip
     ]=])
 
     -- Tarantool Enterprise
     _G.app_state.name = app_name
     _G.app_state.tarantool_is_enterprise = true
     _G.app_state.sdk_version = sdk_version
-    _G.app_state.dockerfile_base_layers = dockerfile_base_layers
+    _G.app_state.runtime_base_dockerfile_layers = runtime_base_dockerfile_layers
 
     local expected_dockerfile = table.concat({
-        dockerfile_base_layers,
+        runtime_base_dockerfile_layers,
         get_prepare_layers(),
         get_copy_code_layers(app_name),
         get_dockerfile_set_path_layers(app_name),
@@ -210,10 +219,10 @@ g.test_runtime_image_dockerfile_constructor = function()
     _G.app_state.tarantool_is_enterprise = false
     _G.app_state.sdk_version = nil
     _G.app_state.tarantool_version = '2.1.42'
-    _G.app_state.dockerfile_base_layers = dockerfile_base_layers
+    _G.app_state.runtime_base_dockerfile_layers = runtime_base_dockerfile_layers
 
     local expected_dockerfile = table.concat({
-        dockerfile_base_layers,
+        runtime_base_dockerfile_layers,
         get_prepare_layers(),
         get_install_tarantool_opensource_layers('2x'),
         get_copy_code_layers(app_name),
@@ -221,4 +230,13 @@ g.test_runtime_image_dockerfile_constructor = function()
     }, '\n')
 
     assert_lines_are_equal(constructor(), expected_dockerfile)
+
+    -- app_state.runtime_base_dockerfile_layers is required
+    _G.app_state.tarantool_is_enterprise = false
+    _G.app_state.sdk_version = nil
+    _G.app_state.tarantool_version = '2.1.42'
+    _G.app_state.runtime_base_dockerfile_layers = nil
+    local res, err = constructor()
+    t.assert_equals(res, nil)
+    t.assert_str_icontains(err, 'runtime base dockerfile should be set')
 end


### PR DESCRIPTION
Use --build-from option to specify build image base layers on building in
docker
Use --from option to specify runtime imgae base layers on packing to
docker
Tests

See [coment](https://github.com/tarantool/cartridge-cli/issues/98#issuecomment-584737756) for details.