### PR TITLE
Read from Tarantool console socket correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Using Tarantool console socket
+  * end of Tarantool output data and read timeout are handled properly
+  * Tarantool greeting is read once on connection creation
+
 ### Changed
 
 - Improved error message on building in docker fail on GitLab CI

--- a/cli/admin/common.go
+++ b/cli/admin/common.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/spf13/pflag"
+	"github.com/tarantool/cartridge-cli/cli/common"
 	"github.com/tarantool/cartridge-cli/cli/context"
 	"github.com/tarantool/cartridge-cli/cli/project"
 )
@@ -33,7 +34,7 @@ func getAvaliableConn(ctx *context.Ctx) (net.Conn, error) {
 	if ctx.Admin.InstanceName != "" {
 		instanceSocketPath := project.GetInstanceConsoleSock(ctx, ctx.Admin.InstanceName)
 
-		conn, err := getConn(instanceSocketPath)
+		conn, err := common.ConnectToTarantoolSocket(instanceSocketPath)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to use %q: %s", instanceSocketPath, err)
 		}
@@ -50,7 +51,7 @@ func getAvaliableConn(ctx *context.Ctx) (net.Conn, error) {
 	}
 
 	for _, instanceSocketPath := range instanceSocketPaths {
-		conn, err := getConn(instanceSocketPath)
+		conn, err := common.ConnectToTarantoolSocket(instanceSocketPath)
 		if err == nil {
 			log.Debugf("Connected to %q", instanceSocketPath)
 
@@ -61,15 +62,6 @@ func getAvaliableConn(ctx *context.Ctx) (net.Conn, error) {
 	}
 
 	return nil, fmt.Errorf("No available sockets found in: %s", ctx.Running.RunDir)
-}
-
-func getConn(instanceSocketPath string) (net.Conn, error) {
-	conn, err := net.Dial("unix", instanceSocketPath)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to dial: %s", err)
-	}
-
-	return conn, nil
 }
 
 func getInstanceSocketPaths(ctx *context.Ctx) ([]string, error) {

--- a/cli/repair/common.go
+++ b/cli/repair/common.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net"
 	"os"
 	"strings"
 
@@ -130,7 +129,7 @@ func checkThatReloadIsPossible(instanceNames []string, ctx *context.Ctx) error {
 			continue
 		}
 
-		conn, err := net.Dial("unix", consoleSock)
+		conn, err := common.ConnectToTarantoolSocket(consoleSock)
 		if err != nil {
 			continue
 		}

--- a/cli/repair/patch.go
+++ b/cli/repair/patch.go
@@ -2,7 +2,6 @@ package repair
 
 import (
 	"fmt"
-	"net"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -89,9 +88,9 @@ func reloadConf(topologyConfPath string, instanceName string, ctx *context.Ctx) 
 		return nil, fmt.Errorf("Failed to use instanace console socket: %s", err)
 	}
 
-	conn, err := net.Dial("unix", consoleSock)
+	conn, err := common.ConnectToTarantoolSocket(consoleSock)
 	if err != nil {
-		return resMessages, fmt.Errorf("Failed to dial: %s", err)
+		return resMessages, fmt.Errorf("Failed to connect to Tarantool instance: %s", err)
 	}
 
 	defer conn.Close()


### PR DESCRIPTION
Before this patch end of Tarantool output wasn't detected correctly.
So all readings from socket failed by timeout (on `n == 0` check).
It leads that read takes time equal to timeout.
Moreover, before each  eval Tarantool greeting was read, so this time
was doubled.
Now `ConnectToTarantoolSocket` function creates a connection, sets read
timeout and reads the greeting once.
`ReadFromConn` function is fixed - end of output is deteced correctly,
by `"\n...\n"` suffix
