### PR TITLE
Support custom templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- `--force` option for `start` command to send SIGKILL to instances
+- `--force` option for `stop` command to send SIGKILL to instances
 - `cartridge clean` command to remove instance(s) files
+- `--from` option for `create` command to use custom application templates
 
 ## [2.1.0] - 2020-07-17
 

--- a/README.rst
+++ b/README.rst
@@ -193,7 +193,7 @@ The following options (``[flags]``) are supported:
 * ``--from DIR`` is a path to the application template (see details below).
 
 * ``--template string`` is a name of application template to be used.
-  Now only ``cartridge`` template is supported.
+  Currently only ``cartridge`` template is supported.
 
 Application is created in the ``<path>/<app-name>/`` directory.
 

--- a/README.rst
+++ b/README.rst
@@ -262,11 +262,21 @@ Let's take a closer look at the files inside the ``<app_name>/`` directory:
   * ``.luacov``
   * ``.editorconfig``
 
-You can create your own application template and use it with ``cartridge create``.
+You can create your own application template and use it with ``cartridge create``
+with ``--from`` flag.
+
+If template directory is a git repository, the `.git/` files would be ignored on
+instantiating template.
+In the created application a new git repo is initialized.
+
+Template application shouldn't contain `.rocks` directory.
+To specify application dependencies use rockspec and `cartridge.pre-build` files.
+
 Filenames and content can contain `text templates <Templates_>`_.
 
 .. _Templates: https://golang.org/pkg/text/template/
 
+Available variables are:
 
 * ``Name`` — the application name;
 * ``StateboardName`` — the application stateboard name (``<app-name>-stateboard``);

--- a/README.rst
+++ b/README.rst
@@ -182,10 +182,23 @@ To create an application from the Cartridge template, say this in any directory:
 
 .. code-block:: bash
 
-    cartridge create --name <app_name> /path/to/
+    cartridge create [PATH] [flags]
 
-This will create a simple Cartridge application in the ``/path/to/<app_name>/``
-directory with:
+The following options (``[flags]``) are supported:
+
+.. // Please, update the doc in cli/commands on updating this section
+
+* ``--name strin`` is an application name.
+
+* ``--from DIR`` is a path to the application template (see details below).
+
+* ``--template string`` is a name of application template to be used.
+  Now only ``cartridge`` template is supported.
+
+Application is created in the ``<path>/<app-name>/`` directory.
+
+By default, ``cartridge`` template is used.
+It contains a simple Cartridge application with:
 
 * one custom role with an HTTP endpoint;
 * sample tests and basic test helpers;
@@ -248,6 +261,34 @@ Let's take a closer look at the files inside the ``<app_name>/`` directory:
   * ``.luacheckrc``
   * ``.luacov``
   * ``.editorconfig``
+
+You can create your own application template and use it with ``cartridge create``.
+Filenames and content can contain `text templates <Templates_>`_.
+
+.. _Templates: https://golang.org/pkg/text/template/
+
+
+* ``Name`` — the application name;
+* ``StateboardName`` — the application stateboard name (``<app-name>-stateboard``);
+* ``Path`` - an absolute path to the application.
+
+For example:
+
+.. code-block:: text
+
+    my-template
+    ├── {{ .Name }}-scm-1.rockspec
+    └── init.lua
+    └── stateboard.init.lua
+    └── test
+        └── sample_test.lua
+
+``init.lua``:
+
+.. code-block:: lua
+
+    print("Hi, I am {{ .Name }} application")
+    print("I also have a stateboard named {{ .StateboardName }}")
 
 .. _cartridge-cli-building-an-application:
 

