### PR TITLE
Fail on cartidge pack RPM and DEB on MacOS without --use-docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Improved error message on building in docker fail on GitLab CI
+- `cartridge pack` fails for RPM and DEB if `--use-docker` isn't specified
 
 ## [2.4.0] - 2020-10-26
 

--- a/README.rst
+++ b/README.rst
@@ -644,6 +644,12 @@ where:
 * ``PATH`` (optional) is the path to the application directory to pack.
   Defaults to ``.`` (the current directory).
 
+.. note::
+
+  If you pack application into RPM or DEB on MacOS without `--use-docker`
+  flag, the result artifact is broken - it contains rocks and executables
+  that can't be used on Linux. In this case packing fails.
+
 The options (``[flags]``) are as follows:
 
 .. // Please, update cmd_pack usage in cartridge-cli.lua file on updating the doc

--- a/cli/pack/pack.go
+++ b/cli/pack/pack.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/apex/log"
 
@@ -32,6 +33,16 @@ const (
 func Run(ctx *context.Ctx) error {
 	if err := checkCtx(ctx); err != nil {
 		return project.InternalError("Pack context check failed: %s", err)
+	}
+
+	if !ctx.Build.InDocker && (ctx.Pack.Type == RpmType || ctx.Pack.Type == DebType) {
+		if runtime.GOOS != "linux" {
+			return fmt.Errorf(
+				"It's not possible to pack application into RPM or DEB on non-linux OS (%s). "+
+					"Please, use --use-docker flag to pack application inside the Docker container",
+				runtime.GOOS,
+			)
+		}
 	}
 
 	// get packer function


### PR DESCRIPTION
If `cartridge pack rpm/deb` is called on MacOS without `--use-docker`
flag, the result artifact is broken - it contains rocks and executables
that can't be used on Linux. Now in this case packing fails.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Closes #210 
