### PR TITLE
Deliver app stateboard in RPM/DEB

### DIFF
--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -709,8 +709,6 @@ Environment=TARANTOOL_CONSOLE_SOCK=/var/run/tarantool/${stateboard_name}.control
 LimitCORE=infinity
 # Disable OOM killer
 OOMScoreAdjust=-1000
-# Increase fd limit for Vinyl
-LimitNOFILE=65535
 
 # Systemd waits until all xlogs are recovered
 TimeoutStartSec=86400s

--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -613,9 +613,9 @@ local SET_OWNER_SCRIPT = [[
 
 -- * ---------------- Systemd ----------------
 
-local SYSTEMD_UNIT_FILE = [[
+local SYSTEMD_APP_UNIT_FILE = [[
 [Unit]
-Description=Tarantool Cartridge app ${name}.default
+Description=Tarantool Cartridge app ${app_name}.default
 After=network.target
 
 [Service]
@@ -627,10 +627,11 @@ RestartSec=2
 User=tarantool
 Group=tarantool
 
+Environment=TARANTOOL_APP_NAME=${app_name}
 Environment=TARANTOOL_WORKDIR=${workdir}.default
 Environment=TARANTOOL_CFG=/etc/tarantool/conf.d/
-Environment=TARANTOOL_PID_FILE=/var/run/tarantool/${name}.default.pid
-Environment=TARANTOOL_CONSOLE_SOCK=/var/run/tarantool/${name}.default.control
+Environment=TARANTOOL_PID_FILE=/var/run/tarantool/${app_name}.default.pid
+Environment=TARANTOOL_CONSOLE_SOCK=/var/run/tarantool/${app_name}.default.control
 
 LimitCORE=infinity
 # Disable OOM killer
@@ -645,12 +646,12 @@ TimeoutStopSec=10s
 
 [Install]
 WantedBy=multi-user.target
-Alias=${name}
+Alias=${app_name}
 ]]
 
-local SYSTEMD_INSTANTIATED_UNIT_FILE = [[
+local SYSTEMD_APP_INSTANTIATED_UNIT_FILE = [[
 [Unit]
-Description=Tarantool Cartridge app ${name}@%i
+Description=Tarantool Cartridge app ${app_name}@%i
 After=network.target
 
 [Service]
@@ -662,10 +663,11 @@ RestartSec=2
 User=tarantool
 Group=tarantool
 
+Environment=TARANTOOL_APP_NAME=${app_name}
 Environment=TARANTOOL_WORKDIR=${workdir}.%i
 Environment=TARANTOOL_CFG=/etc/tarantool/conf.d/
-Environment=TARANTOOL_PID_FILE=/var/run/tarantool/${name}.%i.pid
-Environment=TARANTOOL_CONSOLE_SOCK=/var/run/tarantool/${name}.%i.control
+Environment=TARANTOOL_PID_FILE=/var/run/tarantool/${app_name}.%i.pid
+Environment=TARANTOOL_CONSOLE_SOCK=/var/run/tarantool/${app_name}.%i.control
 Environment=TARANTOOL_INSTANCE_NAME=%i
 
 LimitCORE=infinity
@@ -681,7 +683,43 @@ TimeoutStopSec=10s
 
 [Install]
 WantedBy=multi-user.target
-Alias=${name}.%i
+Alias=${app_name}.%i
+]]
+
+local SYSTEMD_STATEBOARD_UNIT_FILE = [[
+[Unit]
+Description=Tarantool Cartridge stateboard for ${app_name}
+After=network.target
+
+[Service]
+Type=simple
+ExecStartPre=/bin/sh -c 'mkdir -p ${stateboard_workdir}'
+ExecStart=${bindir}/tarantool ${dir}/stateboard.init.lua
+Restart=on-failure
+RestartSec=2
+User=tarantool
+Group=tarantool
+
+Environment=TARANTOOL_APP_NAME=${stateboard_name}
+Environment=TARANTOOL_WORKDIR=${stateboard_workdir}
+Environment=TARANTOOL_CFG=/etc/tarantool/conf.d/
+Environment=TARANTOOL_PID_FILE=/var/run/tarantool/${stateboard_name}.pid
+Environment=TARANTOOL_CONSOLE_SOCK=/var/run/tarantool/${stateboard_name}.control
+
+LimitCORE=infinity
+# Disable OOM killer
+OOMScoreAdjust=-1000
+# Increase fd limit for Vinyl
+LimitNOFILE=65535
+
+# Systemd waits until all xlogs are recovered
+TimeoutStartSec=86400s
+# Give a reasonable amount of time to close xlogs
+TimeoutStopSec=10s
+
+[Install]
+WantedBy=multi-user.target
+Alias=${stateboard_name}
 ]]
 
 -- * --------------------- Debian --------------------
@@ -1587,15 +1625,9 @@ local function form_systemd_dir(base_dir, opts)
     opts = opts or {}
     info('Form application systemd dir')
 
-    local unit_template = opts.unit_template or SYSTEMD_UNIT_FILE
-    local instantiated_unit_template = opts.instantiated_unit_template or SYSTEMD_INSTANTIATED_UNIT_FILE
-
-    local systemd_dir = fio.pathjoin(base_dir, '/etc/systemd/system')
-    local ok, err = utils.make_tree(systemd_dir)
-    if not ok then return false, err end
-
+    -- Common params
     local expand_params = {
-        name = app_state.name,
+        app_name = app_state.name,
         dir = fio.pathjoin('/usr/share/tarantool/', app_state.name),
         workdir = fio.pathjoin('/var/lib/tarantool/', app_state.name),
     }
@@ -1606,17 +1638,39 @@ local function form_systemd_dir(base_dir, opts)
         expand_params.bindir = '/usr/bin'
     end
 
+    -- Application unit files
+    local unit_template = opts.unit_template or SYSTEMD_APP_UNIT_FILE
+    local instantiated_unit_template = opts.instantiated_unit_template or SYSTEMD_APP_INSTANTIATED_UNIT_FILE
+
+    local systemd_dir = fio.pathjoin(base_dir, '/etc/systemd/system')
+    local ok, err = utils.make_tree(systemd_dir)
+    if not ok then return false, err end
+
+    -- default unit template
     local unit_template_filepath = fio.pathjoin(systemd_dir, string.format('%s.service', app_state.name))
-    local instantiated_unit_template_filepath = fio.pathjoin(systemd_dir, string.format('%s@.service', app_state.name))
     local ok, err = utils.write_file(
         unit_template_filepath,
         utils.expand(unit_template, expand_params)
     )
     if not ok then return false, err end
 
+    -- instantiated unit template
+    local instantiated_unit_template_filepath = fio.pathjoin(systemd_dir, string.format('%s@.service', app_state.name))
     local ok, err = utils.write_file(
         instantiated_unit_template_filepath,
         utils.expand(instantiated_unit_template, expand_params)
+    )
+    if not ok then return false, err end
+
+    -- Stateboard unit file
+    local stateboard_name = string.format('%s-stateboard', app_state.name)
+    expand_params.stateboard_name = stateboard_name
+    expand_params.stateboard_workdir = fio.pathjoin('/var/lib/tarantool/', stateboard_name)
+
+    local stateboard_unit_filepath = fio.pathjoin(systemd_dir, string.format('%s.service', stateboard_name))
+    local ok, err = utils.write_file(
+        stateboard_unit_filepath,
+        utils.expand(SYSTEMD_STATEBOARD_UNIT_FILE, expand_params)
     )
     if not ok then return false, err end
 

--- a/cartridge-cli.lua
+++ b/cartridge-cli.lua
@@ -621,7 +621,7 @@ After=network.target
 [Service]
 Type=simple
 ExecStartPre=/bin/sh -c 'mkdir -p ${workdir}.default'
-ExecStart=${bindir}/tarantool ${dir}/init.lua
+ExecStart=${bindir}/tarantool ${app_dir}/init.lua
 Restart=on-failure
 RestartSec=2
 User=tarantool
@@ -657,7 +657,7 @@ After=network.target
 [Service]
 Type=simple
 ExecStartPre=/bin/sh -c 'mkdir -p ${workdir}.%i'
-ExecStart=${bindir}/tarantool ${dir}/init.lua
+ExecStart=${bindir}/tarantool ${app_dir}/init.lua
 Restart=on-failure
 RestartSec=2
 User=tarantool
@@ -694,7 +694,7 @@ After=network.target
 [Service]
 Type=simple
 ExecStartPre=/bin/sh -c 'mkdir -p ${stateboard_workdir}'
-ExecStart=${bindir}/tarantool ${dir}/stateboard.init.lua
+ExecStart=${bindir}/tarantool ${app_dir}/stateboard.init.lua
 Restart=on-failure
 RestartSec=2
 User=tarantool
@@ -830,7 +830,7 @@ USER tarantool:tarantool
 CMD TARANTOOL_WORKDIR=${workdir}.${instance_name} \
     TARANTOOL_PID_FILE=/var/run/tarantool/${name}.${instance_name}.pid \
     TARANTOOL_CONSOLE_SOCK=/var/run/tarantool/${name}.${instance_name}.control \
-    tarantool ${dir}/init.lua
+    tarantool ${app_dir}/init.lua
 ]]
 
 -- * ---------- Application build commands ----------
@@ -848,7 +848,7 @@ local BUILD_IMAGE_COMMAND_TEMPLATE = [[
 
 local BUILD_APPLICATION_ON_IMAGE_COMMAND = [[
     ${docker} run \
-        --volume ${dir}:/opt/tarantool \
+        --volume ${app_dir}:/opt/tarantool \
         --rm \
         ${image_fullname} \
         /bin/bash -c '
@@ -1349,7 +1349,7 @@ local function construct_runtime_image_dockerfile()
     -- runtime layers
     local runtime_part = utils.expand(DOCKERFILE_RUNTIME_TEMPLATE, {
         name = app_state.name,
-        dir = fio.pathjoin('/usr/share/tarantool/', app_state.name),
+        app_dir = fio.pathjoin('/usr/share/tarantool/', app_state.name),
         instance_name = '${"$"}{TARANTOOL_INSTANCE_NAME:-default}',
         workdir = fio.pathjoin('/var/lib/tarantool/', app_state.name),
         tmpfiles_config = TMPFILES_CONFIG,
@@ -1447,7 +1447,7 @@ local function build_application_in_docker(dir)
     -- - Construct application build command (`docker run <base-image> <build-commands>`)
     local build_app_command_params = {
         docker = docker,
-        dir = dir,
+        app_dir = dir,
         image_fullname = app_state.base_image_fullname,
         prebuild_script_name = PREBUILD_SCRIPT_NAME,
         copy_tarantool_binaries = ':',  -- XXX: refactor it
@@ -1628,12 +1628,12 @@ local function form_systemd_dir(base_dir, opts)
     -- Common params
     local expand_params = {
         app_name = app_state.name,
-        dir = fio.pathjoin('/usr/share/tarantool/', app_state.name),
+        app_dir = fio.pathjoin('/usr/share/tarantool/', app_state.name),
         workdir = fio.pathjoin('/var/lib/tarantool/', app_state.name),
     }
 
     if app_state.tarantool_is_enterprise then
-        expand_params.bindir = expand_params.dir
+        expand_params.bindir = expand_params.app_dir
     else
         expand_params.bindir = '/usr/bin'
     end

--- a/cartridge-cli/templates/cartridge/files/app_files.lua
+++ b/cartridge-cli/templates/cartridge/files/app_files.lua
@@ -13,7 +13,7 @@ local app_files = {
                 'tarantool',
                 'lua >= 5.1',
                 'checks == 3.0.1-1',
-                'cartridge == 2.0.1-1',
+                'cartridge == scm-1',
             }
             build = {
                 type = 'none';
@@ -108,7 +108,42 @@ local app_files = {
             assert(ok, tostring(err))
 
         ]=]
-    }
+    },
+    {
+        name = 'stateboard.init.lua',
+        mode = tonumber('0755', 8),
+        content = [=[
+            #!/usr/bin/env tarantool
+
+            require('strict').on()
+
+            if package.setsearchroot ~= nil then
+                package.setsearchroot()
+            else
+                -- Workaround for rocks loading in tarantool 1.10
+                -- It can be removed in tarantool > 2.2
+                -- By default, when you do require('mymodule'), tarantool looks into
+                -- the current working directory and whatever is specified in
+                -- package.path and package.cpath. If you run your app while in the
+                -- root directory of that app, everything goes fine, but if you try to
+                -- start stateboard with "tarantool myapp/stateboard.init.lua", it will fail to load
+                -- its modules, and modules from myapp/.rocks.
+                local fio = require('fio')
+                local app_dir = fio.abspath(fio.dirname(arg[0]))
+                print('App dir set to ' .. app_dir)
+                package.path = app_dir .. '/?.lua;' .. package.path
+                package.path = app_dir .. '/?/init.lua;' .. package.path
+                package.path = app_dir .. '/.rocks/share/tarantool/?.lua;' .. package.path
+                package.path = app_dir .. '/.rocks/share/tarantool/?/init.lua;' .. package.path
+                package.cpath = app_dir .. '/?.so;' .. package.cpath
+                package.cpath = app_dir .. '/?.dylib;' .. package.cpath
+                package.cpath = app_dir .. '/.rocks/lib/tarantool/?.so;' .. package.cpath
+                package.cpath = app_dir .. '/.rocks/lib/tarantool/?.dylib;' .. package.cpath
+            end
+
+            require('cartridge.stateboard').cfg()
+        ]=]
+    },
 }
 
 return app_files

--- a/cartridge-cli/templates/cartridge/files/app_files.lua
+++ b/cartridge-cli/templates/cartridge/files/app_files.lua
@@ -13,7 +13,7 @@ local app_files = {
                 'tarantool',
                 'lua >= 5.1',
                 'checks == 3.0.1-1',
-                'cartridge == scm-1',
+                'cartridge == 2.1.0-1',
             }
             build = {
                 type = 'none';

--- a/test/python/project.py
+++ b/test/python/project.py
@@ -215,6 +215,7 @@ ignore_patterns = [
     '!*.sh',
     '!.rocks/**',
     '!init.lua',
+    '!stateboard.init.lua',
     '!app/roles/custom.lua',
     '!asterisk/',
     # for ignore

--- a/test/python/test_pack.py
+++ b/test/python/test_pack.py
@@ -96,40 +96,40 @@ def rpm_archive_with_custom_units(cartridge_cmd, tmpdir, light_project):
 
     unit_template = '''
 [Unit]
-Description=Tarantool service: ${name}
+Description=Tarantool service: ${app_name}
 SIMPLE_UNIT_TEMPLATE
 [Service]
 Type=simple
-ExecStart=${dir}/tarantool ${dir}/init.lua
+ExecStart=${bindir}/tarantool ${app_dir}/init.lua
 
 Environment=TARANTOOL_WORK_DIR=${workdir}
-Environment=TARANTOOL_CONSOLE_SOCK=/var/run/tarantool/${name}.control
-Environment=TARANTOOL_PID_FILE=/var/run/tarantool/${name}.pid
-Environment=TARANTOOL_INSTANCE_NAME=${name}
+Environment=TARANTOOL_CONSOLE_SOCK=/var/run/tarantool/${app_name}.control
+Environment=TARANTOOL_PID_FILE=/var/run/tarantool/${app_name}.pid
+Environment=TARANTOOL_INSTANCE_NAME=${app_name}
 
 [Install]
 WantedBy=multi-user.target
-Alias=${name}
+Alias=${app_name}
     '''
 
     instantiated_unit_template = '''
 [Unit]
-Description=Tarantool service: ${name} %i
+Description=Tarantool service: ${app_name} %i
 INSTANTIATED_UNIT_TEMPLATE
 
 [Service]
 Type=simple
 ExecStartPre=mkdir -p ${workdir}.%i
-ExecStart=${dir}/tarantool ${dir}/init.lua
+ExecStart=${bindir}/tarantool ${app_dir}/init.lua
 
 Environment=TARANTOOL_WORK_DIR=${workdir}.%i
-Environment=TARANTOOL_CONSOLE_SOCK=/var/run/tarantool/${name}.%i.control
-Environment=TARANTOOL_PID_FILE=/var/run/tarantool/${name}.%i.pid
-Environment=TARANTOOL_INSTANCE_NAME=${name}@%i
+Environment=TARANTOOL_CONSOLE_SOCK=/var/run/tarantool/${app_name}.%i.control
+Environment=TARANTOOL_PID_FILE=/var/run/tarantool/${app_name}.%i.pid
+Environment=TARANTOOL_INSTANCE_NAME=${app_name}@%i
 
 [Install]
 WantedBy=multi-user.target
-Alias=${name}
+Alias=${app_name}
     '''
     unit_template_filepath = os.path.join(tmpdir, "unit_template.tmpl")
     with open(unit_template_filepath, 'w') as f:

--- a/test/python/utils.py
+++ b/test/python/utils.py
@@ -224,9 +224,10 @@ def check_systemd_dir(project, basedir):
 
     systemd_files = recursive_listdir(systemd_dir)
 
-    assert len(systemd_files) == 2
+    assert len(systemd_files) == 3
     assert '{}.service'.format(project.name) in systemd_files
     assert '{}@.service'.format(project.name) in systemd_files
+    assert '{}-stateboard.service'.format(project.name) in systemd_files
 
 
 def check_package_files(project, basedir):


### PR DESCRIPTION
This is the first part of #187 (see also https://github.com/tarantool/cartridge/issues/714)

Add `stateboard.init.lua` to template
Use `cartridge == scm-1`
Add stateboard unit file in RPM/DEB systemd directory
Test that this file is created