### PR TITLE
Use flake8 3.8.1

### DIFF
--- a/test/python/requirements.txt
+++ b/test/python/requirements.txt
@@ -3,4 +3,4 @@ tarantool
 requests
 rpmfile==0.1.4
 docker
-flake8
+flake8==3.8.1

--- a/test/python/utils.py
+++ b/test/python/utils.py
@@ -134,8 +134,8 @@ def validate_version_file(project, distribution_dir):
     version_file_content = {}
     with open(version_filepath, 'r') as version_file:
         file_lines = version_file.read().strip().split('\n')
-        for l in file_lines:
-            m = re.match(r'^([^=]+)=([^=]+)$', l)
+        for line in file_lines:
+            m = re.match(r'^([^=]+)=([^=]+)$', line)
             assert m is not None
 
             key, version = m.groups()


### PR DESCRIPTION
Fix flake8 3.8.1 version
Don't use ambiguous variable name in tests