### PR TITLE
Improve build in docker err msg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Improved error message on building in docker fail on GitLab CI
+
 ## [2.4.0] - 2020-10-26
 
 ### Fixed


### PR DESCRIPTION
Building in docker often fails on GitLab CI because volumes aren't working correctly for default build tmp directory.
The solution is to use `CARTRIDGE_TEMPDIR=. cartridge pack ...`.

I think that this workaround should be shown when building in docker fails.
