### PR TITLE
Refactor --quiet flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Improved error message on building in docker fail on GitLab CI
 - `cartridge pack` fails for RPM and DEB if `--use-docker` isn't specified
+- Refactored verbosity flags:
+  * `--quiet`: no logs (only errors are shown)
+  * no flags: logs + spinner instead of commands/docker output
+  * `--verbose`: logs + commands/docker output
+- Spinner is started only for a terminal
 
 ## [2.4.0] - 2020-10-26
 

--- a/README.rst
+++ b/README.rst
@@ -166,10 +166,11 @@ The following commands are supported:
 
 The following global flags are supported:
 
-* ``verbose`` — verbose mode;
+* ``verbose`` — verbose mode, additional log messages are shown as well as
+  commands/docker output (such as `tarantoolctl rocks make` or `docker build` output);
 * ``debug`` — debug mode (the same as verbose, but temporary files and
   directories aren't removed);
-* ``quiet`` — the mode that hides log details during the build process.
+* ``quiet`` — the mode that hides all logs; only errors are shown.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 An application lifecycle

--- a/cli/build/docker.go
+++ b/cli/build/docker.go
@@ -91,9 +91,9 @@ func buildProjectInDocker(ctx *context.Ctx) error {
 		NoCache:    ctx.Docker.NoCache,
 		CacheFrom:  ctx.Docker.CacheFrom,
 
-		BuildDir: ctx.Build.Dir,
-		TmpDir:   ctx.Cli.TmpDir,
-		Quiet:    ctx.Cli.Quiet,
+		BuildDir:   ctx.Build.Dir,
+		TmpDir:     ctx.Cli.TmpDir,
+		ShowOutput: ctx.Cli.Verbose,
 	})
 
 	if err != nil {
@@ -130,8 +130,8 @@ func buildProjectInDocker(ctx *context.Ctx) error {
 			ctx.Build.Dir: containerBuildDir,
 		},
 
-		Quiet: ctx.Cli.Quiet,
-		Debug: ctx.Cli.Debug,
+		ShowOutput: ctx.Cli.Verbose,
+		Debug:      ctx.Cli.Debug,
 	})
 
 	if err != nil {

--- a/cli/build/local.go
+++ b/cli/build/local.go
@@ -23,7 +23,7 @@ func buildProjectLocally(ctx *context.Ctx) error {
 
 	if _, err := os.Stat(preBuildHookPath); err == nil {
 		log.Infof("Running `%s`", preBuildHookName)
-		err = common.RunHook(preBuildHookPath, !ctx.Cli.Quiet)
+		err = common.RunHook(preBuildHookPath, ctx.Cli.Verbose)
 		if err != nil {
 			return fmt.Errorf("Failed to run pre-build hook: %s", err)
 		}
@@ -34,7 +34,7 @@ func buildProjectLocally(ctx *context.Ctx) error {
 	// tarantoolctl rocks make
 	log.Infof("Running `tarantoolctl rocks make`")
 	rocksMakeCmd := exec.Command("tarantoolctl", "rocks", "make")
-	err := common.RunCommand(rocksMakeCmd, ctx.Build.Dir, !ctx.Cli.Quiet)
+	err := common.RunCommand(rocksMakeCmd, ctx.Build.Dir, ctx.Cli.Verbose)
 	if err != nil {
 		return fmt.Errorf("Failed to install rocks: %s", err)
 	}

--- a/cli/build/post_build.go
+++ b/cli/build/post_build.go
@@ -16,7 +16,7 @@ func PostRun(ctx *context.Ctx) error {
 
 	if _, err := os.Stat(postBuildHookPath); err == nil {
 		log.Infof("Running `%s`", postBuildHookName)
-		err = common.RunHook(postBuildHookPath, !ctx.Cli.Quiet)
+		err = common.RunHook(postBuildHookPath, ctx.Cli.Verbose)
 		if err != nil {
 			return fmt.Errorf("Failed to run post-build hook: %s", err)
 		}

--- a/cli/commands/cartridge.go
+++ b/cli/commands/cartridge.go
@@ -50,4 +50,8 @@ func setLogLevel() {
 	if ctx.Cli.Verbose {
 		log.SetLevel(log.DebugLevel)
 	}
+
+	if ctx.Cli.Quiet {
+		log.SetLevel(log.ErrorLevel)
+	}
 }

--- a/cli/common/execute.go
+++ b/cli/common/execute.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/mattn/go-isatty"
+
 	"github.com/apex/log"
 	"github.com/briandowns/spinner"
 )
@@ -86,8 +88,10 @@ func RunCommand(cmd *exec.Cmd, dir string, showOutput bool) error {
 		defer outputBuf.Close()
 		defer os.Remove(outputBuf.Name())
 
-		wg.Add(1)
-		go StartCommandSpinner(c, &wg, "")
+		if isatty.IsTerminal(os.Stdout.Fd()) {
+			wg.Add(1)
+			go StartCommandSpinner(c, &wg, "")
+		}
 	}
 
 	wg.Add(1)
@@ -217,8 +221,10 @@ func RunFunctionWithSpinner(f func() error, prefix string) error {
 	var wg sync.WaitGroup
 	c := make(ReadyChan, 1)
 
-	wg.Add(1)
-	go StartCommandSpinner(c, &wg, prefix)
+	if isatty.IsTerminal(os.Stdout.Fd()) {
+		wg.Add(1)
+		go StartCommandSpinner(c, &wg, prefix)
+	}
 
 	wg.Add(1)
 	go func(f func() error, err *error) {

--- a/cli/docker/build.go
+++ b/cli/docker/build.go
@@ -29,7 +29,7 @@ type BuildOpts struct {
 	BuildDir string
 	TmpDir   string
 
-	Quiet bool
+	ShowOutput bool
 }
 
 var readerSize = 4096
@@ -168,7 +168,7 @@ func BuildImage(opts BuildOpts) error {
 		return err
 	}
 
-	if err := waitBuildOutput(resp, !opts.Quiet); err != nil {
+	if err := waitBuildOutput(resp, opts.ShowOutput); err != nil {
 		return err
 	}
 

--- a/cli/docker/run.go
+++ b/cli/docker/run.go
@@ -25,8 +25,8 @@ type RunOpts struct {
 
 	Volumes map[string]string
 
-	Quiet bool
-	Debug bool
+	ShowOutput bool
+	Debug      bool
 }
 
 func waitForContainer(cli *docker.Client, containerID string, showOutput bool) error {
@@ -161,7 +161,7 @@ func RunContainer(opts RunOpts) error {
 		return fmt.Errorf("Failed to start container: %s", err)
 	}
 
-	if err := waitForContainer(cli, containerID, !opts.Quiet); err != nil {
+	if err := waitForContainer(cli, containerID, opts.ShowOutput); err != nil {
 		return fmt.Errorf("Failed to run command on container: %s", err)
 	}
 

--- a/cli/pack/deb.go
+++ b/cli/pack/deb.go
@@ -88,7 +88,7 @@ func packDeb(ctx *context.Ctx) error {
 		dataArchivePath,
 	)
 
-	err = common.RunCommand(packDebCmd, ctx.Pack.PackageFilesDir, !ctx.Cli.Quiet)
+	err = common.RunCommand(packDebCmd, ctx.Pack.PackageFilesDir, ctx.Cli.Verbose)
 	if err != nil {
 		return fmt.Errorf("Failed to pack DEB: %s", err)
 	}

--- a/cli/pack/docker.go
+++ b/cli/pack/docker.go
@@ -68,9 +68,9 @@ func packDocker(ctx *context.Ctx) error {
 		NoCache:    ctx.Docker.NoCache,
 		CacheFrom:  ctx.Docker.CacheFrom,
 
-		BuildDir: ctx.Build.Dir,
-		TmpDir:   ctx.Cli.TmpDir,
-		Quiet:    ctx.Cli.Quiet,
+		BuildDir:   ctx.Build.Dir,
+		TmpDir:     ctx.Cli.TmpDir,
+		ShowOutput: ctx.Cli.Verbose,
 	})
 
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hpcloud/tail v1.0.0
 	github.com/magefile/mage v1.9.0
+	github.com/mattn/go-isatty v0.0.8
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/otiai10/copy v1.2.0

--- a/test/integration/cli/test_version.py
+++ b/test/integration/cli/test_version.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python3
-
 from utils import run_command_and_get_output
 
 


### PR DESCRIPTION
Now,
--quiet mean no logs
--verbose mean logs + commands/docker output
no flags mean logs + spinner instead of commands/docker output

Spinner is started only for a terminal

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Closes #398 
