### PR TITLE
Refactor reading from Tarantool console

### DIFF
--- a/cli/common/files.go
+++ b/cli/common/files.go
@@ -111,7 +111,6 @@ func GetFileContent(path string) (string, error) {
 	}
 
 	return string(fileContentBytes), nil
-
 }
 
 func writeFileToWriter(filePath string, writer io.Writer) error {

--- a/cli/common/utils.go
+++ b/cli/common/utils.go
@@ -173,7 +173,7 @@ func GetLastNLinesBegin(filepath string, lines int) (int64, error) {
 
 	f, err := os.Open(filepath)
 	if err != nil {
-		return 0, fmt.Errorf("Failed to open log file: %s", err)
+		return 0, fmt.Errorf("Failed to open file: %s", err)
 	}
 	defer f.Close()
 


### PR DESCRIPTION
ReadFromConn function reads plain text from Tarantool connection
These code was inspired by Tarantool console eval
https://github.com/tarantool/tarantool/blob/3bc4a156e937102f23e2157ef88aa6c007759005/src/box/lua/console.lua#L469

By default, Tarantool sends YAML-encoded values as user command response.
In this case the end of output value is `\n...\n`.
What about a case when return string contains this substring?
Everything is OK, since yaml-encoded string is indented via two spaces,
so in fact we never have `\n...\n` in output strings.

If Lua output is set, the end of input is just ";".
And there are some problems.
See https://github.com/tarantool/tarantool/issues/4603

Code is read byte by byte to make parsing output simplier
(in case of box.session.push() response we need to read 2 yaml-encoded values,
it's not enough to catch end of output, we should be sure that only one
yaml-encoded value was read).