### PR TITLE
Clean command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - `--force` option for `start` command to send SIGKILL to instances
+- `cartridge clean` command to remove instance(s) files
 
 ## [2.1.0] - 2020-07-17
 

--- a/README.rst
+++ b/README.rst
@@ -126,6 +126,7 @@ The following commands are supported:
 * ``stop`` — stop a Tarantool instance(s);
 * ``status`` — get current instance(s) status;
 * ``log`` — get logs of instance(s);
+* ``clean`` - clean instance(s) files;
 * ``pack`` — pack the application into a distributable bundle.
 
 The following global flags are supported:
@@ -478,9 +479,9 @@ are supported:
 
 .. // Please, update the doc in cli/commands on updating this section
 
-***********
+*******
 ``log``
-***********
+*******
 
 To get logs of the instance running in background, use the ``log`` command:
 
@@ -499,6 +500,40 @@ The following `options <Options_>`_ from the ``start`` command
 are supported:
 
 * ``--log-dir DIR``
+* ``--run-dir DIR``
+* ``--cfg FILE``
+* ``--stateboard``
+* ``--stateboard-only``
+
+.. // Please, update the doc in cli/commands on updating this section
+
+.. _cartridge-cli-packing-an-application:
+
+*********
+``clean``
+*********
+
+To remove instance(s) files (log, workdir, console and notify sockets),
+use the ``clean`` command:
+
+.. code-block:: bash
+
+    cartridge clean [INSTANCE_NAME...] [flags]
+
+By default, `cartridge clean` for running instances causes an error.
+But it can be forced with ``--force`` flag.
+PID-files aren't remove because they are used by `Cartridge CLI` itself
+to check instance process status.
+
+The following options (``[flags]``) are supported:
+
+* ``-f, --force`` remove files even if instances are running.
+
+The following `options <Options_>`_ from the ``start`` command
+are supported:
+
+* ``--log-dir DIR``
+* ``--data-dir DIR``
 * ``--run-dir DIR``
 * ``--cfg FILE``
 * ``--stateboard``

--- a/README.rst
+++ b/README.rst
@@ -521,7 +521,7 @@ use the ``clean`` command:
     cartridge clean [INSTANCE_NAME...] [flags]
 
 `cartridge clean` for running instance(s) causes an error.
-PID-files aren't remove because they are used by `Cartridge CLI` itself
+PID-files aren't removed because they are used by `Cartridge CLI` itself
 to check instance process status.
 
 The following `options <Options_>`_ from the ``start`` command

--- a/README.rst
+++ b/README.rst
@@ -513,7 +513,7 @@ are supported:
 ``clean``
 *********
 
-To remove instance(s) files (log, workdir, console and notify sockets),
+To remove instance(s) files (log, workdir, console socket, PID-file and notify socket),
 use the ``clean`` command:
 
 .. code-block:: bash
@@ -521,8 +521,6 @@ use the ``clean`` command:
     cartridge clean [INSTANCE_NAME...] [flags]
 
 `cartridge clean` for running instance(s) causes an error.
-PID-files aren't removed because they are used by `Cartridge CLI` itself
-to check instance process status.
 
 The following `options <Options_>`_ from the ``start`` command
 are supported:

--- a/README.rst
+++ b/README.rst
@@ -520,14 +520,9 @@ use the ``clean`` command:
 
     cartridge clean [INSTANCE_NAME...] [flags]
 
-By default, `cartridge clean` for running instances causes an error.
-But it can be forced with ``--force`` flag.
+`cartridge clean` for running instance(s) causes an error.
 PID-files aren't remove because they are used by `Cartridge CLI` itself
 to check instance process status.
-
-The following options (``[flags]``) are supported:
-
-* ``-f, --force`` remove files even if instances are running.
 
 The following `options <Options_>`_ from the ``start`` command
 are supported:

