### PR TITLE
--force option for stop command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `--force` option for `start` command to send SIGKILL to instances
+
 ## [2.1.0] - 2020-07-17
 
 ### Added

--- a/README.rst
+++ b/README.rst
@@ -437,6 +437,12 @@ To stop one or more running instances, say:
 
     cartridge stop [INSTANCE_NAME...] [flags]
 
+By default, SIGTERM is sent to instances.
+
+The following options (``[flags]``) are supported:
+
+* ``-f, --force`` indicates if instance(s) stop should be forced (sends SIGKILL).
+
 The following `options <Options_>`_ from the ``start`` command
 are supported:
 

--- a/cli/commands/stop.go
+++ b/cli/commands/stop.go
@@ -13,7 +13,7 @@ func init() {
 	var stopCmd = &cobra.Command{
 		Use:   "stop [INSTANCE_NAME...]",
 		Short: "Stop instance(s)",
-		Long:  fmt.Sprintf("Stop instance(s)n\n%s", runningCommonUsage),
+		Long:  fmt.Sprintf("Stop instance(s) (sends SIGTERM)\n%s", runningCommonUsage),
 		Run: func(cmd *cobra.Command, args []string) {
 			err := runStopCmd(cmd, args)
 			if err != nil {
@@ -35,6 +35,9 @@ func init() {
 
 	// common running paths
 	addCommonRunningPathsFlags(stopCmd)
+
+	// add --force flag
+	stopCmd.Flags().BoolVarP(&ctx.Running.StopForced, "force", "f", false, stopForceUsage)
 }
 
 func runStopCmd(cmd *cobra.Command, args []string) error {

--- a/cli/commands/usage.go
+++ b/cli/commands/usage.go
@@ -86,7 +86,7 @@ result artifact
 const (
 	runningCommonUsage = `Running instance(s) of current application
 
-Application name is described from rockspec in the current directory.
+Application name is taken from rockspec in the current directory.
 
 If INSTANCE_NAMEs aren't specified, then all instances described in
 config file (see --cfg) are used.
@@ -131,6 +131,9 @@ If specified, "INSTANCE_NAME..." are ignored.
 `
 
 	logFollowUsage = `Output appended data as the log grows
+`
+
+	stopForceUsage = `Force instance(s) stop (sends SIGKILL)
 `
 )
 

--- a/cli/context/context.go
+++ b/cli/context/context.go
@@ -42,6 +42,8 @@ type RunningCtx struct {
 	LogFollow bool
 	LogLines  int
 
+	StopForced bool
+
 	Entrypoint           string
 	StateboardEntrypoint string
 	AppsDir              string

--- a/cli/running/process.go
+++ b/cli/running/process.go
@@ -304,7 +304,14 @@ func (process *Process) SendSignal(sig syscall.Signal) error {
 	return nil
 }
 
-func (process *Process) Stop() error {
+func (process *Process) Stop(force bool) error {
+	if !force {
+		return process.Terminate()
+	}
+	return process.Kill()
+}
+
+func (process *Process) Terminate() error {
 	return process.SendSignal(syscall.SIGTERM)
 }
 

--- a/cli/running/processes_set.go
+++ b/cli/running/processes_set.go
@@ -152,7 +152,7 @@ func (set *ProcessesSet) Start(daemonize bool, timeout time.Duration) error {
 	return nil
 }
 
-func (set *ProcessesSet) Stop() error {
+func (set *ProcessesSet) Stop(force bool) error {
 	var errors []error
 	var warnings []error
 
@@ -171,7 +171,7 @@ func (set *ProcessesSet) Stop() error {
 				Res:       procResSkipped,
 				Error:     fmt.Errorf("Process is not running"),
 			}
-		} else if err := process.Stop(); err != nil {
+		} else if err := process.Stop(force); err != nil {
 			res = ProcessRes{
 				ProcessID: process.ID,
 				Res:       procResFailed,

--- a/cli/running/running.go
+++ b/cli/running/running.go
@@ -112,7 +112,7 @@ func Stop(ctx *context.Ctx) error {
 		return fmt.Errorf("No instances specified")
 	}
 
-	if err := processes.Stop(); err != nil {
+	if err := processes.Stop(ctx.Running.StopForced); err != nil {
 		return err
 	}
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -196,3 +196,56 @@ def project_getting_started(cartridge_cmd, short_tmpdir):
     )
 
     return project
+
+
+##############################
+# Project that ignores SIGTERM
+##############################
+# This project is used in the `running` tests
+# to check that `cartridge stop` sends SIGTERM,
+# but `cartridge stop -f` sends SIGKILL
+@pytest.fixture(scope="function")
+def project_ignore_sigterm(cartridge_cmd, short_tmpdir):
+    project = Project(cartridge_cmd, 'ignore-sigterm', short_tmpdir, 'cartridge')
+
+    remove_all_dependencies(project)
+
+    patched_init = '''#!/usr/bin/env tarantool
+local fiber = require('fiber')
+fiber.create(function()
+    fiber.sleep(1)
+end)
+
+require('log').info('I am starting...')
+
+-- ignore SIGTERM
+local ffi = require('ffi')
+local SIG_IGN = 1
+local SIGTERM = 15
+ffi.cdef[[
+    void (*signal(int sig, void (*func)(int)))(int);
+]]
+local ignore_handler = ffi.cast("void (*)(int)", SIG_IGN)
+ffi.C.signal(SIGTERM, ignore_handler)
+
+-- Copied from cartridge.cfg to provide support for NOTIFY_SOCKET in old tarantool
+local tnt_version = string.split(_TARANTOOL, '.')
+local tnt_major = tonumber(tnt_version[1])
+local tnt_minor = tonumber(tnt_version[2])
+if tnt_major < 2 or (tnt_major == 2 and tnt_minor < 2) then
+  local notify_socket = os.getenv('NOTIFY_SOCKET')
+  if notify_socket then
+      local socket = require('socket')
+      local sock = assert(socket('AF_UNIX', 'SOCK_DGRAM', 0), 'Can not create socket')
+      sock:sendto('unix/', notify_socket, 'READY=1')
+  end
+end
+'''
+
+    with open(os.path.join(project.path, 'init.lua'), 'w') as f:
+        f.write(patched_init)
+
+    with open(os.path.join(project.path, 'stateboard.init.lua'), 'w') as f:
+        f.write(patched_init)
+
+    return project

--- a/test/utils.py
+++ b/test/utils.py
@@ -181,8 +181,11 @@ class Cli():
 
         return self._subprocess.returncode
 
-    def stop(self, project, instances=[], run_dir=None, cfg=None, stateboard=False, stateboard_only=False):
+    def stop(self, project, instances=[], run_dir=None, cfg=None, force=False,
+             stateboard=False, stateboard_only=False):
         cmd = [self._cartridge_cmd, 'stop']
+        if force:
+            cmd.append('--force')
         if stateboard:
             cmd.append('--stateboard')
         if stateboard_only:


### PR DESCRIPTION
Sometimes we need to kill instances instead of gracefully sending SIGTERM.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Closes #312 
