### PR TITLE
Fix template package.path priority

### DIFF
--- a/templates/cartridge/init.lua
+++ b/templates/cartridge/init.lua
@@ -16,14 +16,14 @@ else
     local fio = require('fio')
     local app_dir = fio.abspath(fio.dirname(arg[0]))
     print('App dir set to ' .. app_dir)
-    package.path = package.path .. ';' .. app_dir .. '/?.lua'
-    package.path = package.path .. ';' .. app_dir .. '/?/init.lua'
-    package.path = package.path .. ';' .. app_dir .. '/.rocks/share/tarantool/?.lua'
-    package.path = package.path .. ';' .. app_dir .. '/.rocks/share/tarantool/?/init.lua'
-    package.cpath = package.cpath .. ';' .. app_dir .. '/?.so'
-    package.cpath = package.cpath .. ';' .. app_dir .. '/?.dylib'
-    package.cpath = package.cpath .. ';' .. app_dir .. '/.rocks/lib/tarantool/?.so'
-    package.cpath = package.cpath .. ';' .. app_dir .. '/.rocks/lib/tarantool/?.dylib'
+    package.path = app_dir .. '/?.lua;' .. package.path
+    package.path = app_dir .. '/?/init.lua;' .. package.path
+    package.path = app_dir .. '/.rocks/share/tarantool/?.lua;' .. package.path
+    package.path = app_dir .. '/.rocks/share/tarantool/?/init.lua;' .. package.path
+    package.cpath = app_dir .. '/?.so;' .. package.cpath
+    package.cpath = app_dir .. '/?.dylib;' .. package.cpath
+    package.cpath = app_dir .. '/.rocks/lib/tarantool/?.so;' .. package.cpath
+    package.cpath = app_dir .. '/.rocks/lib/tarantool/?.dylib;' .. package.cpath
 end
 
 local cartridge = require('cartridge')


### PR DESCRIPTION
To avoid clashing with system-wide installed packages, app_dir
should be the first in package.path list.