### PR TITLE
Fix prebuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:8
+FROM centos:7
 
 RUN yum -y update
 RUN yum install -y git gcc make cmake unzip python3-pip


### PR DESCRIPTION
Use centos:7 as a base image instead of centos:8 for building Gitlab CI
image