### PR TITLE
Make RPM and DEB packages less platform-dependent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Packing in docker. Added a new option `--use-docker` for `cartridge pack` command.
   This option allows to build application in docker image.
+- Add `TARANTOOL_DIR` to rockspec build.variables.
+
+### Changed
+
+- RPM and DEB scripts (pre- and post- install, ExecStartPre in systemd
+units) to be platform independent.
+
+## [1.4.2] - 2020-03-13
+
+### Added
 
 - Option `--build-from` to specify build image base layers.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Installation
 
-### RPM package (CentOS, Fedora)
+### RPM package (CentOS, Fedora, ALT Linux)
 
 ```
 # Select a Tarantool version (copy one of these lines):

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,20 +8,28 @@
 Vagrant.configure("2") do |config|
   config.vm.define "centos" do |cfg|
     cfg.vm.box = "centos/7"
-    cfg.vm.provision "shell", inline: <<-SHELL
-      curl -s https://packagecloud.io/install/repositories/tarantool/1_10/script.rpm.sh | bash
-      curl -sL https://rpm.nodesource.com/setup_8.x | bash -
-      yum -y install unzip git gcc cmake nodejs tarantool tarantool-devel
-    SHELL
+    cfg.vm.synced_folder '.', '/vagrant', disabled: true
+    # cfg.vm.provision "shell", inline: <<-SHELL
+    #   curl -s https://packagecloud.io/install/repositories/tarantool/1_10/script.rpm.sh | bash
+    #   curl -sL https://rpm.nodesource.com/setup_8.x | bash -
+    #   yum -y install unzip git gcc cmake nodejs tarantool tarantool-devel
+    # SHELL
   end
 
   config.vm.define "ubuntu" do |cfg|
     cfg.vm.box = "ubuntu/xenial64"
-    cfg.vm.provision "shell", inline: <<-SHELL
-      curl -s https://packagecloud.io/install/repositories/tarantool/1_10/script.deb.sh | bash
-      sudo apt-get -y update
-      sudo apt-get -y install unzip git gcc cmake nodejs tarantool
-      sudo rm /lib/systemd/system/tarantool@.service
-    SHELL
+    cfg.vm.synced_folder '.', '/vagrant', disabled: true
+    # cfg.vm.provision "shell", inline: <<-SHELL
+    #   curl -s https://packagecloud.io/install/repositories/tarantool/1_10/script.deb.sh | bash
+    #   sudo apt-get -y update
+    #   sudo apt-get -y install unzip git gcc cmake nodejs tarantool
+    #   sudo rm /lib/systemd/system/tarantool@.service
+    # SHELL
+  end
+
+  config.vm.define "alt" do |cfg|
+    cfg.vm.box = "vpavel/vstand-altlinux-p8"
+    cfg.vm.box_version = "0.1"
+    cfg.vm.synced_folder '.', '/vagrant', disabled: true
   end
 end

--- a/test/e2e/cleanup.sh
+++ b/test/e2e/cleanup.sh
@@ -3,12 +3,15 @@
 exec 2>&1
 set -x -e
 
-sudo systemctl stop myapp@instance_1
-sudo systemctl stop myapp@instance_2
+APPNAME=${APPNAME:-myapp}
+
+sudo systemctl stop ${APPNAME}@instance_1 || true
+sudo systemctl stop ${APPNAME}@instance_2 || true
 
 sudo systemctl daemon-reload
 
-sudo yum remove -y myapp || true
-sudo dpkg --remove myapp || true
+sudo yum remove -y ${APPNAME} || true
+sudo dpkg --remove ${APPNAME} || true
+sudo apt-get remove ${APPNAME} || true
 
 rm -rf /tmp/e2e

--- a/test/e2e/start-rpm.sh
+++ b/test/e2e/start-rpm.sh
@@ -3,37 +3,32 @@
 exec 2>&1
 set -x -e
 
-git config --global user.email "you@example.com"
-git config --global user.name "Your Name"
 
-pushd $(mktemp -d)
+APPNAME=${APPNAME:-myapp}
+VERSION=${VERSION:-1.2.3-4}
 
-tarantoolctl rocks make cartridge-cli-scm-1.rockspec --chdir=/vagrant
-.rocks/bin/cartridge create --name myapp
+RPM_PATH=/tmp/${APPNAME}-${VERSION}.rpm
 
-sudo yum -y remove myapp || true
-sudo rm -rf /etc/tarantool/conf.d || true
-sudo chmod +x /var/lib/tarantool/ || true
-sudo rm -rf /var/lib/tarantool/myapp.instance_{1,2} || true
-
-.rocks/bin/cartridge pack rpm myapp
-[ -f ./myapp-*.rpm ] && sudo yum -y install ./myapp-*.rpm
+[ -f ${RPM_PATH} ] && (sudo yum -y install ${RPM_PATH} || sudo apt-get install ${RPM_PATH})
 [ -d /etc/tarantool/conf.d/ ]
-sudo tee /etc/tarantool/conf.d/myapp.yml > /dev/null <<'CONFIG'
+sudo tee /etc/tarantool/conf.d/${APPNAME}.yml > /dev/null <<'CONFIG'
 myapp.instance_1:
     alias: i1
+    advertise_uri: localhost:3301
 myapp.instance_2:
     alias: i2
+    advertise_uri: localhost:3302
 CONFIG
 
 sudo systemctl daemon-reload
 
-sudo systemctl start myapp@instance_1
-sudo systemctl enable myapp@instance_1
+sudo systemctl start ${APPNAME}@instance_1
+sudo systemctl enable ${APPNAME}@instance_1
 
-sudo systemctl start myapp@instance_2
-sudo systemctl enable myapp@instance_2
+sudo systemctl start ${APPNAME}@instance_2
+sudo systemctl enable ${APPNAME}@instance_2
 
 sleep 1
 
-popd
+sudo systemctl status ${APPNAME}@instance_1
+sudo systemctl status ${APPNAME}@instance_2


### PR DESCRIPTION
RPM and DEB packages use special scripts  (pre- and post-install for package itself, 
ExecStartPre for systemd services). It requires using absolute paths for commands
like `mkdir`, `chown`, etc. As a result, package becomes platform-dependent (different
paths for binaries). This patch calls `/bin/sh` in scripts explicitly to trigger PATH lookup.
It allows to write `/bin/sh -c 'mkdir -p /my/dir'` without `mkdir` absolute path.

