### PR TITLE
Refactor test projects files

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -73,6 +73,8 @@ prebuild-releaser:
 
     - export CARTRIDGE_TEMPDIR=`pwd`
 
+    - tarantoolctl rocks install luacheck
+
     - mage lint
     - mage unit
     - mage integration

--- a/magefile.go
+++ b/magefile.go
@@ -102,6 +102,11 @@ func Lint() error {
 		return err
 	}
 
+	fmt.Println("Running luacheck for test projects files...")
+	if err := sh.RunV(".rocks/bin/luacheck", "test/files"); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -11,7 +11,7 @@ from project import Project
 from project import remove_dependency
 from project import add_dependency_submodule
 from project import remove_all_dependencies
-from project import rewrite_project_file
+from project import replace_project_file
 
 from clusterwide_conf import ClusterwideConfig
 from clusterwide_conf import get_srv_conf, get_expelled_srv_conf
@@ -141,8 +141,8 @@ def project_without_dependencies(cartridge_cmd, short_tmpdir):
 
     remove_all_dependencies(project)
 
-    rewrite_project_file(project, 'init.lua', INIT_NO_CARTRIDGE_FILEPATH)
-    rewrite_project_file(project, 'stateboard.init.lua', INIT_NO_CARTRIDGE_FILEPATH)
+    replace_project_file(project, 'init.lua', INIT_NO_CARTRIDGE_FILEPATH)
+    replace_project_file(project, 'stateboard.init.lua', INIT_NO_CARTRIDGE_FILEPATH)
 
     return project
 
@@ -182,8 +182,8 @@ def project_ignore_sigterm(cartridge_cmd, short_tmpdir):
 
     remove_all_dependencies(project)
 
-    rewrite_project_file(project, 'init.lua', INIT_IGNORE_SIGTERM_FILEPATH)
-    rewrite_project_file(project, 'stateboard.init.lua', INIT_IGNORE_SIGTERM_FILEPATH)
+    replace_project_file(project, 'init.lua', INIT_IGNORE_SIGTERM_FILEPATH)
+    replace_project_file(project, 'stateboard.init.lua', INIT_IGNORE_SIGTERM_FILEPATH)
 
     return project
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -11,6 +11,7 @@ from project import Project
 from project import remove_dependency
 from project import add_dependency_submodule
 from project import remove_all_dependencies
+from project import rewrite_project_file
 
 from clusterwide_conf import ClusterwideConfig
 from clusterwide_conf import get_srv_conf, get_expelled_srv_conf
@@ -18,6 +19,11 @@ from clusterwide_conf import get_rpl_conf
 from clusterwide_conf import get_topology_conf, get_one_file_conf
 
 from utils import Cli
+
+
+FILES_DIR = 'test/files'
+INIT_NO_CARTRIDGE_FILEPATH = os.path.join(FILES_DIR, 'init_no_cartridge.lua')
+INIT_IGNORE_SIGTERM_FILEPATH = os.path.join(FILES_DIR, 'init_ignore_sigterm.lua')
 
 
 # ########
@@ -105,7 +111,6 @@ def light_project(cartridge_cmd, tmpdir):
     project = Project(cartridge_cmd, 'light-project', tmpdir, 'cartridge')
 
     remove_dependency(project, 'cartridge')
-    remove_dependency(project, 'luatest')
 
     add_dependency_submodule(project)
 
@@ -118,7 +123,6 @@ def light_project(cartridge_cmd, tmpdir):
 @pytest.fixture(scope="function")
 def project_with_cartridge(cartridge_cmd, short_tmpdir):
     project = Project(cartridge_cmd, 'project-with-cartridge', short_tmpdir, 'cartridge')
-    remove_dependency(project, 'luatest')
 
     add_dependency_submodule(project)
 
@@ -128,54 +132,17 @@ def project_with_cartridge(cartridge_cmd, short_tmpdir):
 ##############################
 # Project without dependencies
 ##############################
