### PR TITLE
Refactor computing project paths in tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -21,7 +21,6 @@ from clusterwide_conf import get_topology_conf, get_one_file_conf
 
 from utils import Cli
 from utils import start_instances
-from utils import DEFAULT_RUN_DIR
 
 from project import INIT_NO_CARTRIDGE_FILEPATH
 from project import INIT_IGNORE_SIGTERM_FILEPATH
@@ -245,7 +244,6 @@ def custom_admin_running_instances(cartridge_cmd, start_stop_cli, custom_admin_p
 
     return {
         'project': project,
-        'run_dir': os.path.join(project.path, DEFAULT_RUN_DIR),
     }
 
 

--- a/test/examples/test_getting_started.py
+++ b/test/examples/test_getting_started.py
@@ -1,11 +1,8 @@
 import subprocess
 import yaml
-import os
 import requests
 import pytest
 
-from utils import DEFAULT_CFG
-from utils import get_stateboard_name, get_instance_id
 from utils import check_instances_running
 from utils import create_replicaset, wait_for_replicaset_is_healthy, get_replicaset_roles
 from utils import bootstrap_vshard
@@ -19,11 +16,11 @@ from project import patch_cartridge_proc_titile
 def get_instances_from_conf(project):
     res = dict()
 
-    with open(os.path.join(project.path, DEFAULT_CFG)) as f:
+    with open(project.get_cfg_path()) as f:
         conf = yaml.safe_load(f)
 
     for instance_id, instance_conf in conf.items():
-        if instance_id == get_stateboard_name(project.name):
+        if instance_id == project.get_stateboard_id():
             continue
 
         id_parts = instance_id.split(".")
@@ -69,9 +66,9 @@ def test_api(start_stop_cli, cartridge_cmd, project_getting_started):
     project = project_getting_started
     cli = start_stop_cli
 
-    APP_INSTANCES = [get_instance_id(project.name, 'router')]
-    S1_INSTANCES = [get_instance_id(project.name, 's1-master'), get_instance_id(project.name, 's1-replica')]
-    S2_INSTANCES = [get_instance_id(project.name, 's2-master'), get_instance_id(project.name, 's2-replica')]
+    APP_INSTANCES = [project.get_instance_id('router')]
+    S1_INSTANCES = [project.get_instance_id('s1-master'), project.get_instance_id('s1-replica')]
+    S2_INSTANCES = [project.get_instance_id('s2-master'), project.get_instance_id('s2-replica')]
 
     # build app
     process = subprocess.run([cartridge_cmd, 'build'], cwd=project.path)

--- a/test/integration/admin/test_call.py
+++ b/test/integration/admin/test_call.py
@@ -4,7 +4,7 @@ from utils import get_log_lines
 
 def test_call_many_args(cartridge_cmd, custom_admin_running_instances, tmpdir):
     project = custom_admin_running_instances['project']
-    run_dir = custom_admin_running_instances['run_dir']
+    run_dir = project.get_run_dir()
 
     base_cmd = [
         cartridge_cmd, 'admin',
@@ -60,7 +60,7 @@ def test_call_many_args(cartridge_cmd, custom_admin_running_instances, tmpdir):
 
 def test_func_long_arg(cartridge_cmd, custom_admin_running_instances, tmpdir):
     project = custom_admin_running_instances['project']
-    run_dir = custom_admin_running_instances['run_dir']
+    run_dir = project.get_run_dir()
 
     cmd = [
         cartridge_cmd, 'admin',
@@ -78,7 +78,7 @@ def test_func_long_arg(cartridge_cmd, custom_admin_running_instances, tmpdir):
 
 def test_func_rets_str(cartridge_cmd, custom_admin_running_instances, tmpdir):
     project = custom_admin_running_instances['project']
-    run_dir = custom_admin_running_instances['run_dir']
+    run_dir = project.get_run_dir()
 
     cmd = [
         cartridge_cmd, 'admin',
@@ -96,7 +96,7 @@ def test_func_rets_str(cartridge_cmd, custom_admin_running_instances, tmpdir):
 
 def test_func_rets_non_str(cartridge_cmd, custom_admin_running_instances, tmpdir):
     project = custom_admin_running_instances['project']
-    run_dir = custom_admin_running_instances['run_dir']
+    run_dir = project.get_run_dir()
 
     cmd = [
         cartridge_cmd, 'admin',
@@ -115,7 +115,7 @@ def test_func_rets_non_str(cartridge_cmd, custom_admin_running_instances, tmpdir
 
 def test_func_rets_err(cartridge_cmd, custom_admin_running_instances, tmpdir):
     project = custom_admin_running_instances['project']
-    run_dir = custom_admin_running_instances['run_dir']
+    run_dir = project.get_run_dir()
 
     cmd = [
         cartridge_cmd, 'admin',
@@ -133,7 +133,7 @@ def test_func_rets_err(cartridge_cmd, custom_admin_running_instances, tmpdir):
 
 def test_func_raises_err(cartridge_cmd, custom_admin_running_instances, tmpdir):
     project = custom_admin_running_instances['project']
-    run_dir = custom_admin_running_instances['run_dir']
+    run_dir = project.get_run_dir()
 
     cmd = [
         cartridge_cmd, 'admin',

--- a/test/integration/admin/test_common.py
+++ b/test/integration/admin/test_common.py
@@ -65,7 +65,8 @@ def test_bad_run_dir(cartridge_cmd, custom_admin_running_instances, admin_flow, 
 
 @pytest.mark.parametrize('admin_flow', ['list', 'help-func', 'call'])
 def test_app_name_missed(cartridge_cmd, custom_admin_running_instances, admin_flow, tmpdir):
-    run_dir = custom_admin_running_instances['run_dir']
+    project = custom_admin_running_instances['project']
+    run_dir = project.get_run_dir()
 
     args = simple_args[admin_flow]
 
@@ -82,8 +83,8 @@ def test_app_name_missed(cartridge_cmd, custom_admin_running_instances, admin_fl
 
 @pytest.mark.parametrize('admin_flow', ['help-func', 'call'])
 def test_non_existent_func(cartridge_cmd, custom_admin_running_instances, admin_flow, tmpdir):
-    run_dir = custom_admin_running_instances['run_dir']
     project = custom_admin_running_instances['project']
+    run_dir = project.get_run_dir()
 
     simple_args = {
         'help-func': ['non_existent_func', '--help'],
@@ -106,8 +107,8 @@ def test_non_existent_func(cartridge_cmd, custom_admin_running_instances, admin_
 
 @pytest.mark.parametrize('admin_flow', ['help-func', 'call'])
 def test_conflicting_argnames(cartridge_cmd, custom_admin_running_instances, admin_flow, tmpdir):
-    run_dir = custom_admin_running_instances['run_dir']
     project = custom_admin_running_instances['project']
+    run_dir = project.get_run_dir()
 
     simple_args = {
         'help-func': ['func_conflicting', '--help'],
@@ -144,8 +145,8 @@ def test_conflicting_argnames(cartridge_cmd, custom_admin_running_instances, adm
 
 @pytest.mark.parametrize('admin_flow', ['list', 'help-func', 'call'])
 def test_instance_specified(cartridge_cmd, start_stop_cli, custom_admin_running_instances, admin_flow, tmpdir):
-    run_dir = custom_admin_running_instances['run_dir']
     project = custom_admin_running_instances['project']
+    run_dir = project.get_run_dir()
 
     # stop instance-2
     INSTANCE1 = 'instance-1'

--- a/test/integration/admin/test_default.py
+++ b/test/integration/admin/test_default.py
@@ -1,10 +1,8 @@
-import os
 import pytest
 import subprocess
 
 from utils import run_command_and_get_output
 from utils import start_instances
-from utils import DEFAULT_RUN_DIR
 from utils import get_log_lines
 
 from project import patch_cartridge_proc_titile
@@ -30,13 +28,12 @@ def default_admin_running_instances(cartridge_cmd, start_stop_cli, project_with_
 
     return {
         'project': project,
-        'run_dir': os.path.join(project.path, DEFAULT_RUN_DIR),
     }
 
 
 def test_default_admin_func(cartridge_cmd, default_admin_running_instances, tmpdir):
     project = default_admin_running_instances['project']
-    run_dir = default_admin_running_instances['run_dir']
+    run_dir = project.get_run_dir()
 
     # list
     cmd = [

--- a/test/integration/admin/test_help.py
+++ b/test/integration/admin/test_help.py
@@ -4,7 +4,7 @@ from utils import get_log_lines
 
 def test_help_many_args(cartridge_cmd, custom_admin_running_instances, tmpdir):
     project = custom_admin_running_instances['project']
-    run_dir = custom_admin_running_instances['run_dir']
+    run_dir = project.get_run_dir()
 
     cmd = [
         cartridge_cmd, 'admin',
@@ -27,7 +27,7 @@ def test_help_many_args(cartridge_cmd, custom_admin_running_instances, tmpdir):
 
 def test_help_no_args(cartridge_cmd, custom_admin_running_instances, tmpdir):
     project = custom_admin_running_instances['project']
-    run_dir = custom_admin_running_instances['run_dir']
+    run_dir = project.get_run_dir()
 
     cmd = [
         cartridge_cmd, 'admin',
@@ -46,7 +46,7 @@ def test_help_no_args(cartridge_cmd, custom_admin_running_instances, tmpdir):
 
 def test_help_long_func_name(cartridge_cmd, custom_admin_running_instances, tmpdir):
     project = custom_admin_running_instances['project']
-    run_dir = custom_admin_running_instances['run_dir']
+    run_dir = project.get_run_dir()
 
     exp_output_lines = [
         '• Admin function "func.long.name" usage:',

--- a/test/integration/admin/test_list.py
+++ b/test/integration/admin/test_list.py
@@ -4,7 +4,7 @@ from utils import get_log_lines
 
 def test_list(cartridge_cmd, custom_admin_running_instances, tmpdir):
     project = custom_admin_running_instances['project']
-    run_dir = custom_admin_running_instances['run_dir']
+    run_dir = project.get_run_dir()
 
     cmd = [
         cartridge_cmd, 'admin',

--- a/test/integration/connect/conftest.py
+++ b/test/integration/connect/conftest.py
@@ -8,7 +8,6 @@ from project import remove_dependency
 from project import replace_project_file
 from project import INIT_NO_CARTRIDGE_FILEPATH
 
-from utils import DEFAULT_CFG, DEFAULT_RPL_CFG
 from utils import ProjectWithTopology, Instance
 
 
@@ -27,8 +26,7 @@ def built_project(cartridge_cmd, short_session_tmpdir):
     # don't change process title
     patch_cartridge_proc_titile(project)
 
-    os.remove(os.path.join(project.path, DEFAULT_CFG))
-    os.remove(os.path.join(project.path, DEFAULT_RPL_CFG))
+    os.remove(project.get_cfg_path())
 
     return project
 
@@ -48,8 +46,7 @@ def built_project_no_cartridge(cartridge_cmd, short_session_tmpdir):
     process = subprocess.run(cmd, cwd=project.path)
     assert process.returncode == 0, "Error during building the project"
 
-    os.remove(os.path.join(project.path, DEFAULT_CFG))
-    os.remove(os.path.join(project.path, DEFAULT_RPL_CFG))
+    os.remove(project.get_cfg_path())
 
     return project
 

--- a/test/integration/connect/test_connect.py
+++ b/test/integration/connect/test_connect.py
@@ -46,7 +46,7 @@ def test_socket_piped(cartridge_cmd, project_with_instances):
     instances = project_with_instances.instances
 
     router = instances['router']
-    console_sock_path = project.get_console_sock_path(router.name)
+    console_sock_path = project.get_console_sock(router.name)
 
     cmd = [
         cartridge_cmd, 'connect', console_sock_path,
@@ -60,7 +60,7 @@ def test_socket_no_title(cartridge_cmd, project_with_instances_no_cartridge):
     instances = project_with_instances_no_cartridge.instances
 
     router = instances['router']
-    console_sock_path = project.get_console_sock_path(router.name)
+    console_sock_path = project.get_console_sock(router.name)
 
     cmd = [
         cartridge_cmd, 'connect', console_sock_path,
@@ -89,7 +89,7 @@ def test_socket_instance_exited(cartridge_cmd, project_with_instances):
     instances = project_with_instances.instances
 
     router = instances['router']
-    console_sock_path = project.get_console_sock_path(router.name)
+    console_sock_path = project.get_console_sock(router.name)
 
     cmd = [
         cartridge_cmd, 'connect', console_sock_path,
@@ -103,7 +103,7 @@ def test_socket_session_push(cartridge_cmd, project_with_instances):
     instances = project_with_instances.instances
 
     router = instances['router']
-    console_sock_path = project.get_console_sock_path(router.name)
+    console_sock_path = project.get_console_sock(router.name)
 
     cmd = [
         cartridge_cmd, 'connect', console_sock_path,

--- a/test/integration/repair/test_repair_reload.py
+++ b/test/integration/repair/test_repair_reload.py
@@ -1,14 +1,9 @@
 import subprocess
-import os
 import requests
 import pytest
 
-from utils import get_instance_id
 from utils import check_instances_running
 from utils import check_instances_stopped
-from utils import DEFAULT_CFG
-from utils import DEFAULT_DATA_DIR
-from utils import DEFAULT_RUN_DIR
 from utils import write_conf
 from utils import create_replicaset
 from utils import run_command_and_get_output
@@ -65,8 +60,8 @@ def test_repair_reload_old_cartridge(cartridge_cmd, start_stop_cli, project_with
     INSTANCE1 = 'instance-1'
     INSTANCE2 = 'instance-2'
 
-    ID1 = get_instance_id(project.name, INSTANCE1)
-    ID2 = get_instance_id(project.name, INSTANCE2)
+    ID1 = project.get_instance_id(INSTANCE1)
+    ID2 = project.get_instance_id(INSTANCE2)
 
     cfg = {
         ID1: {
@@ -79,14 +74,14 @@ def test_repair_reload_old_cartridge(cartridge_cmd, start_stop_cli, project_with
         },
     }
 
-    write_conf(os.path.join(project.path, DEFAULT_CFG), cfg)
+    write_conf(project.get_cfg_path(), cfg)
 
     # start instance-1 and instance-2
     cli.start(project, daemonized=True)
     check_instances_running(cli, project, [INSTANCE1, INSTANCE2], daemonized=True)
 
-    data_dir = os.path.join(project.path, DEFAULT_DATA_DIR)
-    run_dir = os.path.join(project.path, DEFAULT_RUN_DIR)
+    data_dir = project.get_data_dir()
+    run_dir = project.get_run_dir()
 
     cmd = [
         cartridge_cmd, 'repair', 'set-leader',
@@ -129,8 +124,8 @@ def test_repair_reload_set_leader(cartridge_cmd, start_stop_cli, project_with_ca
     INSTANCE1 = 'instance-1'
     INSTANCE2 = 'instance-2'
 
-    ID1 = get_instance_id(project.name, INSTANCE1)
-    ID2 = get_instance_id(project.name, INSTANCE2)
+    ID1 = project.get_instance_id(INSTANCE1)
+    ID2 = project.get_instance_id(INSTANCE2)
 
     ADMIN_HTTP_PORT = 8081
 
@@ -145,7 +140,7 @@ def test_repair_reload_set_leader(cartridge_cmd, start_stop_cli, project_with_ca
         },
     }
 
-    write_conf(os.path.join(project.path, DEFAULT_CFG), cfg)
+    write_conf(project.get_cfg_path(), cfg)
 
     # start instance-1 and instance-2
     cli.start(project, daemonized=True)
@@ -164,8 +159,8 @@ def test_repair_reload_set_leader(cartridge_cmd, start_stop_cli, project_with_ca
     instances_by_priority = sorted(cluster_instances, key=lambda i: i['priority'])
     new_leader_uuid = instances_by_priority[-1]['uuid']
 
-    data_dir = os.path.join(project.path, DEFAULT_DATA_DIR)
-    run_dir = os.path.join(project.path, DEFAULT_RUN_DIR)
+    data_dir = project.get_data_dir()
+    run_dir = project.get_run_dir()
 
     cmd = [
         cartridge_cmd, 'repair', 'set-leader',
@@ -207,8 +202,8 @@ def test_repair_reload_remove_instance(cartridge_cmd, start_stop_cli, project_wi
     INSTANCE1 = 'instance-1'
     INSTANCE2 = 'instance-2'
 
-    ID1 = get_instance_id(project.name, INSTANCE1)
-    ID2 = get_instance_id(project.name, INSTANCE2)
+    ID1 = project.get_instance_id(INSTANCE1)
+    ID2 = project.get_instance_id(INSTANCE2)
 
     ADVERTISE_URI_TO_REMOVE = 'localhost:3302'
     ADMIN_HTTP_PORT = 8081
@@ -225,7 +220,7 @@ def test_repair_reload_remove_instance(cartridge_cmd, start_stop_cli, project_wi
         },
     }
 
-    write_conf(os.path.join(project.path, DEFAULT_CFG), cfg)
+    write_conf(project.get_cfg_path(), cfg)
 
     # start instance-1 and instance-2
     cli.start(project, daemonized=True)
@@ -250,8 +245,8 @@ def test_repair_reload_remove_instance(cartridge_cmd, start_stop_cli, project_wi
 
     assert instance_to_remove_uuid is not None
 
-    data_dir = os.path.join(project.path, DEFAULT_DATA_DIR)
-    run_dir = os.path.join(project.path, DEFAULT_RUN_DIR)
+    data_dir = project.get_data_dir()
+    run_dir = project.get_run_dir()
 
     cmd = [
         cartridge_cmd, 'repair', 'remove-instance',
@@ -295,8 +290,8 @@ def test_repair_reload_set_uri(cartridge_cmd, start_stop_cli, project_with_cartr
     INSTANCE1 = 'instance-1'
     INSTANCE2 = 'instance-2'
 
-    ID1 = get_instance_id(project.name, INSTANCE1)
-    ID2 = get_instance_id(project.name, INSTANCE2)
+    ID1 = project.get_instance_id(INSTANCE1)
+    ID2 = project.get_instance_id(INSTANCE2)
 
     ADMIN_HTTP_PORT = 8081
     ADVERTISE_URI_TO_CHANGE = 'localhost:3302'
@@ -318,7 +313,7 @@ def test_repair_reload_set_uri(cartridge_cmd, start_stop_cli, project_with_cartr
         },
     }
 
-    write_conf(os.path.join(project.path, DEFAULT_CFG), cfg)
+    write_conf(project.get_cfg_path(), cfg)
 
     # start instance-1 and instance-2
     cli.start(project, daemonized=True)
@@ -341,10 +336,10 @@ def test_repair_reload_set_uri(cartridge_cmd, start_stop_cli, project_with_cartr
     assert instance_to_set_uri_uuid is not None
 
     # first, change URI in config and restart instance
-    INSTANCE_ID = get_instance_id(project.name, INSTANCE_TO_SET_URI)
+    INSTANCE_ID = project.get_instance_id(INSTANCE_TO_SET_URI)
 
     cfg[INSTANCE_ID]['advertise_uri'] = NEW_ADVERTISE_URI
-    write_conf(os.path.join(project.path, DEFAULT_CFG), cfg)
+    write_conf(project.get_cfg_path(), cfg)
 
     cli.stop(project, [INSTANCE_TO_SET_URI])
     check_instances_stopped(cli, project, [INSTANCE_TO_SET_URI])
@@ -353,8 +348,8 @@ def test_repair_reload_set_uri(cartridge_cmd, start_stop_cli, project_with_cartr
     check_instances_running(cli, project, [INSTANCE1, INSTANCE2],  daemonized=True, skip_env_checks=True)
 
     # then, update cluster-wide configs
-    data_dir = os.path.join(project.path, DEFAULT_DATA_DIR)
-    run_dir = os.path.join(project.path, DEFAULT_RUN_DIR)
+    data_dir = project.get_data_dir()
+    run_dir = project.get_run_dir()
 
     cmd = [
         cartridge_cmd, 'repair', 'set-advertise-uri',

--- a/test/integration/replicasets/conftest.py
+++ b/test/integration/replicasets/conftest.py
@@ -4,7 +4,6 @@ import os
 import yaml
 
 from utils import run_command_and_get_output
-from utils import DEFAULT_CFG, DEFAULT_RPL_CFG
 from utils import ProjectWithTopology, Replicaset, Instance
 
 from project import Project
@@ -45,8 +44,8 @@ def built_project(cartridge_cmd, short_session_tmpdir, request):
     # don't change process title
     patch_cartridge_proc_titile(project)
 
-    os.remove(os.path.join(project.path, DEFAULT_CFG))
-    os.remove(os.path.join(project.path, DEFAULT_RPL_CFG))
+    os.remove(project.get_cfg_path())
+    os.remove(project.get_replicasets_cfg_path())
 
     return project
 
@@ -56,7 +55,7 @@ def default_project_with_instances(built_default_project, start_stop_cli, reques
     cli = start_stop_cli
     project = built_default_project
 
-    with open(os.path.join(project.path, DEFAULT_CFG)) as f:
+    with open(project.get_cfg_path()) as f:
         instances_cfg = yaml.load(f, Loader=yaml.FullLoader)
 
     instances = [

--- a/test/integration/replicasets/test_list_replicasets.py
+++ b/test/integration/replicasets/test_list_replicasets.py
@@ -1,8 +1,5 @@
-import os
-
 from utils import run_command_and_get_output
 from utils import write_conf
-from utils import DEFAULT_RPL_CFG
 
 
 def test_default_application(cartridge_cmd, default_project_with_instances):
@@ -62,7 +59,7 @@ def test_list(cartridge_cmd, project_with_instances):
     s1_replica2 = instances['s1-replica-2']
 
     # setup replicasets
-    rpl_cfg_path = os.path.join(project.path, DEFAULT_RPL_CFG)
+    rpl_cfg_path = project.get_replicasets_cfg_path()
     rpl_cfg = {
         'router': {
             'roles': ['vshard-router', 'app.roles.custom', 'failover-coordinator'],

--- a/test/integration/replicasets/test_setup.py
+++ b/test/integration/replicasets/test_setup.py
@@ -4,7 +4,6 @@ import yaml
 
 from utils import run_command_and_get_output
 from utils import get_log_lines
-from utils import DEFAULT_RPL_CFG
 from utils import write_conf
 from utils import get_replicasets
 from utils import is_vshard_bootstrapped
@@ -92,7 +91,7 @@ def test_default_application(cartridge_cmd, start_stop_cli, project_with_cartrid
 
     admin_api_url = 'http://localhost:%s/admin/api' % '8081'
 
-    rpl_cfg_path = os.path.join(project.path, DEFAULT_RPL_CFG)
+    rpl_cfg_path = project.get_replicasets_cfg_path()
     with open(rpl_cfg_path) as f:
         rpl_cfg = yaml.load(f, Loader=yaml.FullLoader)
 
@@ -132,7 +131,7 @@ def test_setup(project_with_instances, cartridge_cmd):
 
     admin_api_url = router.get_admin_api_url()
 
-    rpl_cfg_path = os.path.join(project.path, DEFAULT_RPL_CFG)
+    rpl_cfg_path = project.get_replicasets_cfg_path()
 
     # create router replicaset
     rpl_cfg = {
@@ -246,7 +245,7 @@ def test_setup_bootstrap_vshard(project_with_instances, cartridge_cmd):
 
     admin_api_url = router.get_admin_api_url()
 
-    rpl_cfg_path = os.path.join(project.path, DEFAULT_RPL_CFG)
+    rpl_cfg_path = project.get_replicasets_cfg_path()
 
     # create router replicaset
     # vshard bootstrapping will fail
@@ -310,7 +309,7 @@ def test_save(project_with_vshard_replicasets, cartridge_cmd):
     router = instances['router']
     admin_api_url = router.get_admin_api_url()
 
-    rpl_cfg_path = os.path.join(project.path, DEFAULT_RPL_CFG)
+    rpl_cfg_path = project.get_replicasets_cfg_path()
 
     cmd = [
         cartridge_cmd, 'replicasets', 'save',
@@ -348,7 +347,7 @@ def test_setup_file_not_exists(project_with_vshard_replicasets, cartridge_cmd):
 def test_bad_rpl_conf_format(project_with_instances, cartridge_cmd):
     project = project_with_instances.project
 
-    rpl_cfg_path = os.path.join(project.path, DEFAULT_RPL_CFG)
+    rpl_cfg_path = project.get_replicasets_cfg_path()
 
     # create router replicaset
     rpl_cfg = {
@@ -376,7 +375,7 @@ def test_setup_file_specified(project_with_instances, cartridge_cmd):
 
     admin_api_url = router.get_admin_api_url()
 
-    rpl_cfg_path = os.path.join(project.path, 'my-replicasets.yml')
+    rpl_cfg_path = project.get_replicasets_cfg_path('my-replicasets.yml')
 
     # create router replicaset
     rpl_cfg = {
@@ -407,7 +406,7 @@ def test_save_file_specified(project_with_vshard_replicasets, cartridge_cmd):
     router = instances['router']
     admin_api_url = router.get_admin_api_url()
 
-    rpl_cfg_path = os.path.join(project.path, 'my-replicasets.yml')
+    rpl_cfg_path = project.get_replicasets_cfg_path('my-replicasets.yml')
 
     cmd = [
         cartridge_cmd, 'replicasets', 'save',

--- a/test/integration/running/test_clean.py
+++ b/test/integration/running/test_clean.py
@@ -1,36 +1,47 @@
 import os
 
-from utils import get_instance_id, get_stateboard_name
-from utils import DEFAULT_CFG, DEFAULT_DATA_DIR, DEFAULT_LOG_DIR, DEFAULT_RUN_DIR
 from utils import write_conf
 from utils import check_instances_running
 from utils import check_instances_stopped
 
 
-CARTRIDGE_CONF = '.cartridge.yml'
-
 FILES_TO_BE_DELETED = ['log', 'workdir', 'console-sock', 'notify-sock', 'pid']
 
 
-def get_instance_files(project, instance_id, log_dir=DEFAULT_LOG_DIR, data_dir=DEFAULT_DATA_DIR,
-                       run_dir=DEFAULT_RUN_DIR):
+def get_instance_files(project, instance_name, log_dir=None, data_dir=None, run_dir=None):
+    run_dir = project.get_run_dir(run_dir)
+
     return {
-        'log': os.path.join(project.path, log_dir, '%s.log' % instance_id),
-        'workdir': os.path.join(project.path, data_dir, instance_id),
-        'console-sock': os.path.join(project.path, run_dir, '%s.control' % instance_id),
-        'pid': os.path.join(project.path, run_dir, '%s.pid' % instance_id),
-        'notify-sock': os.path.join(project.path, run_dir, '%s.notify' % instance_id),
+        'log': project.get_log_dir(instance_name, log_dir),
+        'workdir': project.get_workdir(instance_name, data_dir),
+        'console-sock': project.get_console_sock(instance_name, run_dir),
+        'pid': project.get_pidfile(instance_name, run_dir),
+        'notify-sock': project.get_notify_sock(instance_name, run_dir),
     }
 
 
-def create_instances_files(project, instance_names=[],
-                           log_dir=DEFAULT_LOG_DIR, data_dir=DEFAULT_DATA_DIR, run_dir=DEFAULT_RUN_DIR):
-    instance_ids = [get_instance_id(project.name, instance_name) for instance_name in instance_names]
-    instance_ids.append(get_stateboard_name(project.name))
+def get_stateboard_files(project, log_dir=None, data_dir=None, run_dir=None):
+    run_dir = project.get_run_dir(run_dir)
 
-    for instance_id in instance_ids:
-        instance_files = get_instance_files(project, instance_id, log_dir, data_dir, run_dir)
+    return {
+        'log': project.get_sb_log_dir(log_dir),
+        'workdir': project.get_sb_workdir(data_dir),
+        'console-sock': project.get_sb_console_sock(run_dir),
+        'pid': project.get_sb_pidfile(run_dir),
+        'notify-sock': project.get_sb_notify_sock(run_dir),
+    }
 
+
+def create_instances_files(project, instance_names=[], stateboard=False, log_dir=None, data_dir=None, run_dir=None):
+    all_files = [
+        get_instance_files(project, instance_name, log_dir, data_dir, run_dir)
+        for instance_name in instance_names
+    ]
+
+    if stateboard:
+        all_files.append(get_stateboard_files(project, log_dir, data_dir, run_dir))
+
+    for instance_files in all_files:
         for _, path in instance_files.items():
             if not os.path.exists(path):
                 basepath = os.path.dirname(path)
@@ -40,9 +51,9 @@ def create_instances_files(project, instance_names=[],
 
 
 def assert_clean_logs(logs, project, instance_names=[], stateboard=False, exp_res='OK'):
-    instance_ids = [get_instance_id(project.name, instance_name) for instance_name in instance_names]
+    instance_ids = [project.get_instance_id(instance_name) for instance_name in instance_names]
     if stateboard:
-        instance_ids.append(get_stateboard_name(project.name))
+        instance_ids.append(project.get_stateboard_id())
 
     assert len(logs) == len(instance_ids)
     assert all([log_line.endswith(exp_res) for log_line in logs])
@@ -53,17 +64,25 @@ def assert_clean_logs(logs, project, instance_names=[], stateboard=False, exp_re
 
 
 def assert_files_cleaned(project, instance_names=[], stateboard=False, logs=None, exp_res_log='OK',
-                         log_dir=DEFAULT_LOG_DIR, data_dir=DEFAULT_DATA_DIR, run_dir=DEFAULT_RUN_DIR):
-    instance_ids = [get_instance_id(project.name, instance_name) for instance_name in instance_names]
+                         log_dir=None, data_dir=None, run_dir=None):
+    run_dir = project.get_run_dir(run_dir)
+
+    instance_ids = [project.get_instance_id(instance_name) for instance_name in instance_names]
     if stateboard:
-        instance_ids.append(get_stateboard_name(project.name))
+        instance_ids.append(project.get_stateboard_id())
 
     if logs is not None:
         assert_clean_logs(logs, project, instance_names, stateboard, exp_res_log)
 
-    for instance_id in instance_ids:
-        instance_files = get_instance_files(project, instance_id, log_dir, data_dir, run_dir)
+    all_files = [
+        get_instance_files(project, instance_name, log_dir, data_dir, run_dir)
+        for instance_name in instance_names
+    ]
 
+    if stateboard:
+        all_files.append(get_stateboard_files(project, log_dir, data_dir, run_dir))
+
+    for instance_files in all_files:
         for file_type, path in instance_files.items():
             if file_type in FILES_TO_BE_DELETED:
                 assert not os.path.exists(path)
@@ -72,14 +91,18 @@ def assert_files_cleaned(project, instance_names=[], stateboard=False, logs=None
 
 
 def assert_files_exists(project, instance_names=[], stateboard=False,
-                        log_dir=DEFAULT_LOG_DIR, data_dir=DEFAULT_DATA_DIR, run_dir=DEFAULT_RUN_DIR):
-    instance_ids = [get_instance_id(project.name, instance_name) for instance_name in instance_names]
+                        log_dir=None, data_dir=None, run_dir=None):
+    run_dir = project.get_run_dir(run_dir)
+
+    all_files = [
+        get_instance_files(project, instance_name, log_dir, data_dir, run_dir)
+        for instance_name in instance_names
+    ]
+
     if stateboard:
-        instance_ids.append(get_stateboard_name(project.name))
+        all_files.append(get_stateboard_files(project, log_dir, data_dir, run_dir))
 
-    for instance_id in instance_ids:
-        instance_files = get_instance_files(project, instance_id, log_dir, data_dir, run_dir)
-
+    for instance_files in all_files:
         for _, path in instance_files.items():
             assert os.path.exists(path)
 
@@ -92,19 +115,19 @@ def test_clean_by_name(start_stop_cli, project_without_dependencies):
     INSTANCE2 = 'instance-2'
 
     # two instances
-    create_instances_files(project, [INSTANCE1, INSTANCE2])
+    create_instances_files(project, [INSTANCE1, INSTANCE2], stateboard=True)
     logs = cli.clean(project, [INSTANCE1, INSTANCE2])
     assert_files_cleaned(project, [INSTANCE1, INSTANCE2], logs=logs)
     assert_files_exists(project, [], stateboard=True)
 
     # one instance w/ stateboard
-    create_instances_files(project, [INSTANCE1, INSTANCE2])
+    create_instances_files(project, [INSTANCE1, INSTANCE2], stateboard=True)
     logs = cli.clean(project, [INSTANCE1], stateboard=True)
     assert_files_cleaned(project, [INSTANCE1],  stateboard=True, logs=logs)
     assert_files_exists(project, [INSTANCE2])
 
     # one instance stateboard-only
-    create_instances_files(project, [INSTANCE1, INSTANCE2])
+    create_instances_files(project, [INSTANCE1, INSTANCE2], stateboard=True)
     logs = cli.clean(project, stateboard_only=True)
     assert_files_cleaned(project, [],  stateboard=True, logs=logs)
     assert_files_exists(project, [INSTANCE1, INSTANCE2])
@@ -117,24 +140,24 @@ def test_clean_from_conf(start_stop_cli, project_without_dependencies):
     INSTANCE1 = 'instance-1'
     INSTANCE2 = 'instance-2'
 
-    write_conf(os.path.join(project.path, DEFAULT_CFG), {
-        get_instance_id(project.name, INSTANCE1): {},
-        get_instance_id(project.name, INSTANCE2): {},
+    write_conf(project.get_cfg_path(), {
+        project.get_instance_id(INSTANCE1): {},
+        project.get_instance_id(INSTANCE2): {},
     })
 
     # only instances
-    create_instances_files(project, [INSTANCE1, INSTANCE2])
+    create_instances_files(project, [INSTANCE1, INSTANCE2], stateboard=True)
     logs = cli.clean(project)
     assert_files_cleaned(project, [INSTANCE1, INSTANCE2], logs=logs)
     assert_files_exists(project, stateboard=True)
 
     # w/ stateboard
-    create_instances_files(project, [INSTANCE1, INSTANCE2])
+    create_instances_files(project, [INSTANCE1, INSTANCE2], stateboard=True)
     logs = cli.clean(project, stateboard=True)
     assert_files_cleaned(project, [INSTANCE1, INSTANCE2], stateboard=True, logs=logs)
 
     # stateboard-only
-    create_instances_files(project, [INSTANCE1, INSTANCE2])
+    create_instances_files(project, [INSTANCE1, INSTANCE2], stateboard=True)
     logs = cli.clean(project, stateboard_only=True)
     assert_files_cleaned(project,  stateboard=True, logs=logs)
     assert_files_exists(project, [INSTANCE1, INSTANCE2])
@@ -150,12 +173,12 @@ def test_clean_cfg(start_stop_cli, project_without_dependencies):
     cfg = 'my-conf.yml'
 
     write_conf(os.path.join(project.path, cfg), {
-        get_instance_id(project.name, INSTANCE1): {},
-        get_instance_id(project.name, INSTANCE2): {},
+        project.get_instance_id(INSTANCE1): {},
+        project.get_instance_id(INSTANCE2): {},
     })
 
     # --cfg
-    create_instances_files(project, [INSTANCE1, INSTANCE2])
+    create_instances_files(project, [INSTANCE1, INSTANCE2], stateboard=True)
     logs = cli.clean(project, stateboard=True, cfg=cfg)
     assert_files_cleaned(project, [INSTANCE1, INSTANCE2], stateboard=True, logs=logs)
 
@@ -169,21 +192,21 @@ def test_clean_by_name_with_paths(start_stop_cli, project_without_dependencies):
 
     # --log-dir
     log_dir = 'my-log'
-    create_instances_files(project, [INSTANCE1, INSTANCE2], log_dir=log_dir)
+    create_instances_files(project, [INSTANCE1, INSTANCE2], log_dir=log_dir, stateboard=True)
     logs = cli.clean(project, [INSTANCE1], stateboard=True, log_dir=log_dir)
     assert_files_cleaned(project, [INSTANCE1],  stateboard=True, log_dir=log_dir, logs=logs)
     assert_files_exists(project, [INSTANCE2], log_dir=log_dir)
 
     # --run-dir
     run_dir = 'my-run'
-    create_instances_files(project, [INSTANCE1, INSTANCE2], run_dir=run_dir)
+    create_instances_files(project, [INSTANCE1, INSTANCE2], run_dir=run_dir, stateboard=True)
     logs = cli.clean(project, [INSTANCE1], stateboard=True, run_dir=run_dir)
     assert_files_cleaned(project, [INSTANCE1],  stateboard=True, run_dir=run_dir, logs=logs)
     assert_files_exists(project, [INSTANCE2], run_dir=run_dir)
 
     # --data-dir
     data_dir = 'my-data'
-    create_instances_files(project, [INSTANCE1, INSTANCE2], data_dir=data_dir)
+    create_instances_files(project, [INSTANCE1, INSTANCE2], data_dir=data_dir, stateboard=True)
     logs = cli.clean(project, [INSTANCE1], stateboard=True, data_dir=data_dir)
     assert_files_cleaned(project, [INSTANCE1],  stateboard=True, data_dir=data_dir, logs=logs)
     assert_files_exists(project, [INSTANCE2], data_dir=data_dir)
@@ -198,30 +221,30 @@ def test_clean_by_name_with_paths_from_conf(start_stop_cli, project_without_depe
 
     # --log-dir
     log_dir = 'my-log'
-    write_conf(os.path.join(project.path, CARTRIDGE_CONF), {
+    write_conf(project.get_cli_cfg_path(), {
         'log-dir': log_dir,
     })
-    create_instances_files(project, [INSTANCE1, INSTANCE2], log_dir=log_dir)
+    create_instances_files(project, [INSTANCE1, INSTANCE2], stateboard=True, log_dir=log_dir)
     logs = cli.clean(project, [INSTANCE1], stateboard=True)
     assert_files_cleaned(project, [INSTANCE1],  stateboard=True, log_dir=log_dir, logs=logs)
     assert_files_exists(project, [INSTANCE2], log_dir=log_dir)
 
     # --run-dir
     run_dir = 'my-run'
-    write_conf(os.path.join(project.path, CARTRIDGE_CONF), {
+    write_conf(project.get_cli_cfg_path(), {
         'run-dir': run_dir,
     })
-    create_instances_files(project, [INSTANCE1, INSTANCE2], run_dir=run_dir)
+    create_instances_files(project, [INSTANCE1, INSTANCE2], stateboard=True, run_dir=run_dir)
     logs = cli.clean(project, [INSTANCE1], stateboard=True)
     assert_files_cleaned(project, [INSTANCE1],  stateboard=True, run_dir=run_dir, logs=logs)
     assert_files_exists(project, [INSTANCE2], run_dir=run_dir)
 
     # --data-dir
     data_dir = 'my-data'
-    write_conf(os.path.join(project.path, CARTRIDGE_CONF), {
+    write_conf(project.get_cli_cfg_path(), {
         'data-dir': data_dir,
     })
-    create_instances_files(project, [INSTANCE1, INSTANCE2], data_dir=data_dir)
+    create_instances_files(project, [INSTANCE1, INSTANCE2], stateboard=True, data_dir=data_dir)
     logs = cli.clean(project, [INSTANCE1], stateboard=True)
     assert_files_cleaned(project, [INSTANCE1],  stateboard=True, data_dir=data_dir, logs=logs)
     assert_files_exists(project, [INSTANCE2], data_dir=data_dir)
@@ -235,15 +258,13 @@ def test_skipped(start_stop_cli, project_without_dependencies):
     INSTANCE2 = 'instance-2'
 
     # clean once
-    create_instances_files(project, [INSTANCE1, INSTANCE2])
-    logs = cli.clean(project, [INSTANCE1, INSTANCE2])
-    assert_files_cleaned(project, [INSTANCE1, INSTANCE2], logs=logs)
-    assert_files_exists(project, [], stateboard=True)
+    create_instances_files(project, [INSTANCE1, INSTANCE2], stateboard=True)
+    logs = cli.clean(project, [INSTANCE1, INSTANCE2], stateboard=True)
+    assert_files_cleaned(project, [INSTANCE1, INSTANCE2], stateboard=True, logs=logs)
 
     # clean again
-    logs = cli.clean(project, [INSTANCE1, INSTANCE2])
-    assert_files_cleaned(project, [INSTANCE1, INSTANCE2], logs=logs, exp_res_log='SKIPPED')
-    assert_files_exists(project, [], stateboard=True)
+    logs = cli.clean(project, [INSTANCE1, INSTANCE2], stateboard=True)
+    assert_files_cleaned(project, [INSTANCE1, INSTANCE2], stateboard=True, logs=logs, exp_res_log='SKIPPED')
 
 
 def test_for_running(start_stop_cli, project_without_dependencies):
@@ -253,8 +274,8 @@ def test_for_running(start_stop_cli, project_without_dependencies):
     INSTANCE1 = 'instance-1'
     INSTANCE2 = 'instance-2'
 
-    ID1 = get_instance_id(project.name, INSTANCE1)
-    ID2 = get_instance_id(project.name, INSTANCE2)
+    ID1 = project.get_instance_id(INSTANCE1)
+    ID2 = project.get_instance_id(INSTANCE2)
 
     # start two instances
     cli.start(project, [INSTANCE1, INSTANCE2], daemonized=True)

--- a/test/integration/running/test_log.py
+++ b/test/integration/running/test_log.py
@@ -1,8 +1,4 @@
-import os
-
-from utils import get_instance_id, get_stateboard_name
 from utils import check_instances_running
-from utils import DEFAULT_CFG
 
 from project import patch_init_to_log_lines
 from utils import write_conf
@@ -33,9 +29,9 @@ def test_log_by_name(start_stop_cli, project_without_dependencies):
     INSTANCE1 = 'instance-1'
     INSTANCE2 = 'instance-2'
 
-    ID1 = get_instance_id(project.name, INSTANCE1)
-    ID2 = get_instance_id(project.name, INSTANCE2)
-    STATEBOARD_ID = get_stateboard_name(project.name)
+    ID1 = project.get_instance_id(INSTANCE1)
+    ID2 = project.get_instance_id(INSTANCE2)
+    STATEBOARD_ID = project.get_stateboard_id()
 
     # start instance-1 and instance-2
     cli.start(project, [INSTANCE1, INSTANCE2], stateboard=True, daemonized=True)
@@ -69,11 +65,11 @@ def test_log_from_conf(start_stop_cli, project_without_dependencies):
     INSTANCE1 = 'instance-1'
     INSTANCE2 = 'instance-2'
 
-    ID1 = get_instance_id(project.name, INSTANCE1)
-    ID2 = get_instance_id(project.name, INSTANCE2)
-    STATEBOARD_ID = get_stateboard_name(project.name)
+    ID1 = project.get_instance_id(INSTANCE1)
+    ID2 = project.get_instance_id(INSTANCE2)
+    STATEBOARD_ID = project.get_stateboard_id()
 
-    write_conf(os.path.join(project.path, DEFAULT_CFG), {
+    write_conf(project.get_cfg_path(), {
         ID1: {},
         ID2: {},
     })
@@ -110,12 +106,12 @@ def test_log_cfg(start_stop_cli, project_without_dependencies):
     INSTANCE1 = 'instance-1'
     INSTANCE2 = 'instance-2'
 
-    ID1 = get_instance_id(project.name, INSTANCE1)
-    ID2 = get_instance_id(project.name, INSTANCE2)
+    ID1 = project.get_instance_id(INSTANCE1)
+    ID2 = project.get_instance_id(INSTANCE2)
 
     CFG = 'my-conf.yml'
 
-    write_conf(os.path.join(project.path, CFG), {
+    write_conf(project.get_cfg_path(CFG), {
         ID1: {},
         ID2: {},
     })
@@ -140,12 +136,12 @@ def test_log_log_dir(start_stop_cli, project_without_dependencies):
     INSTANCE1 = 'instance-1'
     INSTANCE2 = 'instance-2'
 
-    ID1 = get_instance_id(project.name, INSTANCE1)
-    ID2 = get_instance_id(project.name, INSTANCE2)
+    ID1 = project.get_instance_id(INSTANCE1)
+    ID2 = project.get_instance_id(INSTANCE2)
 
     LOG_DIR = 'my-log-dir'
 
-    write_conf(os.path.join(project.path, DEFAULT_CFG), {
+    write_conf(project.get_cfg_path(), {
         ID1: {},
         ID2: {},
     })
@@ -170,12 +166,12 @@ def test_log_run_dir(start_stop_cli, project_without_dependencies):
     INSTANCE1 = 'instance-1'
     INSTANCE2 = 'instance-2'
 
-    ID1 = get_instance_id(project.name, INSTANCE1)
-    ID2 = get_instance_id(project.name, INSTANCE2)
+    ID1 = project.get_instance_id(INSTANCE1)
+    ID2 = project.get_instance_id(INSTANCE2)
 
-    RUN_DIR = 'my-log-dir'
+    RUN_DIR = 'my-run-dir'
 
-    write_conf(os.path.join(project.path, DEFAULT_CFG), {
+    write_conf(project.get_cfg_path(), {
         ID1: {},
         ID2: {},
     })
@@ -202,9 +198,9 @@ def test_log_last_n_lines(start_stop_cli, project_without_dependencies):
     INSTANCE1 = 'instance-1'
     INSTANCE2 = 'instance-2'
 
-    ID1 = get_instance_id(project.name, INSTANCE1)
-    ID2 = get_instance_id(project.name, INSTANCE2)
-    STATEBOARD_ID = get_stateboard_name(project.name)
+    ID1 = project.get_instance_id(INSTANCE1)
+    ID2 = project.get_instance_id(INSTANCE2)
+    STATEBOARD_ID = project.get_stateboard_id()
 
     # start instance-1 and instance-2
     cli.start(project, [INSTANCE1, INSTANCE2], stateboard=True, daemonized=True)

--- a/test/integration/running/test_running.py
+++ b/test/integration/running/test_running.py
@@ -3,18 +3,12 @@ import shutil
 import pytest
 import re
 
-from utils import get_instance_id, get_stateboard_name
 from utils import check_instances_running, check_instances_stopped
-from utils import DEFAULT_CFG
-from utils import DEFAULT_SCRIPT
 from utils import STATUS_NOT_STARTED, STATUS_RUNNING, STATUS_STOPPED
 from utils import write_conf
 
 from project import patch_init_to_send_statuses
 from project import patch_init_to_send_ready_after_timeout
-
-
-CARTRIDGE_CONF = '.cartridge.yml'
 
 
 # #####
@@ -106,9 +100,9 @@ def test_start_interactive_from_conf(start_stop_cli, project_without_dependencie
     INSTANCE1 = 'instance-1'
     INSTANCE2 = 'instance-2'
 
-    write_conf(os.path.join(project.path, DEFAULT_CFG), {
-        get_instance_id(project.name, INSTANCE1): {},
-        get_instance_id(project.name, INSTANCE2): {},
+    write_conf(project.get_cfg_path(), {
+        project.get_instance_id(INSTANCE1): {},
+        project.get_instance_id(INSTANCE2): {},
     })
 
     # start instances
@@ -123,9 +117,9 @@ def test_start_stop_from_conf(start_stop_cli, project_without_dependencies):
     INSTANCE1 = 'instance-1'
     INSTANCE2 = 'instance-2'
 
-    write_conf(os.path.join(project.path, DEFAULT_CFG), {
-        get_instance_id(project.name, INSTANCE1): {},
-        get_instance_id(project.name, INSTANCE2): {},
+    write_conf(project.get_cfg_path(), {
+        project.get_instance_id(INSTANCE1): {},
+        project.get_instance_id(INSTANCE2): {},
     })
 
     # start instances
@@ -144,9 +138,9 @@ def test_start_interactive_from_conf_with_stateboard(start_stop_cli, project_wit
     INSTANCE1 = 'instance-1'
     INSTANCE2 = 'instance-2'
 
-    write_conf(os.path.join(project.path, DEFAULT_CFG), {
-        get_instance_id(project.name, INSTANCE1): {},
-        get_instance_id(project.name, INSTANCE2): {},
+    write_conf(project.get_cfg_path(), {
+        project.get_instance_id(INSTANCE1): {},
+        project.get_instance_id(INSTANCE2): {},
     })
 
     # start instances
@@ -161,9 +155,9 @@ def test_start_interactive_from_conf_stateboard_only(start_stop_cli, project_wit
     INSTANCE1 = 'instance-1'
     INSTANCE2 = 'instance-2'
 
-    write_conf(os.path.join(project.path, DEFAULT_CFG), {
-        get_instance_id(project.name, INSTANCE1): {},
-        get_instance_id(project.name, INSTANCE2): {},
+    write_conf(project.get_cfg_path(), {
+        project.get_instance_id(INSTANCE1): {},
+        project.get_instance_id(INSTANCE2): {},
     })
 
     # start instances
@@ -178,9 +172,9 @@ def test_start_stop_from_conf_with_stateboard(start_stop_cli, project_without_de
     INSTANCE1 = 'instance-1'
     INSTANCE2 = 'instance-2'
 
-    write_conf(os.path.join(project.path, DEFAULT_CFG), {
-        get_instance_id(project.name, INSTANCE1): {},
-        get_instance_id(project.name, INSTANCE2): {},
+    write_conf(project.get_cfg_path(), {
+        project.get_instance_id(INSTANCE1): {},
+        project.get_instance_id(INSTANCE2): {},
     })
 
     # start instances
@@ -199,9 +193,9 @@ def test_start_stop_from_conf_stateboard_only(start_stop_cli, project_without_de
     INSTANCE1 = 'instance-1'
     INSTANCE2 = 'instance-2'
 
-    write_conf(os.path.join(project.path, DEFAULT_CFG), {
-        get_instance_id(project.name, INSTANCE1): {},
-        get_instance_id(project.name, INSTANCE2): {},
+    write_conf(project.get_cfg_path(), {
+        project.get_instance_id(INSTANCE1): {},
+        project.get_instance_id(INSTANCE2): {},
     })
 
     # start instances
@@ -220,9 +214,9 @@ def test_status_by_name(start_stop_cli, project_without_dependencies):
     INSTANCE1 = 'instance-1'
     INSTANCE2 = 'instance-2'
 
-    ID1 = get_instance_id(project.name, INSTANCE1)
-    ID2 = get_instance_id(project.name, INSTANCE2)
-    STATEBOARD_ID = get_stateboard_name(project.name)
+    ID1 = project.get_instance_id(INSTANCE1)
+    ID2 = project.get_instance_id(INSTANCE2)
+    STATEBOARD_ID = project.get_stateboard_id()
 
     # get status w/o stateboard
     status = cli.get_status(project, [INSTANCE1, INSTANCE2])
@@ -292,11 +286,11 @@ def test_status_from_conf(start_stop_cli, project_without_dependencies):
     INSTANCE1 = 'instance-1'
     INSTANCE2 = 'instance-2'
 
-    ID1 = get_instance_id(project.name, INSTANCE1)
-    ID2 = get_instance_id(project.name, INSTANCE2)
-    STATEBOARD_ID = get_stateboard_name(project.name)
+    ID1 = project.get_instance_id(INSTANCE1)
+    ID2 = project.get_instance_id(INSTANCE2)
+    STATEBOARD_ID = project.get_stateboard_id()
 
-    write_conf(os.path.join(project.path, DEFAULT_CFG), {
+    write_conf(project.get_cfg_path(), {
         ID1: {},
         ID2: {},
     })
@@ -370,12 +364,12 @@ def test_start_stop_status_cfg(start_stop_cli, project_without_dependencies):
     INSTANCE1 = 'instance-1'
     INSTANCE2 = 'instance-2'
 
-    ID1 = get_instance_id(project.name, INSTANCE1)
-    ID2 = get_instance_id(project.name, INSTANCE2)
+    ID1 = project.get_instance_id(INSTANCE1)
+    ID2 = project.get_instance_id(INSTANCE2)
 
     CFG = 'my-conf.yml'
 
-    write_conf(os.path.join(project.path, CFG), {
+    write_conf(project.get_cfg_path(CFG), {
         ID1: {},
         ID2: {},
     })
@@ -411,9 +405,9 @@ def test_start_stop_status_run_dir(start_stop_cli, project_without_dependencies)
     INSTANCE1 = 'instance-1'
     INSTANCE2 = 'instance-2'
 
-    ID1 = get_instance_id(project.name, INSTANCE1)
-    ID2 = get_instance_id(project.name, INSTANCE2)
-    STATEBOARD_ID = get_stateboard_name(project.name)
+    ID1 = project.get_instance_id(INSTANCE1)
+    ID2 = project.get_instance_id(INSTANCE2)
+    STATEBOARD_ID = project.get_stateboard_id()
 
     RUN_DIR = 'my-run'
 
@@ -447,13 +441,13 @@ def test_start_stop_status_run_dir_from_conf(start_stop_cli, project_without_dep
     INSTANCE1 = 'instance-1'
     INSTANCE2 = 'instance-2'
 
-    ID1 = get_instance_id(project.name, INSTANCE1)
-    ID2 = get_instance_id(project.name, INSTANCE2)
-    STATEBOARD_ID = get_stateboard_name(project.name)
+    ID1 = project.get_instance_id(INSTANCE1)
+    ID2 = project.get_instance_id(INSTANCE2)
+    STATEBOARD_ID = project.get_stateboard_id()
 
     RUN_DIR = 'my-run'
 
-    write_conf(os.path.join(project.path, CARTRIDGE_CONF), {
+    write_conf(project.get_cli_cfg_path(), {
         'run-dir': RUN_DIR,
     })
 
@@ -506,7 +500,7 @@ def test_start_data_dir_from_conf(start_stop_cli, project_without_dependencies):
 
     DATA_DIR = 'my-data'
 
-    write_conf(os.path.join(project.path, CARTRIDGE_CONF), {
+    write_conf(project.get_cli_cfg_path(), {
         'data-dir': DATA_DIR,
     })
 
@@ -526,7 +520,7 @@ def test_start_script(start_stop_cli, project_without_dependencies):
     INSTANCE2 = 'instance-2'
 
     SCRIPT = 'my-init.lua'
-    shutil.copyfile(os.path.join(project.path, DEFAULT_SCRIPT), os.path.join(project.path, SCRIPT))
+    shutil.copyfile(project.get_script(), os.path.join(project.path, SCRIPT))
 
     cli.start(project, [INSTANCE1, INSTANCE2], stateboard=True, script=SCRIPT)
     check_instances_running(
@@ -544,9 +538,9 @@ def test_start_script_from_conf(start_stop_cli, project_without_dependencies):
     INSTANCE2 = 'instance-2'
 
     SCRIPT = 'my-init.lua'
-    shutil.copyfile(os.path.join(project.path, DEFAULT_SCRIPT), os.path.join(project.path, SCRIPT))
+    shutil.copyfile(project.get_script(), os.path.join(project.path, SCRIPT))
 
-    write_conf(os.path.join(project.path, CARTRIDGE_CONF), {
+    write_conf(project.get_cli_cfg_path(), {
         'script': SCRIPT,
     })
 
@@ -585,7 +579,7 @@ def test_start_log_dir_from_conf(start_stop_cli, project_without_dependencies):
 
     LOG_DIR = 'my-log-dir'
 
-    write_conf(os.path.join(project.path, CARTRIDGE_CONF), {
+    write_conf(project.get_cli_cfg_path(), {
         'log-dir': LOG_DIR,
     })
 
@@ -631,7 +625,7 @@ def test_project_with_non_existent_script(start_stop_cli, project_without_depend
     project = project_without_dependencies
     cli = start_stop_cli
 
-    os.remove(os.path.join(project.path, DEFAULT_SCRIPT))
+    os.remove(project.get_script())
 
     INSTANCE1 = 'instance-1'
 
@@ -651,9 +645,9 @@ def test_start_with_timeout(start_stop_cli, project_without_dependencies):
     INSTANCE1 = 'instance-1'
     INSTANCE2 = 'instance-2'
 
-    ID1 = get_instance_id(project.name, INSTANCE1)
-    ID2 = get_instance_id(project.name, INSTANCE2)
-    STATEBOARD_ID = get_stateboard_name(project.name)
+    ID1 = project.get_instance_id(INSTANCE1)
+    ID2 = project.get_instance_id(INSTANCE2)
+    STATEBOARD_ID = project.get_stateboard_id()
 
     # start w/ timeout > TIMEOUT_SECONDS
     cli.terminate()

--- a/test/project.py
+++ b/test/project.py
@@ -6,13 +6,24 @@ import shutil
 from utils import create_project
 from utils import recursive_listdir
 from utils import tarantool_enterprise_is_used
-from utils import DEFAULT_RUN_DIR
 
 
 FILES_DIR = 'test/files'
 INIT_NO_CARTRIDGE_FILEPATH = os.path.join(FILES_DIR, 'init_no_cartridge.lua')
 INIT_IGNORE_SIGTERM_FILEPATH = os.path.join(FILES_DIR, 'init_ignore_sigterm.lua')
 INIT_ADMIN_FUNCS_FILEPATH = os.path.join(FILES_DIR, 'init_admin_funcs.lua')
+
+
+CLI_CONF = '.cartridge.yml'
+
+DEFAULT_CFG = 'instances.yml'
+DEFAULT_REPLICASETS_CFG = 'replicasets.yml'
+DEFAULT_RUN_DIR = 'tmp/run'
+DEFAULT_DATA_DIR = 'tmp/data'
+DEFAULT_LOG_DIR = 'tmp/log'
+
+DEFAULT_SCRIPT = 'init.lua'
+DEFAULT_STATEBOARD_SCRIPT = 'stateboard.init.lua'
 
 
 CARTRIDGE_PACK_SPECIAL_FILES = {
@@ -102,8 +113,97 @@ class Project:
 
         self.image_runtime_requirements_filepath = None
 
-    def get_console_sock_path(self, instance_name):
-        return os.path.join(self.path, DEFAULT_RUN_DIR, '%s.%s.control' % (self.name, instance_name))
+    # IDs
+    def get_instance_id(self, instance_name):
+        return '%s.%s' % (self.name, instance_name)
+
+    def get_stateboard_id(self):
+        return '{}-stateboard'.format(self.name)
+
+    # cfg files
+    def get_cli_cfg_path(self):
+        return os.path.join(self.path, CLI_CONF)
+
+    def get_cfg_path(self, specified_cfg=None):
+        cfg_path = specified_cfg if specified_cfg is not None else DEFAULT_CFG
+        return os.path.join(self.path, cfg_path)
+
+    def get_replicasets_cfg_path(self, specified_cfg=None):
+        replicasets_cfg_path = specified_cfg if specified_cfg is not None else DEFAULT_REPLICASETS_CFG
+        return os.path.join(self.path, replicasets_cfg_path)
+
+    # data dir
+    def get_data_dir(self, specified_data_dir=None):
+        data_dir = specified_data_dir if specified_data_dir is not None else DEFAULT_DATA_DIR
+        return os.path.join(self.path, data_dir)
+
+    # - work dirs
+    def get_workdir(self, instance_name, specified_data_dir=None):
+        data_dir = self.get_data_dir(specified_data_dir)
+        instance_id = self.get_instance_id(instance_name)
+        return os.path.join(data_dir, instance_id)
+
+    def get_sb_workdir(self, specified_data_dir=None):
+        data_dir = self.get_data_dir(specified_data_dir)
+        stateboard_id = self.get_stateboard_id()
+        return os.path.join(data_dir, stateboard_id)
+
+    # log dir
+    def get_log_dir(self, instance_name, specified_path=None):
+        log_dir = specified_path if specified_path is not None else DEFAULT_LOG_DIR
+        instance_id = self.get_instance_id(instance_name)
+        return os.path.join(self.path, log_dir, '%s.log' % instance_id)
+
+    def get_sb_log_dir(self, specified_path=None):
+        log_dir = specified_path if specified_path is not None else DEFAULT_LOG_DIR
+        stateboard_id = self.get_stateboard_id()
+        return os.path.join(self.path, log_dir, '%s.log' % stateboard_id)
+
+    # run dir
+    def get_run_dir(self, specified_path=None):
+        run_dir = specified_path if specified_path is not None else DEFAULT_RUN_DIR
+        return os.path.join(self.path, run_dir)
+
+    # - PID files
+    def get_pidfile(self, instance_name, specified_run_dir=None):
+        run_dir = self.get_run_dir(specified_run_dir)
+        instance_id = self.get_instance_id(instance_name)
+        return os.path.join(run_dir, '%s.pid' % instance_id)
+
+    def get_sb_pidfile(self, specified_run_dir=None):
+        run_dir = self.get_run_dir(specified_run_dir)
+        stateboard_id = self.get_stateboard_id()
+        return os.path.join(run_dir, '%s.pid' % stateboard_id)
+
+    # - control sockets
+    def get_console_sock(self, instance_name, specified_run_dir=None):
+        run_dir = self.get_run_dir(specified_run_dir)
+        instance_id = self.get_instance_id(instance_name)
+        return os.path.join(run_dir, '%s.control' % instance_id)
+
+    def get_sb_console_sock(self, specified_run_dir=None):
+        run_dir = self.get_run_dir(specified_run_dir)
+        stateboard_id = self.get_stateboard_id()
+        return os.path.join(run_dir, '%s.control' % stateboard_id)
+
+    # - notify sockets
+    def get_notify_sock(self, instance_name, specified_run_dir=None):
+        run_dir = self.get_run_dir(specified_run_dir)
+        instance_id = self.get_instance_id(instance_name)
+        return os.path.join(run_dir, '%s.notify' % instance_id)
+
+    def get_sb_notify_sock(self, specified_run_dir=None):
+        run_dir = self.get_run_dir(specified_run_dir)
+        stateboard_id = self.get_stateboard_id()
+        return os.path.join(run_dir, '%s.notify' % stateboard_id)
+
+    # scripts
+    def get_script(self, specified_script=None):
+        script_path = specified_script if specified_script is not None else DEFAULT_SCRIPT
+        return os.path.join(self.path, script_path)
+
+    def get_sb_script(self):
+        return os.path.join(self.path, DEFAULT_STATEBOARD_SCRIPT)
 
 
 # ###############


### PR DESCRIPTION
This patch just reduces copy-paste of computing instances paths in tests