### PR TITLE
Refactor common.ConvertToStringsSlice function

### DIFF
--- a/cli/common/utils.go
+++ b/cli/common/utils.go
@@ -238,9 +238,14 @@ Loop:
 	return lastNewLinePos, nil
 }
 
-func ConvertToStringsSlice(s []interface{}) ([]string, error) {
-	stringsSlice := make([]string, len(s))
-	for i, elem := range s {
+func ConvertToStringsSlice(s interface{}) ([]string, error) {
+	sliceRaw, ok := s.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("Value should be an array, got %#v", s)
+	}
+
+	stringsSlice := make([]string, len(sliceRaw))
+	for i, elem := range sliceRaw {
 		stringElem, ok := elem.(string)
 		if !ok {
 			return nil, fmt.Errorf("Slice element %d isn't a string: %v", i, elem)

--- a/cli/repair/clusterwide_config.go
+++ b/cli/repair/clusterwide_config.go
@@ -288,7 +288,7 @@ func (topologyConf *TopologyConfType) setReplicasetsConf() error {
 				replicasetConf.LeadersIsString = true
 				replicasetConf.Leaders = append(replicasetConf.Leaders, leadersConverted)
 			case []interface{}:
-				leaders, err := common.ConvertToStringsSlice(leadersConverted)
+				leaders, err := common.ConvertToStringsSlice(leadersRaw)
 				if err != nil {
 					return fmt.Errorf("Replicaset %s %q field isn't a list of strings: %s", replicasetUUID, keyReplicasetLeaders, err)
 				}


### PR DESCRIPTION
Old function signature required `s.([]interface{})` converting before each call. 
I decided that it should be performed in function itself.