--- a/cli/commands/clean.go
+++ b/cli/commands/clean.go
@@ -30,9 +30,6 @@ func init() {
 	// application name flag
 	addNameFlag(cleanCmd)
 
-	// clean-specific flags
-	cleanCmd.Flags().BoolVarP(&ctx.Running.CleanForce, "force", "f", false, cleanForceUsage)
-
 	// stateboard flags
 	addStateboardRunningFlags(cleanCmd)
 

--- a/cli/commands/clean.go
+++ b/cli/commands/clean.go
@@ -12,8 +12,8 @@ import (
 func init() {
 	var cleanCmd = &cobra.Command{
 		Use:   "clean [INSTANCE_NAME...]",
-		Short: "Get instance(s) clean",
-		Long:  fmt.Sprintf("Get instance(s) clean\n\n%s", runningCommonUsage),
+		Short: "Clean instance(s) files",
+		Long:  fmt.Sprintf("Clean instance(s) files\n\n%s", runningCommonUsage),
 		Run: func(cmd *cobra.Command, args []string) {
 			err := runCleanCmd(cmd, args)
 			if err != nil {

--- a/cli/commands/clean.go
+++ b/cli/commands/clean.go
@@ -1,0 +1,56 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/apex/log"
+	"github.com/spf13/cobra"
+
+	"github.com/tarantool/cartridge-cli/cli/running"
+)
+
+func init() {
+	var cleanCmd = &cobra.Command{
+		Use:   "clean [INSTANCE_NAME...]",
+		Short: "Get instance(s) clean",
+		Long:  fmt.Sprintf("Get instance(s) clean\n\n%s", runningCommonUsage),
+		Run: func(cmd *cobra.Command, args []string) {
+			err := runCleanCmd(cmd, args)
+			if err != nil {
+				log.Fatalf(err.Error())
+			}
+		},
+	}
+
+	rootCmd.AddCommand(cleanCmd)
+
+	// FLAGS
+	configureFlags(cleanCmd)
+
+	// application name flag
+	addNameFlag(cleanCmd)
+
+	// clean-specific flags
+	cleanCmd.Flags().BoolVarP(&ctx.Running.CleanForce, "force", "f", false, cleanForceUsage)
+
+	// stateboard flags
+	addStateboardRunningFlags(cleanCmd)
+
+	// clean-specific paths
+	cleanCmd.Flags().StringVar(&ctx.Running.LogDir, "log-dir", "", logDirUsage)
+	cleanCmd.Flags().StringVar(&ctx.Running.DataDir, "data-dir", "", dataDirUsage)
+	// common running paths
+	addCommonRunningPathsFlags(cleanCmd)
+}
+
+func runCleanCmd(cmd *cobra.Command, args []string) error {
+	if err := running.FillCtx(&ctx, args); err != nil {
+		return err
+	}
+
+	if err := running.Clean(&ctx); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cli/commands/usage.go
+++ b/cli/commands/usage.go
@@ -84,8 +84,7 @@ result artifact
 
 // RUNNING
 const (
-	runningCommonUsage = `Running instance(s) of current application
-
+	runningCommonUsage = `Application from current directory is used.
 Application name is taken from rockspec in the current directory.
 
 If INSTANCE_NAMEs aren't specified, then all instances described in

--- a/cli/commands/usage.go
+++ b/cli/commands/usage.go
@@ -134,9 +134,6 @@ If specified, "INSTANCE_NAME..." are ignored.
 
 	stopForceUsage = `Force instance(s) stop (sends SIGKILL)
 `
-
-	cleanForceUsage = `Remove files even if instances are running
-`
 )
 
 var (

--- a/cli/commands/usage.go
+++ b/cli/commands/usage.go
@@ -135,6 +135,9 @@ If specified, "INSTANCE_NAME..." are ignored.
 
 	stopForceUsage = `Force instance(s) stop (sends SIGKILL)
 `
+
+	cleanForceUsage = `Remove files even if instances are running
+`
 )
 
 var (

--- a/cli/context/context.go
+++ b/cli/context/context.go
@@ -43,7 +43,6 @@ type RunningCtx struct {
 	LogLines  int
 
 	StopForced bool
-	CleanForce bool
 
 	Entrypoint           string
 	StateboardEntrypoint string

--- a/cli/context/context.go
+++ b/cli/context/context.go
@@ -43,6 +43,7 @@ type RunningCtx struct {
 	LogLines  int
 
 	StopForced bool
+	CleanForce bool
 
 	Entrypoint           string
 	StateboardEntrypoint string

--- a/cli/running/process.go
+++ b/cli/running/process.go
@@ -432,8 +432,8 @@ func (process *Process) Clean() ProcessRes {
 		process.workDir,
 		process.consoleSock,
 		process.notifySockPath,
-		// PID file isn't deleted
-		// since it's used by Cartridge CLI to start and stop instance
+		process.pidFile,
+		// PID file can be deleted since we don't allow to clean running instances data
 	}
 
 	var nonExistedFiles []string

--- a/cli/running/process.go
+++ b/cli/running/process.go
@@ -443,17 +443,14 @@ func (process *Process) Clean() ProcessRes {
 	for _, path := range pathsToDelete {
 		if _, err := os.Stat(path); os.IsNotExist(err) {
 			nonExistedFiles = append(nonExistedFiles, path)
-			continue
 		} else if err != nil {
 			errors = append(errors, err.Error())
-			continue
 		} else if err := os.RemoveAll(path); err != nil {
 			errors = append(errors, err.Error())
-			continue
+		} else {
+			// skipped result is returned only if all files exists
+			skipped = false
 		}
-
-		// skipped result is returned only if all files exists
-		skipped = false
 	}
 
 	if len(errors) > 0 {

--- a/cli/running/process_test.go
+++ b/cli/running/process_test.go
@@ -31,6 +31,8 @@ func TestNewInstanceProcess(t *testing.T) {
 	assert.Equal("tmp/run/myapp.instance-1.pid", process.pidFile)
 	assert.Equal("tmp/log", process.logDir)
 	assert.Equal("tmp/log/myapp.instance-1.log", process.logFile)
+	assert.Equal("tmp/run/myapp.instance-1.control", process.consoleSock)
+
 	assert.Equal("tmp/run/myapp.instance-1.notify", process.notifySockPath)
 
 	expEnv := []string{
@@ -69,6 +71,7 @@ func TestNewStateboardProcess(t *testing.T) {
 	assert.Equal("tmp/run/myapp-stateboard.pid", process.pidFile)
 	assert.Equal("tmp/log", process.logDir)
 	assert.Equal("tmp/log/myapp-stateboard.log", process.logFile)
+	assert.Equal("tmp/run/myapp-stateboard.control", process.consoleSock)
 
 	assert.Equal("tmp/run/myapp-stateboard.notify", process.notifySockPath)
 

--- a/cli/running/processes_set.go
+++ b/cli/running/processes_set.go
@@ -271,7 +271,7 @@ func (set *ProcessesSet) Clean() error {
 				errors = append(errors, fmt.Errorf("%s: %s", res.ProcessID, res.Error))
 			}
 
-			if res.Res == procResSkipped {
+			if res.Res == procResSkipped || res.Res == procResOk && res.Error != nil {
 				warnings = append(warnings, fmt.Errorf("%s: %s", res.ProcessID, res.Error))
 			}
 
@@ -289,7 +289,7 @@ func (set *ProcessesSet) Clean() error {
 		for _, err := range errors {
 			log.Errorf("%s", err)
 		}
-		return fmt.Errorf("Failed to stop some instances")
+		return fmt.Errorf("Failed to clean some instances data")
 	}
 
 	return nil

--- a/cli/running/processes_set.go
+++ b/cli/running/processes_set.go
@@ -232,7 +232,7 @@ func (set *ProcessesSet) Status() error {
 	return nil
 }
 
-func clearProcessData(process *Process, force bool, resCh chan ProcessRes) {
+func clearProcessData(process *Process, resCh chan ProcessRes) {
 	if process.Status == procStatusError {
 		resCh <- ProcessRes{
 			ProcessID: process.ID,
@@ -241,7 +241,7 @@ func clearProcessData(process *Process, force bool, resCh chan ProcessRes) {
 		}
 		return
 	}
-	if !force && process.Status == procStatusRunning {
+	if process.Status == procStatusRunning {
 		resCh <- ProcessRes{
 			ProcessID: process.ID,
 			Res:       procResFailed,
@@ -253,11 +253,11 @@ func clearProcessData(process *Process, force bool, resCh chan ProcessRes) {
 	resCh <- process.Clean()
 }
 
-func (set *ProcessesSet) Clean(force bool) error {
+func (set *ProcessesSet) Clean() error {
 	resCh := make(chan ProcessRes)
 
 	for _, process := range *set {
-		go clearProcessData(process, force, resCh)
+		go clearProcessData(process, resCh)
 	}
 
 	var errors []error

--- a/cli/running/running.go
+++ b/cli/running/running.go
@@ -170,3 +170,29 @@ func Log(ctx *context.Ctx) error {
 
 	return nil
 }
+
+func Clean(ctx *context.Ctx) error {
+	var err error
+
+	if !ctx.Running.StateboardOnly && len(ctx.Running.Instances) == 0 {
+		ctx.Running.Instances, err = collectInstancesFromConf(ctx)
+		if err != nil {
+			return fmt.Errorf("Failed to get configured instances from conf: %s", err)
+		}
+	}
+
+	processes, err := collectProcesses(ctx)
+	if err != nil {
+		return fmt.Errorf("Failed to collect instances processes: %s", err)
+	}
+
+	if len(*processes) == 0 {
+		return fmt.Errorf("No instances specified")
+	}
+
+	if err := processes.Clean(ctx.Running.CleanForce); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cli/running/running.go
+++ b/cli/running/running.go
@@ -190,7 +190,7 @@ func Clean(ctx *context.Ctx) error {
 		return fmt.Errorf("No instances specified")
 	}
 
-	if err := processes.Clean(ctx.Running.CleanForce); err != nil {
+	if err := processes.Clean(); err != nil {
 		return err
 	}
 

--- a/cli/running/running.go
+++ b/cli/running/running.go
@@ -177,7 +177,7 @@ func Clean(ctx *context.Ctx) error {
 	if !ctx.Running.StateboardOnly && len(ctx.Running.Instances) == 0 {
 		ctx.Running.Instances, err = collectInstancesFromConf(ctx)
 		if err != nil {
-			return fmt.Errorf("Failed to get configured instances from conf: %s", err)
+			return fmt.Errorf("Failed to get configured instances from config: %s", err)
 		}
 	}
 

--- a/test/integration/test_clean.py
+++ b/test/integration/test_clean.py
@@ -9,7 +9,7 @@ from utils import check_instances_stopped
 
 CARTRIDGE_CONF = '.cartridge.yml'
 
-FILES_TO_BE_DELETED = ['log', 'workdir', 'console-sock', 'notify-sock']
+FILES_TO_BE_DELETED = ['log', 'workdir', 'console-sock', 'notify-sock', 'pid']
 
 
 def get_instance_files(project, instance_id, log_dir=DEFAULT_LOG_DIR, data_dir=DEFAULT_DATA_DIR,

--- a/test/integration/test_clean.py
+++ b/test/integration/test_clean.py
@@ -246,7 +246,7 @@ def test_skipped(start_stop_cli, project_with_patched_init):
     assert_files_exists(project, [], stateboard=True)
 
 
-def test_force(start_stop_cli, project_with_patched_init):
+def test_for_running(start_stop_cli, project_with_patched_init):
     project = project_with_patched_init
     cli = start_stop_cli
 
@@ -272,11 +272,3 @@ def test_force(start_stop_cli, project_with_patched_init):
     assert any([line.endswith('OK') and line.startswith(ID1) for line in logs])
     assert any([line.endswith('FAILED') and line.startswith(ID2) for line in logs])
     assert any(["%s: Instance is running" % ID2 in line for line in logs])
-
-    # clean with --force
-    logs = cli.clean(project, [INSTANCE1, INSTANCE2], force=True)
-    assert_files_cleaned(project, [INSTANCE1])
-
-    assert len(logs) == 2
-    assert any([line.endswith('SKIPPED') and line.startswith(ID1) for line in logs])
-    assert any([line.endswith('OK') and line.startswith(ID2) for line in logs])

--- a/test/integration/test_clean.py
+++ b/test/integration/test_clean.py
@@ -1,0 +1,244 @@
+import os
+
+from utils import get_instance_id, get_stateboard_name
+from utils import DEFAULT_CFG, DEFAULT_DATA_DIR, DEFAULT_LOG_DIR, DEFAULT_RUN_DIR
+from utils import write_conf
+
+
+CARTRIDGE_CONF = '.cartridge.yml'
+
+FILES_TO_BE_DELETED = ['log', 'workdir', 'console-sock', 'notify-sock']
+
+
+def get_instance_files(project, instance_id, log_dir=DEFAULT_LOG_DIR, data_dir=DEFAULT_DATA_DIR,
+                       run_dir=DEFAULT_RUN_DIR):
+    return {
+        'log': os.path.join(project.path, log_dir, '%s.log' % instance_id),
+        'workdir': os.path.join(project.path, data_dir, instance_id),
+        'console-sock': os.path.join(project.path, run_dir, '%s.control' % instance_id),
+        'pid': os.path.join(project.path, run_dir, '%s.pid' % instance_id),
+        'notify-sock': os.path.join(project.path, run_dir, '%s.notify' % instance_id),
+    }
+
+
+def create_instances_files(project, instance_names=[],
+                           log_dir=DEFAULT_LOG_DIR, data_dir=DEFAULT_DATA_DIR, run_dir=DEFAULT_RUN_DIR):
+    instance_ids = [get_instance_id(project.name, instance_name) for instance_name in instance_names]
+    instance_ids.append(get_stateboard_name(project.name))
+
+    for instance_id in instance_ids:
+        instance_files = get_instance_files(project, instance_id, log_dir, data_dir, run_dir)
+
+        for _, path in instance_files.items():
+            if not os.path.exists(path):
+                basepath = os.path.dirname(path)
+                os.makedirs(basepath, exist_ok=True)
+                with open(path, 'w') as f:
+                    f.write('')
+
+
+def assert_clean_logs(logs, project, instance_names=[], stateboard=False, exp_res='OK'):
+    instance_ids = [get_instance_id(project.name, instance_name) for instance_name in instance_names]
+    if stateboard:
+        instance_ids.append(get_stateboard_name(project.name))
+
+    assert len(logs) == len(instance_ids)
+    assert all([log_line.endswith(exp_res) for log_line in logs])
+    assert all([
+        any([log_line.startswith(instance_id) for log_line in logs])
+        for instance_id in instance_ids
+    ])
+
+
+def assert_files_cleaned(project, instance_names=[], stateboard=False, check_logs=True, logs=None, exp_res_log='OK',
+                         log_dir=DEFAULT_LOG_DIR, data_dir=DEFAULT_DATA_DIR, run_dir=DEFAULT_RUN_DIR):
+    instance_ids = [get_instance_id(project.name, instance_name) for instance_name in instance_names]
+    if stateboard:
+        instance_ids.append(get_stateboard_name(project.name))
+
+    if check_logs and logs is not None:
+        assert_clean_logs(logs, project, instance_names, stateboard, exp_res_log)
+
+    for instance_id in instance_ids:
+        instance_files = get_instance_files(project, instance_id, log_dir, data_dir, run_dir)
+
+        for file_type, path in instance_files.items():
+            if file_type in FILES_TO_BE_DELETED:
+                assert not os.path.exists(path)
+            else:
+                assert os.path.exists(path)
+
+
+def assert_files_exists(project, instance_names=[], stateboard=False,
+                        log_dir=DEFAULT_LOG_DIR, data_dir=DEFAULT_DATA_DIR, run_dir=DEFAULT_RUN_DIR):
+    instance_ids = [get_instance_id(project.name, instance_name) for instance_name in instance_names]
+    if stateboard:
+        instance_ids.append(get_stateboard_name(project.name))
+
+    for instance_id in instance_ids:
+        instance_files = get_instance_files(project, instance_id, log_dir, data_dir, run_dir)
+
+        for _, path in instance_files.items():
+            assert os.path.exists(path)
+
+
+def test_clean_by_name(start_stop_cli, project_with_patched_init):
+    project = project_with_patched_init
+    cli = start_stop_cli
+
+    INSTANCE1 = 'instance-1'
+    INSTANCE2 = 'instance-2'
+
+    # two instances
+    create_instances_files(project, [INSTANCE1, INSTANCE2])
+    logs = cli.clean(project, [INSTANCE1, INSTANCE2])
+    assert_files_cleaned(project, [INSTANCE1, INSTANCE2], logs=logs)
+    assert_files_exists(project, [], stateboard=True)
+
+    # one instance w/ stateboard
+    create_instances_files(project, [INSTANCE1, INSTANCE2])
+    logs = cli.clean(project, [INSTANCE1], stateboard=True)
+    assert_files_cleaned(project, [INSTANCE1],  stateboard=True, logs=logs)
+    assert_files_exists(project, [INSTANCE2])
+
+    # one instance stateboard-only
+    create_instances_files(project, [INSTANCE1, INSTANCE2])
+    logs = cli.clean(project, stateboard_only=True)
+    assert_files_cleaned(project, [],  stateboard=True, logs=logs)
+    assert_files_exists(project, [INSTANCE1, INSTANCE2])
+
+
+def test_clean_from_conf(start_stop_cli, project_with_patched_init):
+    project = project_with_patched_init
+    cli = start_stop_cli
+
+    INSTANCE1 = 'instance-1'
+    INSTANCE2 = 'instance-2'
+
+    write_conf(os.path.join(project.path, DEFAULT_CFG), {
+        get_instance_id(project.name, INSTANCE1): {},
+        get_instance_id(project.name, INSTANCE2): {},
+    })
+
+    # only instances
+    create_instances_files(project, [INSTANCE1, INSTANCE2])
+    logs = cli.clean(project)
+    assert_files_cleaned(project, [INSTANCE1, INSTANCE2], logs=logs)
+    assert_files_exists(project, stateboard=True)
+
+    # w/ stateboard
+    create_instances_files(project, [INSTANCE1, INSTANCE2])
+    logs = cli.clean(project, stateboard=True)
+    assert_files_cleaned(project, [INSTANCE1, INSTANCE2], stateboard=True, logs=logs)
+
+    # stateboard-only
+    create_instances_files(project, [INSTANCE1, INSTANCE2])
+    logs = cli.clean(project, stateboard_only=True)
+    assert_files_cleaned(project,  stateboard=True, logs=logs)
+    assert_files_exists(project, [INSTANCE1, INSTANCE2])
+
+
+def test_clean_cfg(start_stop_cli, project_with_patched_init):
+    project = project_with_patched_init
+    cli = start_stop_cli
+
+    INSTANCE1 = 'instance-1'
+    INSTANCE2 = 'instance-2'
+
+    cfg = 'my-conf.yml'
+
+    write_conf(os.path.join(project.path, cfg), {
+        get_instance_id(project.name, INSTANCE1): {},
+        get_instance_id(project.name, INSTANCE2): {},
+    })
+
+    # --cfg
+    create_instances_files(project, [INSTANCE1, INSTANCE2])
+    logs = cli.clean(project, stateboard=True, cfg=cfg)
+    assert_files_cleaned(project, [INSTANCE1, INSTANCE2], stateboard=True, logs=logs)
+
+
+def test_clean_by_name_with_paths(start_stop_cli, project_with_patched_init):
+    project = project_with_patched_init
+    cli = start_stop_cli
+
+    INSTANCE1 = 'instance-1'
+    INSTANCE2 = 'instance-2'
+
+    # --log-dir
+    log_dir = 'my-log'
+    create_instances_files(project, [INSTANCE1, INSTANCE2], log_dir=log_dir)
+    logs = cli.clean(project, [INSTANCE1], stateboard=True, log_dir=log_dir)
+    assert_files_cleaned(project, [INSTANCE1],  stateboard=True, log_dir=log_dir, logs=logs)
+    assert_files_exists(project, [INSTANCE2], log_dir=log_dir)
+
+    # --run-dir
+    run_dir = 'my-run'
+    create_instances_files(project, [INSTANCE1, INSTANCE2], run_dir=run_dir)
+    logs = cli.clean(project, [INSTANCE1], stateboard=True, run_dir=run_dir)
+    assert_files_cleaned(project, [INSTANCE1],  stateboard=True, run_dir=run_dir, logs=logs)
+    assert_files_exists(project, [INSTANCE2], run_dir=run_dir)
+
+    # --data-dir
+    data_dir = 'my-data'
+    create_instances_files(project, [INSTANCE1, INSTANCE2], data_dir=data_dir)
+    logs = cli.clean(project, [INSTANCE1], stateboard=True, data_dir=data_dir)
+    assert_files_cleaned(project, [INSTANCE1],  stateboard=True, data_dir=data_dir, logs=logs)
+    assert_files_exists(project, [INSTANCE2], data_dir=data_dir)
+
+
+def test_clean_by_name_with_paths_from_conf(start_stop_cli, project_with_patched_init):
+    project = project_with_patched_init
+    cli = start_stop_cli
+
+    INSTANCE1 = 'instance-1'
+    INSTANCE2 = 'instance-2'
+
+    # --log-dir
+    log_dir = 'my-log'
+    write_conf(os.path.join(project.path, CARTRIDGE_CONF), {
+        'log-dir': log_dir,
+    })
+    create_instances_files(project, [INSTANCE1, INSTANCE2], log_dir=log_dir)
+    logs = cli.clean(project, [INSTANCE1], stateboard=True)
+    assert_files_cleaned(project, [INSTANCE1],  stateboard=True, log_dir=log_dir, logs=logs)
+    assert_files_exists(project, [INSTANCE2], log_dir=log_dir)
+
+    # --run-dir
+    run_dir = 'my-run'
+    write_conf(os.path.join(project.path, CARTRIDGE_CONF), {
+        'run-dir': run_dir,
+    })
+    create_instances_files(project, [INSTANCE1, INSTANCE2], run_dir=run_dir)
+    logs = cli.clean(project, [INSTANCE1], stateboard=True)
+    assert_files_cleaned(project, [INSTANCE1],  stateboard=True, run_dir=run_dir, logs=logs)
+    assert_files_exists(project, [INSTANCE2], run_dir=run_dir)
+
+    # --data-dir
+    data_dir = 'my-data'
+    write_conf(os.path.join(project.path, CARTRIDGE_CONF), {
+        'data-dir': data_dir,
+    })
+    create_instances_files(project, [INSTANCE1, INSTANCE2], data_dir=data_dir)
+    logs = cli.clean(project, [INSTANCE1], stateboard=True)
+    assert_files_cleaned(project, [INSTANCE1],  stateboard=True, data_dir=data_dir, logs=logs)
+    assert_files_exists(project, [INSTANCE2], data_dir=data_dir)
+
+
+def test_skipped(start_stop_cli, project_with_patched_init):
+    project = project_with_patched_init
+    cli = start_stop_cli
+
+    INSTANCE1 = 'instance-1'
+    INSTANCE2 = 'instance-2'
+
+    # clean once
+    create_instances_files(project, [INSTANCE1, INSTANCE2])
+    logs = cli.clean(project, [INSTANCE1, INSTANCE2])
+    assert_files_cleaned(project, [INSTANCE1, INSTANCE2], logs=logs)
+    assert_files_exists(project, [], stateboard=True)
+
+    # clean again
+    logs = cli.clean(project, [INSTANCE1, INSTANCE2])
+    assert_files_cleaned(project, [INSTANCE1, INSTANCE2], logs=logs, exp_res_log='SKIPPED')
+    assert_files_exists(project, [], stateboard=True)

--- a/test/utils.py
+++ b/test/utils.py
@@ -278,6 +278,38 @@ class Cli():
 
         return logs
 
+    def clean(self, project, instances=[], log_dir=None, run_dir=None, cfg=None, data_dir=None,
+              stateboard=False, stateboard_only=False):
+        cmd = [self._cartridge_cmd, 'clean']
+        if stateboard:
+            cmd.append('--stateboard')
+        if stateboard_only:
+            cmd.append('--stateboard-only')
+        if cfg is not None:
+            cmd.extend(['--cfg', cfg])
+        if run_dir is not None:
+            cmd.extend(['--run-dir', run_dir])
+        if data_dir is not None:
+            cmd.extend(['--data-dir', data_dir])
+        if log_dir is not None:
+            cmd.extend(['--log-dir', log_dir])
+
+        cmd.extend(instances)
+
+        process = subprocess.Popen(
+            cmd, cwd=project.path,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+
+        process.wait(timeout=10)
+        assert process.returncode == 0
+
+        output = process.stdout.read().decode('utf-8')
+        logs = get_logs(output)
+
+        return logs
+
     def get_child_instances(self, project, run_dir=DEFAULT_RUN_DIR):
         instances = dict()
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -279,12 +279,14 @@ class Cli():
         return logs
 
     def clean(self, project, instances=[], log_dir=None, run_dir=None, cfg=None, data_dir=None,
-              stateboard=False, stateboard_only=False):
+              stateboard=False, stateboard_only=False, force=False, exp_rc=0):
         cmd = [self._cartridge_cmd, 'clean']
         if stateboard:
             cmd.append('--stateboard')
         if stateboard_only:
             cmd.append('--stateboard-only')
+        if force:
+            cmd.append('--force')
         if cfg is not None:
             cmd.extend(['--cfg', cfg])
         if run_dir is not None:
@@ -303,7 +305,7 @@ class Cli():
         )
 
         process.wait(timeout=10)
-        assert process.returncode == 0
+        assert process.returncode == exp_rc
 
         output = process.stdout.read().decode('utf-8')
         logs = get_logs(output)

--- a/test/utils.py
+++ b/test/utils.py
@@ -279,14 +279,12 @@ class Cli():
         return logs
 
     def clean(self, project, instances=[], log_dir=None, run_dir=None, cfg=None, data_dir=None,
-              stateboard=False, stateboard_only=False, force=False, exp_rc=0):
+              stateboard=False, stateboard_only=False, exp_rc=0):
         cmd = [self._cartridge_cmd, 'clean']
         if stateboard:
             cmd.append('--stateboard')
         if stateboard_only:
             cmd.append('--stateboard-only')
-        if force:
-            cmd.append('--force')
         if cfg is not None:
             cmd.extend(['--cfg', cfg])
         if run_dir is not None:


### PR DESCRIPTION
Sometimes we want to cleanup all instances files (working directories, logs, sockets).
We introduce `cartridge clean` command to do it easily.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Closes #316 