--- a/cli/commands/create.go
+++ b/cli/commands/create.go
@@ -33,12 +33,8 @@ func init() {
 	configureFlags(createCmd)
 
 	createCmd.Flags().StringVar(&ctx.Project.Name, "name", "", createNameUsage)
-	createCmd.Flags().StringVar(
-		&ctx.Project.Template,
-		"template",
-		templates.CartridgeTemplateName,
-		templateUsage,
-	)
+	createCmd.Flags().StringVar(&ctx.Create.From, "from", "", createFromUsage)
+	createCmd.Flags().StringVar(&ctx.Create.Template, "template", "", templateUsage)
 }
 
 func runCreateCommand(cmd *cobra.Command, args []string) error {
@@ -54,6 +50,14 @@ func runCreateCommand(cmd *cobra.Command, args []string) error {
 	ctx.Project.Path, err = getNewProjectPath(basePath)
 	if err != nil {
 		return err
+	}
+
+	if ctx.Create.Template != "" && ctx.Create.From != "" {
+		return fmt.Errorf("You can specify only one of --from and --template options")
+	}
+
+	if ctx.Create.Template == "" && ctx.Create.From == "" {
+		ctx.Create.Template = templates.CartridgeTemplateName
 	}
 
 	// fill context

--- a/cli/commands/usage.go
+++ b/cli/commands/usage.go
@@ -5,7 +5,8 @@ import "fmt"
 // CREATE
 const (
 	createNameUsage = `Application name`
-	templateUsage   = `Application template`
+	templateUsage   = `Application template name (cartridge)`
+	createFromUsage = `Path to the application template`
 )
 
 // COMMON
@@ -133,9 +134,6 @@ If specified, "INSTANCE_NAME..." are ignored.
 `
 
 	stopForceUsage = `Force instance(s) stop (sends SIGKILL)
-`
-
-	createFromUsage = `Path to the application template
 `
 )
 

--- a/cli/commands/usage.go
+++ b/cli/commands/usage.go
@@ -134,6 +134,9 @@ If specified, "INSTANCE_NAME..." are ignored.
 
 	stopForceUsage = `Force instance(s) stop (sends SIGKILL)
 `
+
+	createFromUsage = `Path to the application template
+`
 )
 
 var (

--- a/cli/context/context.go
+++ b/cli/context/context.go
@@ -4,6 +4,7 @@ import "time"
 
 type Ctx struct {
 	Project   ProjectCtx
+	Create    CreateCtx
 	Build     BuildCtx
 	Running   RunningCtx
 	Pack      PackCtx
@@ -16,7 +17,11 @@ type ProjectCtx struct {
 	Name           string
 	StateboardName string
 	Path           string
-	Template       string
+}
+
+type CreateCtx struct {
+	Template string
+	From     string
 }
 
 type BuildCtx struct {

--- a/cli/create/create.go
+++ b/cli/create/create.go
@@ -70,8 +70,8 @@ func checkCtx(ctx *context.Ctx) error {
 		return fmt.Errorf("Path is missed")
 	}
 
-	if ctx.Project.Template == "" {
-		return fmt.Errorf("Template is missed")
+	if ctx.Create.Template == "" && ctx.Create.From == "" {
+		return fmt.Errorf("Template name or path is missed")
 	}
 
 	return nil

--- a/cli/create/templates/templates.go
+++ b/cli/create/templates/templates.go
@@ -62,8 +62,10 @@ func Instantiate(ctx *context.Ctx) error {
 }
 
 func parseTemplate(from string) (*templates.FileTreeTemplate, error) {
-	if _, err := os.Stat(from); err != nil {
+	if fileInfo, err := os.Stat(from); err != nil {
 		return nil, fmt.Errorf("Failed to use specified path: %s", err)
+	} else if !fileInfo.IsDir() {
+		return nil, fmt.Errorf("Specified path is not a directory: %s", from)
 	}
 
 	var tmpl templates.FileTreeTemplate

--- a/test/integration/test_create.py
+++ b/test/integration/test_create.py
@@ -63,6 +63,23 @@ def test_both_template_and_from_specified(cartridge_cmd, tmpdir):
     assert "You can specify only one of --from and --template options" in output
 
 
+def test_from_is_not_a_directory(cartridge_cmd, tmpdir):
+    filepath = os.path.join(tmpdir, 'template-file')
+    with open(filepath, 'w') as f:
+        f.write('{{ .Name }}\n')
+
+    cmd = [
+        cartridge_cmd, "create",
+        "--name", "myapp",
+        "--from", filepath,
+        tmpdir,
+    ]
+
+    rc, output = run_command_and_get_output(cmd)
+    assert rc == 1
+    assert "Specified path is not a directory" in output
+
+
 @pytest.fixture
 def app_template(tmpdir):
     template_dir = os.path.join(tmpdir, 'simple-app-template')

--- a/test/integration/test_create.py
+++ b/test/integration/test_create.py
@@ -1,9 +1,11 @@
 import subprocess
 import pytest
 import os
+import stat
 
 from project import Project
 from utils import run_command_and_get_output
+from utils import recursive_listdir
 
 
 @pytest.fixture(scope="module")
@@ -45,3 +47,139 @@ def test_project_recreation(cartridge_cmd, default_project):
 
     # check that project directory wasn't deleted
     assert os.path.exists(project.path)
+
+
+def test_both_template_and_from_specified(cartridge_cmd, tmpdir):
+    cmd = [
+        cartridge_cmd, "create",
+        "--name", "myapp",
+        "--template", "cartridge",
+        "--from", "path/to",
+        tmpdir,
+    ]
+
+    rc, output = run_command_and_get_output(cmd)
+    assert rc == 1
+    assert "You can specify only one of --from and --template options" in output
+
+
+@pytest.fixture
+def app_template(tmpdir):
+    template_dir = os.path.join(tmpdir, 'simple-app-template')
+    os.makedirs(template_dir)
+
+    template_files = {
+        'init.lua': {
+            'mode': 0o755,
+            'content': '''#!/usr/bin/env tarantool
+print('Hi, I am {{ .Name }} app entry point.')
+print('I also have stateboard instance named {{ .StateboardName }}')
+''',
+        },
+        '{{ .Name }}-scm-1.rockspec': {
+            'mode': 0o644,
+            'content': '''package = '{{ .Name }}'
+version = 'scm-1'
+source  = {
+    url = '/dev/null',
+}
+-- Put any modules your app depends on here
+dependencies = {
+    'tarantool',
+    'lua >= 5.1',
+    'checks == 3.0.1-1',
+    'cartridge == 2.2.0-1',
+    'metrics == 0.3.0-1',
+}
+build = {
+    type = 'none';
+}
+'''
+        },
+        '.luacheckrc': {
+            'mode': 0o644,
+            'content': "include_files = {'**/*.lua', '*.luacheckrc', '*.rockspec'}\n"
+        },
+        'test': {
+            'mode': 0o755,
+        },
+        'test/helper': {
+            'mode': 0o755,
+        },
+        'test/helper/integration.lua': {
+            'mode': 0o644,
+            'content': '''local t = require('luatest')
+
+local cartridge_helpers = require('cartridge.test-helpers')
+local shared = require('test.helper')
+
+local helper = {shared = shared}
+'''
+        },
+    }
+
+    for filepath, fileinfo in template_files.items():
+        fullpath = os.path.join(template_dir, filepath)
+        dirname = os.path.dirname(fullpath)
+
+        if not os.path.exists(dirname):
+            os.makedirs(dirname)
+
+        if fileinfo.get('content') is not None:
+            with open(fullpath, 'w') as f:
+                f.write(fileinfo['content'])
+        else:
+            os.makedirs(fullpath)
+
+        os.chmod(fullpath, fileinfo['mode'])
+
+    return {
+        'path': template_dir,
+        'files': template_files,
+    }
+
+
+def test_from(cartridge_cmd, app_template, tmpdir):
+    APPNAME = "myapp"
+
+    cmd = [
+        cartridge_cmd, "create",
+        "--from", app_template['path'],
+        "--name", APPNAME,
+        tmpdir,
+    ]
+
+    rc, output = run_command_and_get_output(cmd)
+    assert rc == 0
+
+    app_path = os.path.join(tmpdir, APPNAME)
+
+    files = recursive_listdir(app_path)
+    files = {f for f in files if not f.startswith('.git')}
+
+    def subst(s):
+        return s.replace('{{ .Name }}', APPNAME).replace('{{ .StateboardName }}', '%s-stateboard' % APPNAME)
+
+    exp_files = {}
+    for filepath, fileinfo in app_template['files'].items():
+        exp_files.update({
+            subst(filepath): {
+                'mode': fileinfo['mode'],
+                'content': subst(fileinfo['content']) if fileinfo.get('content') is not None else None,
+            }
+        })
+
+    assert set(exp_files.keys()) == files
+
+    for filepath, fileinfo in exp_files.items():
+        created_file_path = os.path.join(app_path, filepath)
+        created_file_mode = os.stat(created_file_path)[stat.ST_MODE] & 0o777
+        assert created_file_mode == fileinfo['mode']
+
+        if fileinfo.get('content') is None:
+            continue
+
+        with open(created_file_path, 'r') as f:
+            created_file_content = f.read()
+
+        assert created_file_content == fileinfo['content']


### PR DESCRIPTION
We need an opportunity to create application using custom templates.
This patch introduces `--from` option for `start` command to specify custom template path.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Closes #321 