+# This project is used in the `pack` and `running` tests
+# It allows to build project faster and start an application
+# that entering event loop and sends READY=q to notify socket
 @pytest.fixture(scope="function")
-def project_without_dependencies(cartridge_cmd, tmpdir):
-    project = Project(cartridge_cmd, 'empty-project', tmpdir, 'cartridge')
-
-    remove_all_dependencies(project)
-    return project
-
-
-#######################################################
-# Project with patched init.lua and stateboard.init.lua
-#######################################################
-# This project is used in the `running` tests
-# It doesn't require cartridge, but sends READY=1 signal
-# in old Tarantool versions just like `cartridge.cfg` does
-# It creates a simple fiber to start an event loop
-@pytest.fixture(scope="function")
-def project_with_patched_init(cartridge_cmd, short_tmpdir):
-    project = Project(cartridge_cmd, 'patched-project', short_tmpdir, 'cartridge')
+def project_without_dependencies(cartridge_cmd, short_tmpdir):
+    project = Project(cartridge_cmd, 'empty-project', short_tmpdir, 'cartridge')
 
     remove_all_dependencies(project)
 
-    patched_init = '''#!/usr/bin/env tarantool
-local fiber = require('fiber')
-fiber.create(function()
-    fiber.sleep(1)
-end)
-
-require('log').info('I am starting...')
-
--- Copied from cartridge.cfg to provide support for NOTIFY_SOCKET in old tarantool
-local tnt_version = string.split(_TARANTOOL, '.')
-local tnt_major = tonumber(tnt_version[1])
-local tnt_minor = tonumber(tnt_version[2])
-if tnt_major < 2 or (tnt_major == 2 and tnt_minor < 2) then
-  local notify_socket = os.getenv('NOTIFY_SOCKET')
-  if notify_socket then
-      local socket = require('socket')
-      local sock = assert(socket('AF_UNIX', 'SOCK_DGRAM', 0), 'Can not create socket')
-      sock:sendto('unix/', notify_socket, 'READY=1')
-  end
-end
-'''
-
-    with open(os.path.join(project.path, 'init.lua'), 'w') as f:
-        f.write(patched_init)
-
-    with open(os.path.join(project.path, 'stateboard.init.lua'), 'w') as f:
-        f.write(patched_init)
+    rewrite_project_file(project, 'init.lua', INIT_NO_CARTRIDGE_FILEPATH)
+    rewrite_project_file(project, 'stateboard.init.lua', INIT_NO_CARTRIDGE_FILEPATH)
 
     return project
 
@@ -215,43 +182,8 @@ def project_ignore_sigterm(cartridge_cmd, short_tmpdir):
 
     remove_all_dependencies(project)
 
-    patched_init = '''#!/usr/bin/env tarantool
-local fiber = require('fiber')
-fiber.create(function()
-    fiber.sleep(1)
-end)
-
-require('log').info('I am starting...')
-
--- ignore SIGTERM
-local ffi = require('ffi')
-local SIG_IGN = 1
-local SIGTERM = 15
-ffi.cdef[[
-    void (*signal(int sig, void (*func)(int)))(int);
-]]
-local ignore_handler = ffi.cast("void (*)(int)", SIG_IGN)
-ffi.C.signal(SIGTERM, ignore_handler)
-
--- Copied from cartridge.cfg to provide support for NOTIFY_SOCKET in old tarantool
-local tnt_version = string.split(_TARANTOOL, '.')
-local tnt_major = tonumber(tnt_version[1])
-local tnt_minor = tonumber(tnt_version[2])
-if tnt_major < 2 or (tnt_major == 2 and tnt_minor < 2) then
-  local notify_socket = os.getenv('NOTIFY_SOCKET')
-  if notify_socket then
-      local socket = require('socket')
-      local sock = assert(socket('AF_UNIX', 'SOCK_DGRAM', 0), 'Can not create socket')
-      sock:sendto('unix/', notify_socket, 'READY=1')
-  end
-end
-'''
-
-    with open(os.path.join(project.path, 'init.lua'), 'w') as f:
-        f.write(patched_init)
-
-    with open(os.path.join(project.path, 'stateboard.init.lua'), 'w') as f:
-        f.write(patched_init)
+    rewrite_project_file(project, 'init.lua', INIT_IGNORE_SIGTERM_FILEPATH)
+    rewrite_project_file(project, 'stateboard.init.lua', INIT_IGNORE_SIGTERM_FILEPATH)
 
     return project
 

