### PR TITLE
Use git-core instead of git in base image

### DIFF
--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -1287,7 +1287,7 @@ local DOCKERFILE_PREPARE = [[
 ### Prepare
 SHELL ["/bin/bash", "-c"]
 
-RUN yum install -y git gcc make cmake unzip
+RUN yum install -y git-core gcc make cmake unzip
 
 # create user and directories
 RUN groupadd -r tarantool \


### PR DESCRIPTION
* base image size: 573MB(git) -> 510MB(git-core)
* download size:    73 M(git)     -> 56 M(git-core)
* installed size:     222 M(git)   -> 69 M(git-core)
