### PR TITLE
Repair: Fix fail on non bootstrapped instance

### DIFF
--- a/cli/repair/app_configs.go
+++ b/cli/repair/app_configs.go
@@ -31,6 +31,11 @@ func getAppConfigs(instanceNames []string, ctx *context.Ctx) (AppConfigs, error)
 		if err != nil {
 			return appConfigs, fmt.Errorf("Failed to get cluster-wide config path: %s", err)
 		}
+
+		if topologyConfPath == "" {
+			continue
+		}
+
 		appConfigs.confPathByInstanceID[instanceName] = topologyConfPath
 
 		if _, err := os.Stat(topologyConfPath); err != nil {
@@ -50,6 +55,10 @@ func getAppConfigs(instanceNames []string, ctx *context.Ctx) (AppConfigs, error)
 			}
 		}
 
+	}
+
+	if len(appConfigs.confByHash) == 0 {
+		return appConfigs, fmt.Errorf("No cluster-wide configs found in %s", ctx.Running.DataDir)
 	}
 
 	for _, instanceIDs := range appConfigs.instancesByHash {

--- a/cli/repair/app_configs.go
+++ b/cli/repair/app_configs.go
@@ -32,6 +32,8 @@ func getAppConfigs(instanceNames []string, ctx *context.Ctx) (AppConfigs, error)
 			return appConfigs, fmt.Errorf("Failed to get cluster-wide config path: %s", err)
 		}
 
+		// if topology config file wasn't found, instance isn't bootstrapped yet,
+		// and we just skip it
 		if topologyConfPath == "" {
 			continue
 		}

--- a/test/clusterwide_conf.py
+++ b/test/clusterwide_conf.py
@@ -67,13 +67,13 @@ def write_instances_topology_conf(data_dir, app_name, conf, instances, one_file=
 
     for instance in instances:
         work_dir = os.path.join(data_dir, '%s.%s' % (app_name, instance))
-        os.makedirs(work_dir)
+        os.makedirs(work_dir, exist_ok=True)
 
         if one_file:
             conf_path = os.path.join(work_dir, 'config.yml')
         else:
             conf_dir = os.path.join(work_dir, 'config')
-            os.makedirs(conf_dir)
+            os.makedirs(conf_dir, exist_ok=True)
 
             conf_path = os.path.join(conf_dir, 'topology.yml')
 

--- a/test/integration/test_repair.py
+++ b/test/integration/test_repair.py
@@ -3,6 +3,7 @@ import re
 import pytest
 
 from utils import run_command_and_get_output
+from utils import get_logs
 
 from clusterwide_conf import write_instances_topology_conf
 
@@ -96,3 +97,59 @@ def test_repiar_no_workdirs(cartridge_cmd, clusterwide_conf_simple, repair_cmd, 
     rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
     assert rc == 1
     assert "No instance working directories found in %s" % data_dir in output
+
+
+@pytest.mark.parametrize('repair_cmd', ['set-uri', 'remove-instance', 'set-leader'])
+def test_non_bootstrapped_instance(cartridge_cmd, clusterwide_conf_simple, repair_cmd, tmpdir):
+    data_dir = os.path.join(tmpdir, 'tmp', 'data')
+    os.makedirs(data_dir)
+
+    config = clusterwide_conf_simple
+
+    if repair_cmd == 'set-uri':
+        args = [config.instance_uuid, config.instance_uri]
+    elif repair_cmd == 'remove-instance':
+        args = [config.instance_uuid]
+    elif repair_cmd == 'set-leader':
+        args = [config.replicaset_uuid, config.instance_uuid]
+
+    cmd = [
+        cartridge_cmd, 'repair', repair_cmd,
+        '--name', APPNAME,
+        '--data-dir', data_dir,
+    ]
+    cmd.extend(args)
+
+    instances = ['instance-1', 'instance-2']
+
+    # no cluster-wide configs
+
+    # # create empty work dirs for instance-2
+    for instance in instances:
+        work_dir = os.path.join(data_dir, '%s.%s' % (APPNAME, instance))
+        os.makedirs(work_dir)
+
+    rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
+    assert rc == 1
+    assert "No cluster-wide configs found in %s" % data_dir in output
+
+    # write config for instance-1
+    write_instances_topology_conf(data_dir, APPNAME, clusterwide_conf_simple.conf, instances[:1])
+
+    rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
+    assert rc == 0
+
+    if repair_cmd == 'set-uri':
+        first_log_line = "Set %s advertise URI to %s" % (args[0], args[1])
+    elif repair_cmd == 'remove-instance':
+        first_log_line = "Remove instance with UUID %s" % args[0]
+    elif repair_cmd == 'set-leader':
+        first_log_line = "Set %s leader to %s" % (args[0], args[1])
+
+    logs = get_logs(output)
+    assert len(logs) == 5
+    assert logs[0] == first_log_line
+    assert logs[1] == "Process application cluster-wide configurations..."
+    assert logs[2] == "%s... OK" % instances[0]
+    assert logs[3] == "Write application cluster-wide configurations..."
+    assert logs[4] == "%s... OK" % instances[0]


### PR DESCRIPTION
 When instance is started, but not bootstrapped yet, data directory exists, but cluster-wide configuration don't.
It's a valid case, so it shouldn't cause any error (only if there is no one bootstrapped instance).

I didn't forget about

- [x] Tests
- [ ] Changelog
- [ ] Documentation

