### PR TITLE
It adds SOURCERPM tag

### DIFF
--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -1832,6 +1832,7 @@ local HEADER_TAG_TABLE = {
     SIZE = 1009,
     OS = 1021,
     ARCH = 1022,
+    SOURCERPM = 1044,
     PAYLOADFORMAT = 1124,
     LICENSE = 1014,
     GROUP = 1016,
@@ -2265,6 +2266,7 @@ local function pack_rpm(opts)
         {'GROUP', 'STRING', 'None'},
         {'OS', 'STRING', 'linux'},
         {'ARCH', 'STRING', 'x86_64'},
+        {'SOURCERPM', 'STRING', ''}
         {'PAYLOADCOMPRESSOR', 'STRING', 'gzip'},
         {'PAYLOADFLAGS', 'STRING', '5'},
         {'PREIN', 'STRING', create_user_script_rpm},

--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -2266,7 +2266,7 @@ local function pack_rpm(opts)
         {'GROUP', 'STRING', 'None'},
         {'OS', 'STRING', 'linux'},
         {'ARCH', 'STRING', 'x86_64'},
-        {'SOURCERPM', 'STRING', ''}
+        {'SOURCERPM', 'STRING', ''},
         {'PAYLOADCOMPRESSOR', 'STRING', 'gzip'},
         {'PAYLOADFLAGS', 'STRING', '5'},
         {'PREIN', 'STRING', create_user_script_rpm},


### PR DESCRIPTION
Would you be so kind to add some additional RPM tags to align RPMs packages produced by cartridge-cli with the native builded RPMs. This will prevent errors in rpm processing of third party software like mc, genpkglist (altlinux repo tools) etc. Packages builded with the native rpmbuild are not causing this kind of errors 
Why don't you use rpmbuild for rpm packages building? For example it strips debuginfo symbols from ELF files you are not stipping, it can use xz or gzip for different size files you can't.
Missing SOURCERPM tag causes non error exit code of genpkglist so it is not possible to create the repository with packages builded by cartridge-cli.
Bear in mind that missing of some tags in rpm spec file causes non error exit code of rpmbuild. You can use rpmlint to check produced rpm.
And please add the BuildArch for the package name. 