### PR TITLE
Refactor command flags

### DIFF
--- a/cli/commands/build.go
+++ b/cli/commands/build.go
@@ -8,20 +8,23 @@ import (
 )
 
 func init() {
-	rootCmd.AddCommand(buildCmd)
-}
+	var buildCmd = &cobra.Command{
+		Use:   "build [PATH]",
+		Short: "Build application for local development",
+		Long:  "Build application in specified PATH (default \".\")",
+		Args:  cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			err := runBuildCommand(cmd, args)
+			if err != nil {
+				log.Fatalf(err.Error())
+			}
+		},
+	}
 
-var buildCmd = &cobra.Command{
-	Use:   "build [PATH]",
-	Short: "Build application for local development",
-	Long:  "Build application in specified PATH (default \".\")",
-	Args:  cobra.MaximumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		err := runBuildCommand(cmd, args)
-		if err != nil {
-			log.Fatalf(err.Error())
-		}
-	},
+	rootCmd.AddCommand(buildCmd)
+
+	// FLAGS
+	configureFlags(buildCmd)
 }
 
 func runBuildCommand(cmd *cobra.Command, args []string) error {

--- a/cli/commands/cartridge.go
+++ b/cli/commands/cartridge.go
@@ -5,6 +5,7 @@ import (
 	"github.com/apex/log/handlers/cli"
 	"github.com/spf13/cobra"
 	"github.com/tarantool/cartridge-cli/cli/context"
+	"github.com/tarantool/cartridge-cli/cli/version"
 )
 
 var (
@@ -13,6 +14,8 @@ var (
 	rootCmd = &cobra.Command{
 		Use:   "cartridge",
 		Short: "Tarantool Cartridge command-line interface",
+
+		Version: version.BuildVersionString(),
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			setLogLevel()
 		},
@@ -20,6 +23,8 @@ var (
 )
 
 func init() {
+	rootCmd.SetVersionTemplate("{{ .Version }}\n")
+
 	rootCmd.PersistentFlags().BoolVar(&ctx.Cli.Verbose, "verbose", false, "Verbose output")
 	rootCmd.PersistentFlags().BoolVar(&ctx.Cli.Quiet, "quiet", false, "Hide build commands output")
 	rootCmd.PersistentFlags().BoolVar(&ctx.Cli.Debug, "debug", false, "Debug mode")

--- a/cli/commands/common.go
+++ b/cli/commands/common.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
@@ -36,4 +37,22 @@ func getDuration(durationStr string) (time.Duration, error) {
 	}
 
 	return duration, nil
+}
+
+func configureFlags(cmd *cobra.Command) {
+	cmd.Flags().SortFlags = false
+}
+
+func addNameFlag(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&ctx.Project.Name, "name", "", nameUsage)
+}
+
+func addStateboardRunningFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&ctx.Running.WithStateboard, "stateboard", false, stateboardUsage)
+	cmd.Flags().BoolVar(&ctx.Running.StateboardOnly, "stateboard-only", false, stateboardOnlyUsage)
+}
+
+func addCommonRunningPathsFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&ctx.Running.RunDir, "run-dir", "", runDirUsage)
+	cmd.Flags().StringVar(&ctx.Running.ConfPath, "cfg", "", cfgUsage)
 }

--- a/cli/commands/const.go
+++ b/cli/commands/const.go
@@ -1,0 +1,14 @@
+package commands
+
+import "time"
+
+// DEFAULT VALUES
+const (
+	defaultStartTimeout = 1 * time.Minute
+	defaultLogLines     = 15
+)
+
+// ENV
+const (
+	cartridgeTmpDirEnv = "CARTRIDGE_TEMPDIR"
+)

--- a/cli/commands/create.go
+++ b/cli/commands/create.go
@@ -13,33 +13,32 @@ import (
 	"github.com/tarantool/cartridge-cli/cli/create/templates"
 )
 
-const (
-	defaultTemplate = "cartridge"
-)
-
 func init() {
+	var createCmd = &cobra.Command{
+		Use:   "create [PATH]",
+		Short: "Create an application from the Cartridge template",
+		Long:  "Create an application in the specified PATH (default \".\")",
+		Args:  cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			err := runCreateCommand(cmd, args)
+			if err != nil {
+				log.Fatalf(err.Error())
+			}
+		},
+	}
+
 	rootCmd.AddCommand(createCmd)
 
-	createCmd.Flags().StringVar(&ctx.Project.Name, "name", "", "Application name")
+	// FLAGS
+	configureFlags(createCmd)
+
+	createCmd.Flags().StringVar(&ctx.Project.Name, "name", "", createNameUsage)
 	createCmd.Flags().StringVar(
 		&ctx.Project.Template,
 		"template",
 		templates.CartridgeTemplateName,
-		"Application template",
+		templateUsage,
 	)