--- a/test/files/init_ignore_sigterm.lua
+++ b/test/files/init_ignore_sigterm.lua
@@ -1,0 +1,29 @@
+local fiber = require('fiber')
+fiber.create(function()
+    fiber.sleep(1)
+end)
+
+require('log').info('I am starting...')
+
+-- ignore SIGTERM
+local ffi = require('ffi')
+local SIG_IGN = 1
+local SIGTERM = 15
+ffi.cdef[[
+    void (*signal(int sig, void (*func)(int)))(int);
+]]
+local ignore_handler = ffi.cast("void (*)(int)", SIG_IGN)
+ffi.C.signal(SIGTERM, ignore_handler)
+
+-- Copied from cartridge.cfg to provide support for NOTIFY_SOCKET in old tarantool
+local tnt_version = string.split(_TARANTOOL, '.')
+local tnt_major = tonumber(tnt_version[1])
+local tnt_minor = tonumber(tnt_version[2])
+if tnt_major < 2 or (tnt_major == 2 and tnt_minor < 2) then
+  local notify_socket = os.getenv('NOTIFY_SOCKET')
+  if notify_socket then
+      local socket = require('socket')
+      local sock = assert(socket('AF_UNIX', 'SOCK_DGRAM', 0), 'Can not create socket')
+      sock:sendto('unix/', notify_socket, 'READY=1')
+  end
+end

--- a/test/files/init_ignore_sigterm.lua
+++ b/test/files/init_ignore_sigterm.lua
@@ -20,10 +20,10 @@ local tnt_version = string.split(_TARANTOOL, '.')
 local tnt_major = tonumber(tnt_version[1])
 local tnt_minor = tonumber(tnt_version[2])
 if tnt_major < 2 or (tnt_major == 2 and tnt_minor < 2) then
-  local notify_socket = os.getenv('NOTIFY_SOCKET')
-  if notify_socket then
-      local socket = require('socket')
-      local sock = assert(socket('AF_UNIX', 'SOCK_DGRAM', 0), 'Can not create socket')
-      sock:sendto('unix/', notify_socket, 'READY=1')
-  end
+    local notify_socket = os.getenv('NOTIFY_SOCKET')
+    if notify_socket then
+        local socket = require('socket')
+        local sock = assert(socket('AF_UNIX', 'SOCK_DGRAM', 0), 'Can not create socket')
+        sock:sendto('unix/', notify_socket, 'READY=1')
+    end
 end

--- a/test/files/init_no_cartridge.lua
+++ b/test/files/init_no_cartridge.lua
@@ -11,10 +11,10 @@ local tnt_version = string.split(_TARANTOOL, '.')
 local tnt_major = tonumber(tnt_version[1])
 local tnt_minor = tonumber(tnt_version[2])
 if tnt_major < 2 or (tnt_major == 2 and tnt_minor < 2) then
-  local notify_socket = os.getenv('NOTIFY_SOCKET')
-  if notify_socket then
-      local socket = require('socket')
-      local sock = assert(socket('AF_UNIX', 'SOCK_DGRAM', 0), 'Can not create socket')
-      sock:sendto('unix/', notify_socket, 'READY=1')
-  end
+    local notify_socket = os.getenv('NOTIFY_SOCKET')
+    if notify_socket then
+        local socket = require('socket')
+        local sock = assert(socket('AF_UNIX', 'SOCK_DGRAM', 0), 'Can not create socket')
+        sock:sendto('unix/', notify_socket, 'READY=1')
+    end
 end

