### PR TITLE
Add Arch Linux install option via AUR

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,12 @@ Installation
      .. code-block:: bash
 
          sudo apt-get install cartridge-cli
+         
+   * for Arch Linux:
+
+     .. code-block:: bash
+
+         yaourt -S cartridge-cli-git    
 
    * for MacOS X (Homebrew formula):
 


### PR DESCRIPTION
**Problem:** I am using Arch Linux on my primary development station, and I was quite disappointed when I discovered tarantool-cartridge has no option for installing from AUR (or official Arch Repository).

**Solution:** Therefore, I`ve created package for AUR by myself, and I suppose this install option worth mentioning in your Readme, because other Arch users can benefit from it.

**Implementation details:** As I am not affiliated with Tarantool development team, so, probably I could not  update my package to be in-sync with your version in reasonable time, so I decided to build package, which, during install clones your Git repository, search for last from HEAD tagged commit(release) and builds it for user.

**Link to AUR package:**  https://aur.archlinux.org/packages/cartridge-cli-git/

If you are interested in maintaining this package in AUR, please contact me.