-}
-
-var createCmd = &cobra.Command{
-	Use:   "create [PATH]",
-	Short: "Create an application from the Cartridge template",
-	Long:  "Create an application in the specified PATH (default \".\")",
-	Args:  cobra.MaximumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		err := runCreateCommand(cmd, args)
-		if err != nil {
-			log.Fatalf(err.Error())
-		}
-	},
 }
 
 func runCreateCommand(cmd *cobra.Command, args []string) error {

--- a/cli/commands/log.go
+++ b/cli/commands/log.go
@@ -11,45 +11,41 @@ import (
 	"github.com/tarantool/cartridge-cli/cli/running"
 )
 
-var (
-	linesFlagDoc = fmt.Sprintf(`Output the last NUM lines.
-Defaults to %d`, defaultLogLines)
-)
-
-const (
-	defaultLogLines = 15
-)
-
 func init() {
+	var logCmd = &cobra.Command{
+		Use:   "log [INSTANCE_NAME...]",
+		Short: "Get logs of instance(s)",
+		Long:  fmt.Sprintf("Get logs of instance(s)\n\n%s", runningCommonUsage),
+		Run: func(cmd *cobra.Command, args []string) {
+			err := runLogCmd(cmd, args)
+			if err != nil {
+				log.Fatalf(err.Error())
+			}
+		},
+	}
+
 	rootCmd.AddCommand(logCmd)
 
-	logCmd.Flags().StringVar(&ctx.Project.Name, "name", "", nameFlagDoc)
+	// FLAGS
+	configureFlags(logCmd)
 
-	logCmd.Flags().StringVar(&ctx.Running.RunDir, "run-dir", "", runDirFlagDoc)
-	logCmd.Flags().StringVar(&ctx.Running.LogDir, "log-dir", "", logDirFlagDoc)
-	logCmd.Flags().StringVar(&ctx.Running.ConfPath, "cfg", "", cfgFlagDoc)
+	// application name flag
+	addNameFlag(logCmd)
 
-	logCmd.Flags().BoolVar(&ctx.Running.WithStateboard, "stateboard", false, stateboardFlagDoc)
-	logCmd.Flags().BoolVar(&ctx.Running.StateboardOnly, "stateboard-only", false, stateboardOnlyFlagDoc)
+	// log-specific flags
+	logCmd.Flags().BoolVarP(&ctx.Running.LogFollow, "follow", "f", false, logFollowUsage)
+	logCmd.Flags().IntVarP(&ctx.Running.LogLines, "lines", "n", 0, logLinesUsage)
 
-	logCmd.Flags().BoolVarP(&ctx.Running.LogFollow, "follow", "f", false, followFlagDoc)
-	logCmd.Flags().IntVarP(&ctx.Running.LogLines, "lines", "n", 0, linesFlagDoc)
-}
+	// stateboard flags
+	addStateboardRunningFlags(logCmd)
 
-var logCmd = &cobra.Command{
-	Use:   "log [INSTANCE_NAME...]",
-	Short: "Get logs of instance(s)",
-	Long:  fmt.Sprintf("Get logs of instance(s)\n\n%s", runningCommonDoc),
-	Run: func(cmd *cobra.Command, args []string) {
-		err := runLogCmd(cmd, args)
-		if err != nil {
-			log.Fatalf(err.Error())
-		}
-	},
+	// log-specific paths
+	logCmd.Flags().StringVar(&ctx.Running.LogDir, "log-dir", "", logDirUsage)
+	// common running paths
+	addCommonRunningPathsFlags(logCmd)
 }
 
 func runLogCmd(cmd *cobra.Command, args []string) error {
-	fmt.Printf("string(defaultLogLines): %s\n", strconv.Itoa(defaultLogLines))
 	if err := setDefaultValue(cmd.Flags(), "lines", strconv.Itoa(defaultLogLines)); err != nil {
 		return project.InternalError("Failed to set default lines value: %s", err)
 	}
@@ -64,8 +60,3 @@ func runLogCmd(cmd *cobra.Command, args []string) error {
 
 	return nil
 }
-
-const (
-	followFlagDoc = `Output appended data as the log grows
-`
-)

--- a/cli/commands/pack.go
+++ b/cli/commands/pack.go
@@ -1,39 +1,39 @@
 package commands
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
 
-	"github.com/tarantool/cartridge-cli/cli/context"
 	"github.com/tarantool/cartridge-cli/cli/pack"
 )
 
 func init() {
 	rootCmd.AddCommand(packCmd)
+	configureFlags(packCmd)
 
-	packCmd.Flags().StringVar(&ctx.Project.Name, "name", "", nameFlagDoc)
-	packCmd.Flags().StringVar(&ctx.Pack.Version, "version", "", versionFlagDoc)
-	packCmd.Flags().StringVar(&ctx.Pack.Suffix, "suffix", "", suffixFlagDoc)
-	packCmd.Flags().StringSliceVar(&ctx.Pack.ImageTags, "tag", []string{}, tagFlagDoc)
+	addNameFlag(packCmd)
 
-	packCmd.Flags().BoolVar(&ctx.Build.InDocker, "use-docker", false, useDockerDoc)
-	packCmd.Flags().BoolVar(&ctx.Docker.NoCache, "no-cache", false, noCacheDoc)
-	packCmd.Flags().StringVar(&ctx.Build.DockerFrom, "build-from", "", buildFromDoc)
-	packCmd.Flags().StringVar(&ctx.Pack.DockerFrom, "from", "", fromDoc)
-	packCmd.Flags().StringSliceVar(&ctx.Docker.CacheFrom, "cache-from", []string{}, cacheFromDoc)
+	packCmd.Flags().StringVar(&ctx.Pack.Version, "version", "", versionUsage)
+	packCmd.Flags().StringVar(&ctx.Pack.Suffix, "suffix", "", suffixUsage)
+	packCmd.Flags().StringSliceVar(&ctx.Pack.ImageTags, "tag", []string{}, tagUsage)
 
-	packCmd.Flags().BoolVar(&ctx.Build.SDKLocal, "sdk-local", false, sdkLocalDoc)
-	packCmd.Flags().StringVar(&ctx.Build.SDKPath, "sdk-path", "", sdkPathDoc)
+	packCmd.Flags().BoolVar(&ctx.Build.InDocker, "use-docker", false, useDockerUsage)
+	packCmd.Flags().BoolVar(&ctx.Docker.NoCache, "no-cache", false, noCacheUsage)
+	packCmd.Flags().StringVar(&ctx.Build.DockerFrom, "build-from", "", buildFromUsage)
+	packCmd.Flags().StringVar(&ctx.Pack.DockerFrom, "from", "", fromUsage)
+	packCmd.Flags().StringSliceVar(&ctx.Docker.CacheFrom, "cache-from", []string{}, cacheFromUsage)
 
-	packCmd.Flags().StringVar(&ctx.Pack.UnitTemplatePath, "unit-template", "", unitTemplateFlagDoc)
+	packCmd.Flags().BoolVar(&ctx.Build.SDKLocal, "sdk-local", false, sdkLocalUsage)
+	packCmd.Flags().StringVar(&ctx.Build.SDKPath, "sdk-path", "", sdkPathUsage)
+
+	packCmd.Flags().StringVar(&ctx.Pack.UnitTemplatePath, "unit-template", "", unitTemplateUsage)
 	packCmd.Flags().StringVar(
-		&ctx.Pack.InstUnitTemplatePath, "instantiated-unit-template", "", instUnitTemplateFlagDoc,
+		&ctx.Pack.InstUnitTemplatePath, "instantiated-unit-template", "", instUnitTemplateUsage,
 	)
 	packCmd.Flags().StringVar(
-		&ctx.Pack.StatboardUnitTemplatePath, "stateboard-unit-template", "", stateboardUnitTemplateFlagDoc,
+		&ctx.Pack.StatboardUnitTemplatePath, "stateboard-unit-template", "", stateboardUnitTemplateUsage,
 	)
 }
 
@@ -55,13 +55,13 @@ The supported types are: rpm, tgz, docker, deb`,
 func runPackCommand(cmd *cobra.Command, args []string) error {
 	ctx.Pack.Type = cmd.Flags().Arg(0)
 	ctx.Project.Path = cmd.Flags().Arg(1)
-	ctx.Cli.CartridgeTmpDir = os.Getenv(cartridgeTmpDir)
+	ctx.Cli.CartridgeTmpDir = os.Getenv(cartridgeTmpDirEnv)
 
 	if err := pack.FillCtx(&ctx); err != nil {
 		return err
 	}
 
-	if err := checkOptions(&ctx); err != nil {
+	if err := validatePack(&ctx); err != nil {
 		return err
 	}
 
@@ -71,124 +71,3 @@ func runPackCommand(cmd *cobra.Command, args []string) error {
 
 	return nil
 }
-
-func checkOptions(ctx *context.Ctx) error {
-	if ctx.Pack.Type != pack.RpmType && ctx.Pack.Type != pack.DebType {
-		if ctx.Pack.UnitTemplatePath != "" {
-			return fmt.Errorf("--unit-template option can be used only with rpm and deb types")
-		}
-
-		if ctx.Pack.InstUnitTemplatePath != "" {
-			return fmt.Errorf("--instantiated-unit-template option can be used only with rpm and deb types")
-		}
-
-		if ctx.Pack.StatboardUnitTemplatePath != "" {
-			return fmt.Errorf("--statboard-unit-template option can be used only with rpm and deb types")
-		}
-	}
-
-	if ctx.Pack.Type != pack.DockerType {
-		if len(ctx.Pack.ImageTags) > 0 {
-			return fmt.Errorf("--tag option can be used only with docker type")
-		}
-	}
-
-	if !ctx.Build.InDocker && ctx.Pack.Type != pack.DockerType {
-		if len(ctx.Docker.CacheFrom) > 0 {
-			return fmt.Errorf("--cache-from option can be used only with --use-docker flag or docker type")
-		}
-
-		if ctx.Build.DockerFrom != "" {
-			return fmt.Errorf("--build-from option can be used only with --use-docker flag or docker type")
-		}
-
-		if ctx.Pack.DockerFrom != "" {
-			return fmt.Errorf("--from option can be used only with --use-docker flag or docker type")
-		}
-
-		if ctx.Docker.NoCache {
-			return fmt.Errorf("--no-cache option can be used only with --use-docker flag or docker type")
-		}
-
-		if ctx.Build.SDKLocal {
-			return fmt.Errorf("--sdk-local option can be used only with --use-docker flag or docker type")
-		}
-
-		if ctx.Build.SDKPath != "" {
-			return fmt.Errorf("--sdk-path option can be used only with --use-docker flag or docker type")
-		}
-	}
-
-	return nil
-}
-
-const (
-	cartridgeTmpDir = "CARTRIDGE_TEMPDIR"
-
-	nameFlagDoc = `Application name.
-The default name comes from the "package"
-field in the rockspec file.
-`
-
-	versionFlagDoc = `Application version
-The default version is determined as the result of
-"git describe --tags --long"
-`
-
-	suffixFlagDoc = `Result file (or image) name suffix
-`
-
-	unitTemplateFlagDoc = `Path to the template for systemd
-unit file
-Used for rpm and deb types
-`
-
-	instUnitTemplateFlagDoc = `Path to the template for systemd
-instantiated unit file
-Used for rpm and deb types
-`
-
-	stateboardUnitTemplateFlagDoc = `Path to the template for
-stateboard systemd unit file
-Used for rpm and deb types
-`
-
-	useDockerDoc = `Forces to build the application in Docker`
-
-	tagFlagDoc = `Tag(s) of the Docker image that results
-from "pack docker"
-Used for docker type
-`
-
-	fromDoc = `Path to the base Dockerfile of the runtime
-image
-Defaults to Dockerfile.cartridge
-Used for docker type
-`
-
-	buildFromDoc = `Path to the base dockerfile fof the build
-image
-Used on build in docker
-Defaults to Dockerfile.build.cartridge
-`
-
-	noCacheDoc = `Creates build and runtime images with
-"--no-cache" docker flag
-`
-
-	cacheFromDoc = `Images to consider as cache sources
-for both build and runtime images
-See "--cache-from" docker flag
-`
-
-	sdkPathDoc = `Path to the SDK to be delivered
-in the result artifact
-Alternatively, you can pass the path via the
-"TARANTOOL_SDK_PATH" environment variable
-`
-
-	sdkLocalDoc = `Flag that indicates if SDK from the local
-machine should be delivered in the
-result artifact
-`
-)

--- a/cli/commands/pack.go
+++ b/cli/commands/pack.go
@@ -57,11 +57,11 @@ func runPackCommand(cmd *cobra.Command, args []string) error {
 	ctx.Project.Path = cmd.Flags().Arg(1)
 	ctx.Cli.CartridgeTmpDir = os.Getenv(cartridgeTmpDirEnv)
 
-	if err := pack.FillCtx(&ctx); err != nil {
+	if err := pack.Validate(&ctx); err != nil {
 		return err
 	}
 
-	if err := validatePack(&ctx); err != nil {
+	if err := pack.FillCtx(&ctx); err != nil {
 		return err
 	}
 

--- a/cli/commands/start.go
+++ b/cli/commands/start.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
@@ -11,48 +10,45 @@ import (
 	"github.com/tarantool/cartridge-cli/cli/running"
 )
 
-const (
-	defaultStartTimeout = 1 * time.Minute
-)
-
 var (
-	timeoutStr     string
-	timeoutFlagDoc = fmt.Sprintf(`Time to wait for instance(s) start
-in background.
-Can be specified in seconds or in duration format.
-Timeout can't be negative.
-Timeout 0s means no timeout.
-Defaults to %s`, defaultStartTimeout.String())
+	timeoutStr string
 )
 
 func init() {
+	var startCmd = &cobra.Command{
+		Use:   "start [INSTANCE_NAME...]",
+		Short: "Start application instance(s)",
+		Long:  fmt.Sprintf("Start application instance(s)\n\n%s", runningCommonUsage),
+		Run: func(cmd *cobra.Command, args []string) {
+			err := runStartCmd(cmd, args)
+			if err != nil {
+				log.Fatalf(err.Error())
+			}
+		},
+	}
+
 	rootCmd.AddCommand(startCmd)
 
-	startCmd.Flags().StringVar(&ctx.Project.Name, "name", "", nameFlagDoc)
+	// FLAGS
+	configureFlags(startCmd)
 
-	startCmd.Flags().StringVar(&ctx.Running.Entrypoint, "script", "", scriptFlagDoc)
-	startCmd.Flags().StringVar(&ctx.Running.RunDir, "run-dir", "", runDirFlagDoc)
-	startCmd.Flags().StringVar(&ctx.Running.DataDir, "data-dir", "", dataDirFlagDoc)
-	startCmd.Flags().StringVar(&ctx.Running.LogDir, "log-dir", "", logDirFlagDoc)
-	startCmd.Flags().StringVar(&ctx.Running.ConfPath, "cfg", "", cfgFlagDoc)
+	// application name flag
+	addNameFlag(startCmd)
 
-	startCmd.Flags().BoolVarP(&ctx.Running.Daemonize, "daemonize", "d", false, daemonizeFlagDoc)
-	startCmd.Flags().BoolVar(&ctx.Running.WithStateboard, "stateboard", false, stateboardFlagDoc)
-	startCmd.Flags().BoolVar(&ctx.Running.StateboardOnly, "stateboard-only", false, stateboardOnlyFlagDoc)
+	// start-specific flags
+	startCmd.Flags().BoolVarP(&ctx.Running.Daemonize, "daemonize", "d", false, daemonizeUsage)
+	startCmd.Flags().StringVar(&timeoutStr, "timeout", "", timeoutUsage)
 
-	startCmd.Flags().StringVar(&timeoutStr, "timeout", "", timeoutFlagDoc)
-}
+	// stateboard flags
+	addStateboardRunningFlags(startCmd)
 
-var startCmd = &cobra.Command{
-	Use:   "start [INSTANCE_NAME...]",
-	Short: "Start application instance(s)",
-	Long:  fmt.Sprintf("Start application instance(s)\n\n%s", runningCommonDoc),
-	Run: func(cmd *cobra.Command, args []string) {
-		err := runStartCmd(cmd, args)
-		if err != nil {
-			log.Fatalf(err.Error())
-		}
-	},
+	// common running paths
+	addCommonRunningPathsFlags(startCmd)
+	// start-specific paths
+	startCmd.Flags().StringVar(&ctx.Running.DataDir, "data-dir", "", dataDirUsage)
+	startCmd.Flags().StringVar(&ctx.Running.LogDir, "log-dir", "", logDirUsage)
+	startCmd.Flags().StringVar(&ctx.Running.Entrypoint, "script", "", scriptUsage)
+
 }
 
 func runStartCmd(cmd *cobra.Command, args []string) error {
@@ -77,49 +73,3 @@ func runStartCmd(cmd *cobra.Command, args []string) error {
 
 	return nil
 }
-
-const (
-	runningCommonDoc = `Application name is taken from rockspec in the current directory.
-
-If INSTANCE_NAMEs aren't specified, then all instances described in
-config file (see --cfg) are used.
-
-Some flags default options can be override in ./.cartridge.yml config file.
-`
-
-	scriptFlagDoc = `Application's entry point
-It should be a relative path to the entry point
-in the project directory or an absolute path.
-Defaults to "init.lua" (or "script" in .cartridge.yml)
-`
-
-	runDirFlagDoc = `Directory where PID and socket files are stored
-Defaults to ./tmp/run (or "run-dir" in .cartridge.yml)
-`
-
-	dataDirFlagDoc = `Directory where instances' data is stored
-Each instance's working directory is
-"<data-dir>/<app-name>.<instance-name>".
-Defaults to ./tmp/data (or "data-dir" in .cartridge.yml)
-`
-
-	logDirFlagDoc = `Directory to store instances logs
-when running in background
-Defaults to ./tmp/log (or "log-dir" in .cartridge.yml)
-`
-
-	cfgFlagDoc = `Configuration file for Cartridge instances
-Defaults to ./instances.yml (or "cfg" in .cartridge.yml)
-`
-
-	daemonizeFlagDoc = `Start instance(s) in background
-`
-
-	stateboardFlagDoc = `Manage application stateboard as well as instances
-Ignored if "--stateboard-only" is specified
-`
-
-	stateboardOnlyFlagDoc = `Manage only application stateboard
-If specified, "INSTANCE_NAME..." are ignored.
-`
-)

--- a/cli/commands/status.go
+++ b/cli/commands/status.go
@@ -10,27 +10,31 @@ import (
 )
 
 func init() {
+	var statusCmd = &cobra.Command{
+		Use:   "status [INSTANCE_NAME...]",
+		Short: "Get instance(s) status",
+		Long:  fmt.Sprintf("Get instance(s) status\n\n%s", runningCommonUsage),
+		Run: func(cmd *cobra.Command, args []string) {
+			err := runStatusCmd(cmd, args)
+			if err != nil {
+				log.Fatalf(err.Error())
+			}
+		},
+	}
+
 	rootCmd.AddCommand(statusCmd)
 
-	statusCmd.Flags().StringVar(&ctx.Project.Name, "name", "", nameFlagDoc)
+	// FLAGS
+	configureFlags(statusCmd)
 
-	statusCmd.Flags().StringVar(&ctx.Running.RunDir, "run-dir", "", runDirFlagDoc)
-	statusCmd.Flags().StringVar(&ctx.Running.ConfPath, "cfg", "", cfgFlagDoc)
+	// application name flag
+	addNameFlag(statusCmd)
 
-	statusCmd.Flags().BoolVar(&ctx.Running.WithStateboard, "stateboard", false, stateboardFlagDoc)
-	statusCmd.Flags().BoolVar(&ctx.Running.StateboardOnly, "stateboard-only", false, stateboardOnlyFlagDoc)
-}
+	// stateboard flags
+	addStateboardRunningFlags(statusCmd)
 
-var statusCmd = &cobra.Command{
-	Use:   "status [INSTANCE_NAME...]",
-	Short: "Get instance(s) status",
-	Long:  fmt.Sprintf("Get instance(s) status\n\n%s", runningCommonDoc),
-	Run: func(cmd *cobra.Command, args []string) {
-		err := runStatusCmd(cmd, args)
-		if err != nil {
-			log.Fatalf(err.Error())
-		}
-	},
+	// common running paths
+	addCommonRunningPathsFlags(statusCmd)
 }
 
 func runStatusCmd(cmd *cobra.Command, args []string) error {

--- a/cli/commands/stop.go
+++ b/cli/commands/stop.go
@@ -10,27 +10,31 @@ import (
 )
 
 func init() {
+	var stopCmd = &cobra.Command{
+		Use:   "stop [INSTANCE_NAME...]",
+		Short: "Stop instance(s)",
+		Long:  fmt.Sprintf("Stop instance(s)n\n%s", runningCommonUsage),
+		Run: func(cmd *cobra.Command, args []string) {
+			err := runStopCmd(cmd, args)
+			if err != nil {
+				log.Fatalf(err.Error())
+			}
+		},
+	}
+
 	rootCmd.AddCommand(stopCmd)
 
-	stopCmd.Flags().StringVar(&ctx.Project.Name, "name", "", nameFlagDoc)
+	// FLAGS
+	configureFlags(stopCmd)
 
-	stopCmd.Flags().StringVar(&ctx.Running.RunDir, "run-dir", "", runDirFlagDoc)
-	stopCmd.Flags().StringVar(&ctx.Running.ConfPath, "cfg", "", cfgFlagDoc)
+	// application name flag
+	addNameFlag(stopCmd)
 
-	stopCmd.Flags().BoolVar(&ctx.Running.WithStateboard, "stateboard", false, stateboardFlagDoc)
-	stopCmd.Flags().BoolVar(&ctx.Running.StateboardOnly, "stateboard-only", false, stateboardOnlyFlagDoc)
-}
+	// stateboard flags
+	addStateboardRunningFlags(stopCmd)
 
-var stopCmd = &cobra.Command{
-	Use:   "stop [INSTANCE_NAME...]",
-	Short: "Stop instance(s)",
-	Long:  fmt.Sprintf("Stop instance(s)n\n%s", runningCommonDoc),
-	Run: func(cmd *cobra.Command, args []string) {
-		err := runStopCmd(cmd, args)
-		if err != nil {
-			log.Fatalf(err.Error())
-		}
-	},
+	// common running paths
+	addCommonRunningPathsFlags(stopCmd)
 }
 
 func runStopCmd(cmd *cobra.Command, args []string) error {

--- a/cli/commands/usage.go
+++ b/cli/commands/usage.go
@@ -1,0 +1,149 @@
+package commands
+
+import "fmt"
+
+// CREATE
+const (
+	createNameUsage = `Application name`
+	templateUsage   = `Application template`
+)
+
+// COMMON
+const (
+	nameUsage = `Application name
+The default name comes from the "package"
+field in the rockspec file
+`
+)
+
+// PACK
+const (
+	versionUsage = `Application version
+The default version is determined by
+"git describe --tags --long"
+`
+
+	suffixUsage = `Result file (or image) name suffix
+`
+
+	unitTemplateUsage = `Path to the template for systemd
+unit file
+Used for rpm and deb types
+`
+
+	instUnitTemplateUsage = `Path to the template for systemd
+instantiated unit file
+Used for rpm and deb types
+`
+
+	stateboardUnitTemplateUsage = `Path to the template for
+stateboard systemd unit file
+Used for rpm and deb types
+`
+
+	useDockerUsage = `Forces to build the application in Docker
+`
+
+	tagUsage = `Tag(s) of the Docker image that results
+from "pack docker"
+Used for docker type
+`
+
+	fromUsage = `Path to the base Dockerfile of the runtime
+image
+Defaults to Dockerfile.cartridge
+Used for docker type
+`
+
+	buildFromUsage = `Path to the base dockerfile fof the build
+image
+Used on build in docker
+Defaults to Dockerfile.build.cartridge
+`
+
+	noCacheUsage = `Creates build and runtime images with
+"--no-cache" docker flag
+`
+
+	cacheFromUsage = `Images to consider as cache sources
+for both build and runtime images
+See "--cache-from" docker flag
+`
+
+	sdkPathUsage = `Path to the SDK to be delivered
+in the result artifact
+Alternatively, you can pass the path via the
+"TARANTOOL_SDK_PATH" environment variable
+`
+
+	sdkLocalUsage = `Flag that indicates if SDK from the local
+machine should be delivered in the
+result artifact
+`
+)
+
+// RUNNING
+const (
+	runningCommonUsage = `Running instance(s) of current application
+
+Application name is described from rockspec in the current directory.
+
+If INSTANCE_NAMEs aren't specified, then all instances described in
+config file (see --cfg) are used.
+
+Some flags default options can be override in ./.cartridge.yml config file.
+`
+
+	scriptUsage = `Application's entry point
+It should be a relative path to the entry point
+in the project directory or an absolute path.
+Defaults to "init.lua" (or "script" in .cartridge.yml)
+`
+
+	runDirUsage = `Directory where PID and socket files are stored
+Defaults to ./tmp/run (or "run-dir" in .cartridge.yml)
+`
+
+	dataDirUsage = `Directory where instances' data is stored
+Each instance's working directory is
+"<data-dir>/<app-name>.<instance-name>".
+Defaults to ./tmp/data (or "data-dir" in .cartridge.yml)
+`
+
+	logDirUsage = `Directory to store instances logs
+when running in background
+Defaults to ./tmp/log (or "log-dir" in .cartridge.yml)
+`
+
+	cfgUsage = `Configuration file for Cartridge instances
+Defaults to ./instances.yml (or "cfg" in .cartridge.yml)
+`
+
+	daemonizeUsage = `Start instance(s) in background
+`
+
+	stateboardUsage = `Manage application stateboard as well as instances
+Ignored if "--stateboard-only" is specified
+`
+
+	stateboardOnlyUsage = `Manage only application stateboard
+If specified, "INSTANCE_NAME..." are ignored.
+`
+
+	logFollowUsage = `Output appended data as the log grows
+`
+)
+
+var (
+	timeoutUsage = fmt.Sprintf(`Time to wait for instance(s) start
+in background
+Can be specified in seconds or in duration format
+Timeout can't be negative
+Timeout 0s means no timeout
+Defaults to %s
+`, defaultStartTimeout.String())
+
+	logLinesUsage = fmt.Sprintf(`Count of last lines to output
+Defaults to %d
+`, defaultLogLines)
+)

--- a/cli/commands/validate.go
+++ b/cli/commands/validate.go
@@ -1,0 +1,58 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/tarantool/cartridge-cli/cli/context"
+	"github.com/tarantool/cartridge-cli/cli/pack"
+)
+
+func validatePack(ctx *context.Ctx) error {
+	if ctx.Pack.Type != pack.RpmType && ctx.Pack.Type != pack.DebType {
+		if ctx.Pack.UnitTemplatePath != "" {
+			return fmt.Errorf("--unit-template option can be used only with rpm and deb types")
+		}
+
+		if ctx.Pack.InstUnitTemplatePath != "" {
+			return fmt.Errorf("--instantiated-unit-template option can be used only with rpm and deb types")
+		}
+
+		if ctx.Pack.StatboardUnitTemplatePath != "" {
+			return fmt.Errorf("--statboard-unit-template option can be used only with rpm and deb types")
+		}
+	}
+
+	if ctx.Pack.Type != pack.DockerType {
+		if len(ctx.Pack.ImageTags) > 0 {
+			return fmt.Errorf("--tag option can be used only with docker type")
+		}
+	}
+
+	if !ctx.Build.InDocker && ctx.Pack.Type != pack.DockerType {
+		if len(ctx.Docker.CacheFrom) > 0 {
+			return fmt.Errorf("--cache-from option can be used only with --use-docker flag or docker type")
+		}
+
+		if ctx.Build.DockerFrom != "" {
+			return fmt.Errorf("--build-from option can be used only with --use-docker flag or docker type")
+		}
+
+		if ctx.Pack.DockerFrom != "" {
+			return fmt.Errorf("--from option can be used only with --use-docker flag or docker type")
+		}
+
+		if ctx.Docker.NoCache {
+			return fmt.Errorf("--no-cache option can be used only with --use-docker flag or docker type")
+		}
+
+		if ctx.Build.SDKLocal {
+			return fmt.Errorf("--sdk-local option can be used only with --use-docker flag or docker type")
+		}
+
+		if ctx.Build.SDKPath != "" {
+			return fmt.Errorf("--sdk-path option can be used only with --use-docker flag or docker type")
+		}
+	}
+
+	return nil
+}

--- a/cli/commands/version.go
+++ b/cli/commands/version.go
@@ -8,15 +8,15 @@ import (
 )
 
 func init() {
-	rootCmd.AddCommand(versionCmd)
-}
+	var versionCmd = &cobra.Command{
+		Use:   "version",
+		Short: "Print the version number of Cartridge CLI",
+		Long:  `All software has versions. This is Cartridge CLI's`,
+		Args:  cobra.MaximumNArgs(0),
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(version.BuildVersionString())
+		},
+	}
 
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Print the version number of Cartridge CLI",
-	Long:  `All software has versions. This is Cartridge CLI's`,
-	Args:  cobra.MaximumNArgs(0),
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(version.BuildVersionString())
-	},
+	rootCmd.AddCommand(versionCmd)
 }

