### PR TITLE
Fix bash completion permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Bash completion file mode discarding
+
+### Changed
+
 - Updated tarantool/metrics to version 0.5.0
 
 ## [2.3.0] - 2020-08-31

--- a/cli/commands/gen.go
+++ b/cli/commands/gen.go
@@ -102,6 +102,14 @@ func cutFlagsDescription(cmd *cobra.Command) {
 }
 
 func genCompletion(cmd *cobra.Command, args []string) error {
+	curDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("Cailed to get current directory path: %s", err)
+	}
+
+	bashCompFilePath := filepath.Join(curDir, bashCompFilePath)
+	zshCompFilePath := filepath.Join(curDir, zshCompFilePath)
+
 	// create directories
 	bashCompFileDir := filepath.Dir(bashCompFilePath)
 	if err := os.MkdirAll(bashCompFileDir, 0755); err != nil {
@@ -115,8 +123,12 @@ func genCompletion(cmd *cobra.Command, args []string) error {
 
 	// gen completions
 	if !skipBash {
+		if err := os.RemoveAll(bashCompFilePath); err != nil {
+			return fmt.Errorf("Failed to remove existent bash completion: %s", err)
+		}
+
 		if err := cmd.Root().GenBashCompletionFile(bashCompFilePath); err != nil {
-			return fmt.Errorf("failed to generate bash completion: %s", err)
+			return fmt.Errorf("Failed to generate bash completion: %s", err)
 		}
 
 		// bash: remove flags duplicates (e.g. '--name', '--name=')
@@ -127,8 +139,12 @@ func genCompletion(cmd *cobra.Command, args []string) error {
 	}
 
 	if !skipZsh {
+		if err := os.RemoveAll(zshCompFilePath); err != nil {
+			return fmt.Errorf("Failed to remove existent zsh completion: %s", err)
+		}
+
 		if err := cmd.Root().GenZshCompletionFile(zshCompFilePath); err != nil {
-			return fmt.Errorf("failed to generate zsh completion: %s", err)
+			return fmt.Errorf("Failed to generate zsh completion: %s", err)
 		}
 	}
 

--- a/test/integration/cli/test_completion.py
+++ b/test/integration/cli/test_completion.py
@@ -1,0 +1,23 @@
+import subprocess
+import os
+
+
+def test_completion(cartridge_cmd, tmpdir):
+    cmd = [
+        cartridge_cmd, "gen", "completion",
+    ]
+
+    process = subprocess.run(cmd, cwd=tmpdir)
+    assert process.returncode == 0
+
+    comp_names = [
+        "completion/bash/cartridge",
+        "completion/zsh/_cartridge",
+    ]
+
+    for comp_name in comp_names:
+        comp_path = os.path.join(tmpdir, comp_name)
+        assert os.path.exists(comp_path)
+
+        filemode = os.stat(comp_path).st_mode & 0o777
+        assert filemode == 0o644


### PR DESCRIPTION
File permissions was discarded on removing duplicate flags (e.g. `--name`, `--name=`).
