### PR TITLE
Refactor reading from Tarantool conn timeouts

### DIFF
--- a/cli/admin/call.go
+++ b/cli/admin/call.go
@@ -52,7 +52,7 @@ func adminFuncCall(conn net.Conn, funcName string, flagSet *pflag.FlagSet, args 
 		"Args":              argsSerialized,
 	})
 
-	callResRaw, err := common.EvalTarantoolConn(conn, callFuncBody)
+	callResRaw, err := common.EvalTarantoolConnNoTimeout(conn, callFuncBody)
 	if err != nil {
 		return fmt.Errorf("Failed to call %q: %s", funcName, err)
 	}

--- a/cli/admin/help.go
+++ b/cli/admin/help.go
@@ -54,7 +54,7 @@ func getFuncHelpRawMap(funcName string, conn net.Conn) (map[interface{}]interfac
 		"FuncName":          funcName,
 	})
 
-	helpResRaw, err := common.EvalTarantoolConn(conn, adminHelpFuncBody)
+	helpResRaw, err := common.EvalTarantoolConnNoTimeout(conn, adminHelpFuncBody)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to call %s(%q): %s", adminHelpFuncName, funcName, err)
 	}

--- a/cli/admin/list.go
+++ b/cli/admin/list.go
@@ -58,7 +58,7 @@ func getFuncListRawMap(conn net.Conn) (map[interface{}]interface{}, error) {
 		"AdminListFuncName": adminListFuncName,
 	})
 
-	listResRaw, err := common.EvalTarantoolConn(conn, adminListFuncBody)
+	listResRaw, err := common.EvalTarantoolConnNoTimeout(conn, adminListFuncBody)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to call %s(): %s", adminListFuncName, err)
 	}

--- a/cli/commands/admin.go
+++ b/cli/commands/admin.go
@@ -44,6 +44,8 @@ func addAdminFlags(flagSet *pflag.FlagSet) {
 	flagSet.StringVar(&ctx.Admin.InstanceName, "instance", "", "Instance name")
 	flagSet.StringVar(&ctx.Running.RunDir, "run-dir", "", prodRunDirUsage)
 
+	flagSet.StringVar(&timeoutStr, "timeout", "", timeoutUsage)
+
 	flagSet.SortFlags = false
 }
 

--- a/cli/common/tarantool.go
+++ b/cli/common/tarantool.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	goVersion "github.com/hashicorp/go-version"
 )