--- a/cli/pack/validate.go
+++ b/cli/pack/validate.go
@@ -1,14 +1,13 @@
-package commands
+package pack
 
 import (
 	"fmt"
 
 	"github.com/tarantool/cartridge-cli/cli/context"
-	"github.com/tarantool/cartridge-cli/cli/pack"
 )
 
-func validatePack(ctx *context.Ctx) error {
-	if ctx.Pack.Type != pack.RpmType && ctx.Pack.Type != pack.DebType {
+func Validate(ctx *context.Ctx) error {
+	if ctx.Pack.Type != RpmType && ctx.Pack.Type != DebType {
 		if ctx.Pack.UnitTemplatePath != "" {
 			return fmt.Errorf("--unit-template option can be used only with rpm and deb types")
 		}
@@ -22,13 +21,13 @@ func validatePack(ctx *context.Ctx) error {
 		}
 	}
 
-	if ctx.Pack.Type != pack.DockerType {
+	if ctx.Pack.Type != DockerType {
 		if len(ctx.Pack.ImageTags) > 0 {
 			return fmt.Errorf("--tag option can be used only with docker type")
 		}
 	}
 
-	if !ctx.Build.InDocker && ctx.Pack.Type != pack.DockerType {
+	if !ctx.Build.InDocker && ctx.Pack.Type != DockerType {
 		if len(ctx.Docker.CacheFrom) > 0 {
 			return fmt.Errorf("--cache-from option can be used only with --use-docker flag or docker type")
 		}

--- a/test/integration/test_version.py
+++ b/test/integration/test_version.py
@@ -4,6 +4,7 @@ from utils import run_command_and_get_output
 
 
 def test_version_command(cartridge_cmd):
-    rc, output = run_command_and_get_output([cartridge_cmd, "version"])
-    assert rc == 0
-    assert 'Tarantool Cartridge CLI v' in output
+    for version_cmd in ["version", "-v", "--version"]:
+        rc, output = run_command_and_get_output([cartridge_cmd, version_cmd])
+        assert rc == 0
+        assert 'Tarantool Cartridge CLI v2' in output


### PR DESCRIPTION
This is the preparation step for #282 

* Make *Cmd variables non-global to avoid copy-paste errors
* Move all flags usage to the separated file
* Add function for flags configuring
* Add functions for adding common flags
* Move default values to the separated file
* Support -v and --version