--- a/test/files/init_no_cartridge.lua
+++ b/test/files/init_no_cartridge.lua
@@ -1,0 +1,20 @@
+local fiber = require('fiber')
+
+fiber.create(function()
+    fiber.sleep(1)
+end)
+
+require('log').info('I am starting...')
+
+-- Copied from cartridge.cfg to provide support for NOTIFY_SOCKET in old tarantool
+local tnt_version = string.split(_TARANTOOL, '.')
+local tnt_major = tonumber(tnt_version[1])
+local tnt_minor = tonumber(tnt_version[2])
+if tnt_major < 2 or (tnt_major == 2 and tnt_minor < 2) then
+  local notify_socket = os.getenv('NOTIFY_SOCKET')
+  if notify_socket then
+      local socket = require('socket')
+      local sock = assert(socket('AF_UNIX', 'SOCK_DGRAM', 0), 'Can not create socket')
+      sock:sendto('unix/', notify_socket, 'READY=1')
+  end
+end

--- a/test/integration/running/test_clean.py
+++ b/test/integration/running/test_clean.py
@@ -84,8 +84,8 @@ def assert_files_exists(project, instance_names=[], stateboard=False,
             assert os.path.exists(path)
 
 
-def test_clean_by_name(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_clean_by_name(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     INSTANCE1 = 'instance-1'
@@ -110,8 +110,8 @@ def test_clean_by_name(start_stop_cli, project_with_patched_init):
     assert_files_exists(project, [INSTANCE1, INSTANCE2])
 
 
-def test_clean_from_conf(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_clean_from_conf(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     INSTANCE1 = 'instance-1'
@@ -140,8 +140,8 @@ def test_clean_from_conf(start_stop_cli, project_with_patched_init):
     assert_files_exists(project, [INSTANCE1, INSTANCE2])
 
 
-def test_clean_cfg(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_clean_cfg(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     INSTANCE1 = 'instance-1'
@@ -160,8 +160,8 @@ def test_clean_cfg(start_stop_cli, project_with_patched_init):
     assert_files_cleaned(project, [INSTANCE1, INSTANCE2], stateboard=True, logs=logs)
 
 
-def test_clean_by_name_with_paths(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_clean_by_name_with_paths(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     INSTANCE1 = 'instance-1'
@@ -189,8 +189,8 @@ def test_clean_by_name_with_paths(start_stop_cli, project_with_patched_init):
     assert_files_exists(project, [INSTANCE2], data_dir=data_dir)
 
 
-def test_clean_by_name_with_paths_from_conf(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_clean_by_name_with_paths_from_conf(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     INSTANCE1 = 'instance-1'
@@ -227,8 +227,8 @@ def test_clean_by_name_with_paths_from_conf(start_stop_cli, project_with_patched
     assert_files_exists(project, [INSTANCE2], data_dir=data_dir)
 
 
-def test_skipped(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_skipped(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     INSTANCE1 = 'instance-1'
@@ -246,8 +246,8 @@ def test_skipped(start_stop_cli, project_with_patched_init):
     assert_files_exists(project, [], stateboard=True)
 
 
-def test_for_running(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_for_running(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     INSTANCE1 = 'instance-1'

--- a/test/integration/running/test_log.py
+++ b/test/integration/running/test_log.py
@@ -24,8 +24,8 @@ def assert_instance_logs(logs, instance_id, expected_lines):
     assert logs[instance_id] == expected_lines_formatted
 
 
-def test_log_by_name(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_log_by_name(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     patch_init_to_log_lines(project, LOG_LINES)
@@ -60,8 +60,8 @@ def test_log_by_name(start_stop_cli, project_with_patched_init):
     assert_instance_logs(logs, STATEBOARD_ID, LOG_LINES)
 
 
-def test_log_from_conf(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_log_from_conf(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     patch_init_to_log_lines(project, LOG_LINES)
@@ -101,8 +101,8 @@ def test_log_from_conf(start_stop_cli, project_with_patched_init):
     assert_instance_logs(logs, STATEBOARD_ID, LOG_LINES)
 
 
-def test_log_cfg(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_log_cfg(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     patch_init_to_log_lines(project, LOG_LINES)
@@ -131,8 +131,8 @@ def test_log_cfg(start_stop_cli, project_with_patched_init):
     assert_instance_logs(logs, ID2, LOG_LINES)
 
 
-def test_log_log_dir(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_log_log_dir(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     patch_init_to_log_lines(project, LOG_LINES)
@@ -161,8 +161,8 @@ def test_log_log_dir(start_stop_cli, project_with_patched_init):
     assert_instance_logs(logs, ID2, LOG_LINES)
 
 
-def test_log_run_dir(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_log_run_dir(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     patch_init_to_log_lines(project, LOG_LINES)
@@ -191,8 +191,8 @@ def test_log_run_dir(start_stop_cli, project_with_patched_init):
     assert_instance_logs(logs, ID2, LOG_LINES)
 
 
-def test_log_last_n_lines(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_log_last_n_lines(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     log_lines = ["I am log line number {}".format(i) for i in range(DEFAULT_LAST_N_LINES+5)]

--- a/test/integration/running/test_running.py
+++ b/test/integration/running/test_running.py
@@ -20,8 +20,8 @@ CARTRIDGE_CONF = '.cartridge.yml'
 # #####
 # Tests
 # #####
-def test_start_interactive_by_name(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_start_interactive_by_name(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     INSTANCE1 = 'instance-1'
@@ -31,8 +31,8 @@ def test_start_interactive_by_name(start_stop_cli, project_with_patched_init):
     check_instances_running(cli, project, [INSTANCE1])
 
 
-def test_start_stop_by_name(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_start_stop_by_name(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     INSTANCE1 = 'instance-1'
@@ -48,8 +48,8 @@ def test_start_stop_by_name(start_stop_cli, project_with_patched_init):
     check_instances_stopped(cli, project, [INSTANCE1])
 
 
-def test_start_interactive_by_name_with_stateboard(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_start_interactive_by_name_with_stateboard(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     INSTANCE1 = 'instance-1'
@@ -60,8 +60,8 @@ def test_start_interactive_by_name_with_stateboard(start_stop_cli, project_with_
     check_instances_running(cli, project, [INSTANCE1, INSTANCE2], stateboard=True)
 
 
-def test_start_interactive_stateboard_only(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_start_interactive_stateboard_only(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     # start with stateboard-only flag
@@ -69,8 +69,8 @@ def test_start_interactive_stateboard_only(start_stop_cli, project_with_patched_
     check_instances_running(cli, project, stateboard_only=True)
 
 
-def test_start_stop_by_name_with_stateboard(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_start_stop_by_name_with_stateboard(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     INSTANCE1 = 'instance-1'
@@ -86,8 +86,8 @@ def test_start_stop_by_name_with_stateboard(start_stop_cli, project_with_patched
     check_instances_stopped(cli, project, [INSTANCE1], stateboard=True)
 
 
-def test_start_stop_stateboard_only(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_start_stop_stateboard_only(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     # start with stateboard-only flag
@@ -99,8 +99,8 @@ def test_start_stop_stateboard_only(start_stop_cli, project_with_patched_init):
     check_instances_stopped(cli, project, stateboard_only=True)
 
 
-def test_start_interactive_from_conf(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_start_interactive_from_conf(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     INSTANCE1 = 'instance-1'
@@ -116,8 +116,8 @@ def test_start_interactive_from_conf(start_stop_cli, project_with_patched_init):
     check_instances_running(cli, project, [INSTANCE1, INSTANCE2])
 
 
-def test_start_stop_from_conf(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_start_stop_from_conf(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     INSTANCE1 = 'instance-1'
@@ -137,8 +137,8 @@ def test_start_stop_from_conf(start_stop_cli, project_with_patched_init):
     check_instances_stopped(cli, project, [INSTANCE1, INSTANCE2])
 
 
-def test_start_interactive_from_conf_with_stateboard(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_start_interactive_from_conf_with_stateboard(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     INSTANCE1 = 'instance-1'
@@ -154,8 +154,8 @@ def test_start_interactive_from_conf_with_stateboard(start_stop_cli, project_wit
     check_instances_running(cli, project, [INSTANCE1, INSTANCE2], stateboard=True)
 
 
-def test_start_interactive_from_conf_stateboard_only(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_start_interactive_from_conf_stateboard_only(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     INSTANCE1 = 'instance-1'
@@ -171,8 +171,8 @@ def test_start_interactive_from_conf_stateboard_only(start_stop_cli, project_wit
     check_instances_running(cli, project, stateboard_only=True)
 
 
-def test_start_stop_from_conf_with_stateboard(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_start_stop_from_conf_with_stateboard(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     INSTANCE1 = 'instance-1'
@@ -192,8 +192,8 @@ def test_start_stop_from_conf_with_stateboard(start_stop_cli, project_with_patch
     check_instances_stopped(cli, project, [INSTANCE1, INSTANCE2], stateboard=True)
 
 
-def test_start_stop_from_conf_stateboard_only(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_start_stop_from_conf_stateboard_only(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     INSTANCE1 = 'instance-1'
@@ -213,8 +213,8 @@ def test_start_stop_from_conf_stateboard_only(start_stop_cli, project_with_patch
     check_instances_stopped(cli, project, stateboard_only=True)
 
 
-def test_status_by_name(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_status_by_name(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     INSTANCE1 = 'instance-1'
@@ -285,8 +285,8 @@ def test_status_by_name(start_stop_cli, project_with_patched_init):
     assert status.get(STATEBOARD_ID) == STATUS_RUNNING
 
 
-def test_status_from_conf(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_status_from_conf(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     INSTANCE1 = 'instance-1'
@@ -363,8 +363,8 @@ def test_status_from_conf(start_stop_cli, project_with_patched_init):
     assert status.get(STATEBOARD_ID) == STATUS_RUNNING
 
 
-def test_start_stop_status_cfg(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_start_stop_status_cfg(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     INSTANCE1 = 'instance-1'
@@ -404,8 +404,8 @@ def test_start_stop_status_cfg(start_stop_cli, project_with_patched_init):
     assert status.get(ID2) == STATUS_STOPPED
 
 
-def test_start_stop_status_run_dir(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_start_stop_status_run_dir(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     INSTANCE1 = 'instance-1'
@@ -440,8 +440,8 @@ def test_start_stop_status_run_dir(start_stop_cli, project_with_patched_init):
     assert status.get(STATEBOARD_ID) == STATUS_STOPPED
 
 
-def test_start_stop_status_run_dir_from_conf(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_start_stop_status_run_dir_from_conf(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     INSTANCE1 = 'instance-1'
@@ -480,8 +480,8 @@ def test_start_stop_status_run_dir_from_conf(start_stop_cli, project_with_patche
     assert status.get(STATEBOARD_ID) == STATUS_STOPPED
 
 
-def test_start_data_dir(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_start_data_dir(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     INSTANCE1 = 'instance-1'
@@ -497,8 +497,8 @@ def test_start_data_dir(start_stop_cli, project_with_patched_init):
     )
 
 
-def test_start_data_dir_from_conf(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_start_data_dir_from_conf(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     INSTANCE1 = 'instance-1'
@@ -518,8 +518,8 @@ def test_start_data_dir_from_conf(start_stop_cli, project_with_patched_init):
     )
 
 
-def test_start_script(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_start_script(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     INSTANCE1 = 'instance-1'
@@ -536,8 +536,8 @@ def test_start_script(start_stop_cli, project_with_patched_init):
     )
 
 
-def test_start_script_from_conf(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_start_script_from_conf(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     INSTANCE1 = 'instance-1'
@@ -558,8 +558,8 @@ def test_start_script_from_conf(start_stop_cli, project_with_patched_init):
     )
 
 
-def test_start_log_dir(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_start_log_dir(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     INSTANCE1 = 'instance-1'
@@ -576,8 +576,8 @@ def test_start_log_dir(start_stop_cli, project_with_patched_init):
     )
 
 
-def test_start_log_dir_from_conf(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_start_log_dir_from_conf(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     INSTANCE1 = 'instance-1'
@@ -598,8 +598,8 @@ def test_start_log_dir_from_conf(start_stop_cli, project_with_patched_init):
     )
 
 
-def test_notify_status_failed(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_notify_status_failed(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     HORRIBLE_ERR = "SOME HORRIBLE ERROR"
@@ -615,8 +615,8 @@ def test_notify_status_failed(start_stop_cli, project_with_patched_init):
 
 
 @pytest.mark.parametrize('status', ['running', 'loading', 'orphan', 'hot_standby'])
-def test_notify_status_allowed(start_stop_cli, project_with_patched_init, status):
-    project = project_with_patched_init
+def test_notify_status_allowed(start_stop_cli, project_without_dependencies, status):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     patch_init_to_send_statuses(project, [status])
@@ -627,8 +627,8 @@ def test_notify_status_allowed(start_stop_cli, project_with_patched_init, status
     check_instances_running(cli, project, [INSTANCE1], daemonized=True, stateboard=True)
 
 
-def test_project_with_non_existent_script(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_project_with_non_existent_script(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     os.remove(os.path.join(project.path, DEFAULT_SCRIPT))
@@ -639,8 +639,8 @@ def test_project_with_non_existent_script(start_stop_cli, project_with_patched_i
     assert any(["Can't use instance entrypoint" in msg for msg in logs])
 
 
-def test_start_with_timeout(start_stop_cli, project_with_patched_init):
-    project = project_with_patched_init
+def test_start_with_timeout(start_stop_cli, project_without_dependencies):
+    project = project_without_dependencies
     cli = start_stop_cli
 
     TIMEOUT_SECONDS = 2

--- a/test/project.py
+++ b/test/project.py
@@ -86,7 +86,6 @@ class Project:
             self.name,
             # default application dependencies
             'cartridge',
-            'luatest',
         }
         if tarantool_is_enterprise:
             self.version_file_keys.add('TARANTOOL_SDK')

--- a/test/project.py
+++ b/test/project.py
@@ -1,6 +1,7 @@
 import os
 import re
 import subprocess
+import shutil
 
 from utils import create_project
 from utils import recursive_listdir
@@ -390,7 +391,5 @@ def patch_cartridge_version(project, new_version):
         f.write(new_version_code)
 
 
-def rewrite_project_file(project, project_filepath, filepath):
-    with open(filepath) as file:
-        with open(os.path.join(project.path, project_filepath), 'w') as project_file:
-            project_file.write(file.read())
+def replace_project_file(project, project_file_rel_path, new_file_path):
+    shutil.copy(new_file_path, os.path.join(project.path, project_file_rel_path))

--- a/test/project.py
+++ b/test/project.py
@@ -389,3 +389,9 @@ def patch_cartridge_version(project, new_version):
 
     with open(os.path.join(project.path, 'init.lua'), 'a') as f:
         f.write(new_version_code)
+
+
+def rewrite_project_file(project, project_filepath, filepath):
+    with open(filepath) as file:
+        with open(os.path.join(project.path, project_filepath), 'w') as project_file:
+            project_file.write(file.read())


### PR DESCRIPTION
In some tests application files (such as `init.lua`) are rewritten completely.
I think it's time to store such files in a separated directory and provide a function to easily replace files in test projects.
It will be used in #378 to rewrite admin role for different tests.
