### PR TITLE
Place Dockerfile in build context

### DIFF
--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -3072,11 +3072,6 @@ local function pack_docker(opts)
 
     info('Result image tagged as: %s', image_fullname)
 
-    local ok, err = remove_by_path(runtime_dockerfile_path)
-    if not ok then
-        warn('Failed to remove runtime image Dockerfile %s: %s', runtime_dockerfile_name, err)
-    end
-
     return true
 end
 

--- a/test/python/test_pack_docker.py
+++ b/test/python/test_pack_docker.py
@@ -78,7 +78,10 @@ def test_pack(docker_image, tmpdir, docker_client):
 
     distribution_dir_contents = recursive_listdir(os.path.join(tmpdir, 'usr/share/tarantool/', project.name))
 
-    # add runtime Dockerfile to project distribution files
+    # The runtime image is built using Dockerfile.<random-string> in the
+    #   distribution directory
+    # This dockerfile name should be added to project distribution files set
+    #   to correctly check distribution directory contents
     for f in distribution_dir_contents:
         if f.startswith('Dockerfile') and f not in ['Dockerfile.build.cartridge', 'Dockerfile.cartridge']:
             project.distribution_files.add(f)

--- a/test/python/test_pack_docker.py
+++ b/test/python/test_pack_docker.py
@@ -76,6 +76,14 @@ def test_pack(docker_image, tmpdir, docker_client):
         arch.extractall(path=os.path.join(tmpdir, 'usr/share/tarantool'))
     os.remove(arhive_path)
 
+    distribution_dir_contents = recursive_listdir(os.path.join(tmpdir, 'usr/share/tarantool/', project.name))
+
+    # add runtime Dockerfile to project distribution files
+    for f in distribution_dir_contents:
+        if f.startswith('Dockerfile') and f not in ['Dockerfile.build.cartridge', 'Dockerfile.cartridge']:
+            project.distribution_files.add(f)
+            break
+
     assert_distribution_dir_contents(
         dir_contents=recursive_listdir(os.path.join(tmpdir, 'usr/share/tarantool/', project.name)),
         project=project,


### PR DESCRIPTION
The Dockerfile path must be to a file within the build context.
See the [doc](https://docs.docker.com/engine/reference/commandline/build/#text-files).

`cartridge-cli` used  dockerfiles placed in the tmpdir, so building in docker didn't work on some versions of `docker`.