### PR TITLE
Start instance process in the application directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Now instance process is ran from the application directory
+
 ## [2.2.0] - 2020-08-12
 
 ### Added

--- a/cli/running/process.go
+++ b/cli/running/process.go
@@ -176,7 +176,6 @@ func (process *Process) Start(daemonize bool) error {
 	process.cmd = exec.CommandContext(ctx, "tarantool", process.entrypoint)
 
 	process.cmd.Env = append(os.Environ(), process.env...)
-	process.cmd.Dir = process.workDir
 
 	// initialize logs writer
 	if !daemonize {

--- a/test/utils.py
+++ b/test/utils.py
@@ -84,6 +84,7 @@ class InstanceProcess():
 
         self.name = self._process.name()
         self.cmd = self._process.cmdline()
+        self.cwd = self._process.cwd()
 
         env = self._process.environ()
         self._env = {
@@ -656,6 +657,7 @@ def check_running_instance(child_instances, app_path, app_name, instance_id,
     instance = child_instances[instance_id]
 
     assert instance.is_running()
+    assert instance.cwd == app_path
 
     assert instance.cmd == ["tarantool", os.path.join(app_path, script)]
 


### PR DESCRIPTION
If instance process is started in the working directory instead of application directory, it can't require rocks modules without `setsearchroot`. Moreover, code changes aren't applied without `cartridge build`, and it's important for local development.

