### PR TITLE
Refactor error handling on socket  eval

### DIFF
--- a/cli/common/socket.go
+++ b/cli/common/socket.go
@@ -91,7 +91,7 @@ func EvalTarantoolConn(conn net.Conn, funcBody string) (interface{}, error) {
 	end
 
 	if err ~= nil then
-		return { success = false, err = err }
+		return { success = false, err = tostring(err) }
 	end
 
 	return { success = true, data = res }
@@ -147,7 +147,7 @@ func processEvalTarantoolRes(resBytes []byte) (*TarantoolEvalRes, error) {
 
 		}
 
-		return nil, fmt.Errorf("Function should return { success = ..., err = ..., data = .... }")
+		return nil, fmt.Errorf("Failed to parse eval result: %s", err)
 	}
 
 	if len(results) != 1 {

--- a/cli/common/socket_test.go
+++ b/cli/common/socket_test.go
@@ -62,5 +62,5 @@ func TestProcessEvalTarantoolRes(t *testing.T) {
 ...`
 
 	res, err = processEvalTarantoolRes([]byte(resStr))
-	assert.Equal("Function should return { success = ..., err = ..., data = .... }", err.Error())
+	assert.Contains(err.Error(), "Failed to parse eval result: yaml: unmarshal errors")
 }


### PR DESCRIPTION
This patch fixes two problems:
* function can return non-string error, `tostring(err)` is performed before return now
* parsing result yaml error was confusing, now it shows `Unmarshal` error