### PR TITLE
Rewrite in Go: Check entrypoint on pack

### DIFF
--- a/cli/pack/pack.go
+++ b/cli/pack/pack.go
@@ -35,6 +35,10 @@ func Run(projectCtx *project.ProjectCtx) error {
 		panic(err)
 	}
 
+	// All types except TGZ pack require init.lua in the project root
+	// because project from TGZ can be started using `cartridge start` command
+	// that has `--script` option, but all other types use `tarantool init.lua`
+	// command to define application start command
 	if projectCtx.PackType != TgzType {
 		entrypointPath := filepath.Join(projectCtx.Path, projectCtx.Entrypoint)
 		if _, err := os.Stat(entrypointPath); os.IsNotExist(err) {

--- a/cli/pack/pack.go
+++ b/cli/pack/pack.go
@@ -35,6 +35,15 @@ func Run(projectCtx *project.ProjectCtx) error {
 		panic(err)
 	}
 
+	if projectCtx.PackType != TgzType {
+		entrypointPath := filepath.Join(projectCtx.Path, projectCtx.Entrypoint)
+		if _, err := os.Stat(entrypointPath); os.IsNotExist(err) {
+			return fmt.Errorf("Application doesn't contain entrypoint script %s", projectCtx.Entrypoint)
+		} else if err != nil {
+			return fmt.Errorf("Can't use application entrypoint script: %s", err)
+		}
+	}
+
 	projectCtx.PackID = common.RandomString(10)
 	projectCtx.BuildID = projectCtx.PackID
 

--- a/test/integration/test_pack.py
+++ b/test/integration/test_pack.py
@@ -668,8 +668,30 @@ def test_project_without_stateboard(cartridge_cmd, project_without_dependencies,
     assert '{}-stateboard.service'.format(project.name) not in systemd_files
 
 
-# @pytest.mark.parametrize('pack_format', ['rpm', 'deb', 'tgz', 'docker'])
-@pytest.mark.parametrize('pack_format', ['rpm', 'deb', 'tgz'])
+@pytest.mark.parametrize('pack_format', ['rpm', 'deb', 'tgz', 'docker'])
+def test_project_without_init(cartridge_cmd, project_without_dependencies, pack_format, tmpdir):
+    project = project_without_dependencies
+
+    ENTRYPOINT_NAME = 'init.lua'
+
+    # remove entrypoint from project
+    os.remove(os.path.join(project.path, ENTRYPOINT_NAME))
+
+    cmd = [
+        cartridge_cmd,
+        "pack", pack_format,
+        project.path,
+    ]
+
+    rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
+    if pack_format == 'tgz':
+        assert rc == 0
+    else:
+        assert rc == 1
+        assert "Application doesn't contain entrypoint script" in output
+
+
+@pytest.mark.parametrize('pack_format', ['rpm', 'deb', 'tgz', 'docker'])
 def test_files_with_bad_symbols(cartridge_cmd, project_without_dependencies, pack_format, tmpdir):
     project = project_without_dependencies
 


### PR DESCRIPTION
All types except tgz requires init.lua in the project root