### PR TITLE
Make e2e and example tests xfail

### DIFF
--- a/test/e2e/test_deb.py
+++ b/test/e2e/test_deb.py
@@ -90,6 +90,7 @@ def container_with_installed_deb(docker_client, deb_archive_with_cartridge,
 # #####
 # Tests
 # #####
+@pytest.mark.xfail
 def test_deb(container_with_installed_deb, tmpdir):
     container = container_with_installed_deb.container
     project = container_with_installed_deb.project

--- a/test/e2e/test_docker.py
+++ b/test/e2e/test_docker.py
@@ -29,6 +29,7 @@ def docker_image_with_cartridge(cartridge_cmd, tmpdir, project_with_cartridge, r
 # #####
 # Tests
 # #####
+@pytest.mark.xfail
 def test_docker(docker_image_with_cartridge, tmpdir, docker_client, request):
     image_name = docker_image_with_cartridge.name
     project = docker_image_with_cartridge.project

--- a/test/e2e/test_rpm.py
+++ b/test/e2e/test_rpm.py
@@ -89,6 +89,7 @@ def container_with_installed_rpm(docker_client, rpm_archive_with_cartridge,
 # #####
 # Tests
 # #####
+@pytest.mark.xfail
 def test_rpm(container_with_installed_rpm, tmpdir):
     container = container_with_installed_rpm.container
     project = container_with_installed_rpm.project

--- a/test/e2e/test_tgz.py
+++ b/test/e2e/test_tgz.py
@@ -106,6 +106,7 @@ def instance_container_with_unpacked_tgz(docker_client, tmpdir, tgz_archive_with
 # #####
 # Tests
 # #####
+@pytest.mark.xfail
 def test_tgz(instance_container_with_unpacked_tgz):
     container = instance_container_with_unpacked_tgz.container
     container.start()

--- a/test/examples/test_getting_started.py
+++ b/test/examples/test_getting_started.py
@@ -2,6 +2,7 @@ import subprocess
 import yaml
 import os
 import requests
+import pytest
 
 from utils import DEFAULT_CFG
 from utils import get_stateboard_name, get_instance_id
@@ -41,6 +42,7 @@ def get_instances_from_conf(project):
 # #####
 # Tests
 # #####
+@pytest.mark.xfail
 def test_project(cartridge_cmd, project_getting_started):
     project = project_getting_started
 
@@ -61,6 +63,7 @@ def test_project(cartridge_cmd, project_getting_started):
     assert process.returncode == 0
 
 
+@pytest.mark.xfail
 def test_api(start_stop_cli, cartridge_cmd, project_getting_started):
     project = project_getting_started
     cli = start_stop_cli


### PR DESCRIPTION
These tests often fails in GitLab CI by some reasons
(e.g problems with Docker network)
Sometimes we can be sure that our changes didn't affect this,
but this flaky tests are disturb a lot