@@ -93,7 +94,7 @@ func GetNextMajorVersion(versionStr string) (string, error) {
 }
 
 func GetMajorCartridgeVersion(conn net.Conn) (int, error) {
-	cartridgeVersionRaw, err := EvalTarantoolConn(conn, getCartridgeVersionBody)
+	cartridgeVersionRaw, err := EvalTarantoolConn(conn, getCartridgeVersionBody, 3*time.Second)
 	if err != nil {
 		return 0, fmt.Errorf("Failed to eval get Cartridge version function")
 	}

--- a/cli/connect/binary.go
+++ b/cli/connect/binary.go
@@ -7,7 +7,6 @@ import (
 	"github.com/FZambia/tarantool"
 	"github.com/apex/log"
 	"github.com/c-bata/go-prompt"
-	"github.com/tarantool/cartridge-cli/cli/common"
 )
 
 func binaryConnect(console *Console) error {
@@ -17,7 +16,7 @@ func binaryConnect(console *Console) error {
 	console.binaryConn, err = tarantool.Connect(connectStr, tarantool.Opts{
 		User:           console.connOpts.Username,
 		Password:       console.connOpts.Password,
-		RequestTimeout: common.EvalTarantoolConnTimeout,
+		RequestTimeout: 0,
 	})
 	if err != nil {
 		return fmt.Errorf("Failed to connect: %s", err)

--- a/cli/connect/console.go
+++ b/cli/connect/console.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/FZambia/tarantool"
 	"github.com/apex/log"
@@ -31,6 +32,10 @@ const (
 	HistoryFileName = ".tarantool_history"
 
 	MaxLivePrefixIndent = 15
+
+	readGreetingTimeout     = 3 * time.Second
+	evalCompletionTimeout   = 3 * time.Second
+	readFromConnExecTimeout = 0
 )
 
 var (
@@ -370,6 +375,8 @@ func getPromptOptions(console *Console) []prompt.Option {
 }
 
 func readGreeting(conn net.Conn) (string, error) {
+	conn.SetReadDeadline(time.Now().Add(readGreetingTimeout))
+
 	greeting := make([]byte, 1024)
 	if _, err := conn.Read(greeting); err != nil {
 		return "", fmt.Errorf("Failed to read Tarantool greeting: %s", err)

--- a/cli/repair/common.go
+++ b/cli/repair/common.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+	"time"
 
 	goVersion "github.com/hashicorp/go-version"
 
@@ -136,7 +137,7 @@ func checkThatReloadIsPossible(instanceNames []string, ctx *context.Ctx) error {
 
 		defer conn.Close()
 
-		cartridgeVersionRaw, err := common.EvalTarantoolConn(conn, evalFunc)
+		cartridgeVersionRaw, err := common.EvalTarantoolConn(conn, evalFunc, 3*time.Second)
 		if err != nil {
 			return fmt.Errorf("Failed to get cartridge version using %s socket: %s", consoleSock, err)
 		}

--- a/cli/repair/patch.go
+++ b/cli/repair/patch.go
@@ -148,7 +148,7 @@ func reloadConf(topologyConfPath string, instanceName string, ctx *context.Ctx) 
 		return resMessages, fmt.Errorf("Failed to instantiate reload config function template: %s", err)
 	}
 
-	reloadedRaw, err := common.EvalTarantoolConn(conn, evalFunc)
+	reloadedRaw, err := common.EvalTarantoolConnNoTimeout(conn, evalFunc)
 	if err != nil {
 		return resMessages, fmt.Errorf("Failed to call reload config function: %s", err)
 	}

--- a/cli/replicasets/bootstrap_vshard.go
+++ b/cli/replicasets/bootstrap_vshard.go
@@ -27,7 +27,7 @@ func BootstrapVshard(ctx *context.Ctx, args []string) error {
 }
 
 func bootstrapVshard(conn net.Conn) error {
-	_, err := common.EvalTarantoolConn(conn, bootstrapVshardBody)
+	_, err := common.EvalTarantoolConnNoTimeout(conn, bootstrapVshardBody)
 	if err != nil {
 		if strings.Contains(err.Error(), `Sharding config is empty`) {
 			// XXX: see https://github.com/tarantool/cartridge/issues/1148

--- a/cli/replicasets/common.go
+++ b/cli/replicasets/common.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/apex/log"
 	"github.com/tarantool/cartridge-cli/cli/common"
@@ -19,6 +20,10 @@ type InstanceConf struct {
 }
 
 type InstancesConf map[string]*InstanceConf
+
+const (
+	SimpleOperationTimeout = 10 * time.Second
+)
 
 // connectToSomeRunningInstance connects to some running instance.
 // It's used for some actions that can be performed via any instance socket,

--- a/cli/replicasets/completion.go
+++ b/cli/replicasets/completion.go
@@ -2,10 +2,15 @@ package replicasets
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/tarantool/cartridge-cli/cli/common"
 	"github.com/tarantool/cartridge-cli/cli/context"
 	"github.com/tarantool/cartridge-cli/cli/project"
+)
+
+const (
+	completionEvalTimeout = 3 * time.Second
 )
 
 func GetReplicasetRolesComp(ctx *context.Ctx) ([]string, error) {
@@ -41,7 +46,7 @@ func GetReplicasetRolesToAddComp(ctx *context.Ctx) ([]string, error) {
 	}
 
 	// get all known roles
-	knownRolesRaw, err := common.EvalTarantoolConn(conn, getKnownRolesBody)
+	knownRolesRaw, err := common.EvalTarantoolConn(conn, getKnownRolesBody, completionEvalTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get known roles: %s", err)
 	}

--- a/cli/replicasets/edit_topology.go
+++ b/cli/replicasets/edit_topology.go
@@ -68,7 +68,7 @@ func editReplicasetsList(conn net.Conn, opts *EditReplicasetsListOpts) (*Topolog
 		return nil, project.InternalError("Failed to compute edit_topology call body: %s", err)
 	}
 
-	newTopologyReplicasetsRaw, err := common.EvalTarantoolConn(conn, editReplicasetsBody)
+	newTopologyReplicasetsRaw, err := common.EvalTarantoolConnNoTimeout(conn, editReplicasetsBody)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to edit topology: %s", err)
 	}
@@ -116,7 +116,7 @@ func editInstances(conn net.Conn, opts *EditInstancesListOpts) (bool, error) {
 		return false, project.InternalError("Failed to get edit topology body by template: %s", err)
 	}
 
-	_, err = common.EvalTarantoolConn(conn, editInstanceBody)
+	_, err = common.EvalTarantoolConnNoTimeout(conn, editInstanceBody)
 	if err != nil {
 		return false, fmt.Errorf("Failed to edit topology: %s", err)
 	}
@@ -135,7 +135,7 @@ func waitForClusterIsHealthy(conn net.Conn) error {
 	}
 
 	checkClusterIsHealthyFunc := func() error {
-		isHealthyRaw, err := common.EvalTarantoolConn(conn, getClusterIsHealthyBody)
+		isHealthyRaw, err := common.EvalTarantoolConnNoTimeout(conn, getClusterIsHealthyBody)
 		if err != nil {
 			return fmt.Errorf("Failed to get replicaset status: %s", err)
 		}

--- a/cli/replicasets/membership.go
+++ b/cli/replicasets/membership.go
@@ -40,7 +40,7 @@ func connectToMembership(conn net.Conn, runningInstancesNames []string, instance
 		return project.InternalError("Failed to compute probe instances function body: %s", err)
 	}
 
-	if _, err := common.EvalTarantoolConn(conn, probeInstancesBody); err != nil {
+	if _, err := common.EvalTarantoolConnNoTimeout(conn, probeInstancesBody); err != nil {
 		return fmt.Errorf("Failed to probe all instances mentioned in replica sets: %s", err)
 	}
 
@@ -48,7 +48,7 @@ func connectToMembership(conn net.Conn, runningInstancesNames []string, instance
 }
 
 func getMembershipInstancesFromConn(conn net.Conn) (*MembershipInstances, error) {
-	membershipInstancesRaw, err := common.EvalTarantoolConn(conn, getMembershipInstancesBody)
+	membershipInstancesRaw, err := common.EvalTarantoolConn(conn, getMembershipInstancesBody, SimpleOperationTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get membership members: %s", err)
 	}

--- a/cli/replicasets/roles.go
+++ b/cli/replicasets/roles.go
@@ -43,7 +43,7 @@ func ListRoles(ctx *context.Ctx, args []string) error {
 		return fmt.Errorf("Failed to connect to Tarantool instance: %s", err)
 	}
 
-	knownRolesRaw, err := common.EvalTarantoolConn(conn, getKnownRolesBody)
+	knownRolesRaw, err := common.EvalTarantoolConn(conn, getKnownRolesBody, SimpleOperationTimeout)
 	if err != nil {
 		return fmt.Errorf("Failed to get known roles: %s", err)
 	}
@@ -124,29 +124,6 @@ func addRolesToList(currentRoles, rolesToAdd []string) []string {
 
 func removeRolesFromList(currentRoles, rolesToRemove []string) []string {
 	return common.GetStringSlicesDifference(currentRoles, rolesToRemove)
-}
-
-func getKnownRoles(ctx *context.Ctx) ([]string, error) {
-	if err := FillCtx(ctx); err != nil {
-		return nil, err
-	}
-
-	conn, err := connectToSomeJoinedInstance(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	knownRolesRaw, err := common.EvalTarantoolConn(conn, getKnownRolesBody)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to get known roles: %s", err)
-	}
-
-	knownRoles, err := common.ConvertToStringsSlice(knownRolesRaw)
-	if err != nil {
-		return nil, project.InternalError("Roles received in bad format: %#v", knownRolesRaw)
-	}
-
-	return knownRoles, nil
 }
 
 func updateRoles(ctx *context.Ctx, getNewRolesListFunc GetNewRolesListFunc, vshardGroup string) error {

--- a/cli/replicasets/topology_replicasets.go
+++ b/cli/replicasets/topology_replicasets.go
@@ -70,7 +70,7 @@ func getTopologyReplicasets(conn net.Conn) (*TopologyReplicasets, error) {
 		return nil, project.InternalError("Failed to compute get topology replica set function body: %s", err)
 	}
 
-	topologyReplicasetsRaw, err := common.EvalTarantoolConn(conn, getTopologyReplicasetsBody)
+	topologyReplicasetsRaw, err := common.EvalTarantoolConn(conn, getTopologyReplicasetsBody, SimpleOperationTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get current topology: %s", err)
 	}

--- a/cli/replicasets/vshard_group.go
+++ b/cli/replicasets/vshard_group.go
@@ -15,7 +15,7 @@ func ListVshardGroups(ctx *context.Ctx, args []string) error {
 		return fmt.Errorf("Failed to connect to Tarantool instance: %s", err)
 	}
 
-	knownVshardGroupsRaw, err := common.EvalTarantoolConn(conn, getKnownVshardGroupsBody)
+	knownVshardGroupsRaw, err := common.EvalTarantoolConn(conn, getKnownVshardGroupsBody, SimpleOperationTimeout)
 	if err != nil {
 		return fmt.Errorf("Failed to get known vshard groups: %s", err)
 	}


### PR DESCRIPTION
Timeouts is a good approach, but sometimes we have to wait for command
to be completed
For example, connect,enter,admin commands can be used to collect statistics from huge clusters.
Generally, there is no "right" timeout for `edit_topology` calls, so
it's called without timeout.
Some simple things (like fetching Cartridge version) or completion
operations are performed with a little timeout.