### PR TITLE
Allow to pass push callback to eval functions

### DIFF
--- a/cli/admin/call.go
+++ b/cli/admin/call.go
@@ -52,7 +52,7 @@ func adminFuncCall(conn net.Conn, funcName string, flagSet *pflag.FlagSet, args 
 		"Args":              argsSerialized,
 	})
 
-	callResRaw, err := common.EvalTarantoolConnNoTimeout(conn, callFuncBody)
+	callResRaw, err := common.EvalTarantoolConn(conn, callFuncBody, common.ConnOpts{})
 	if err != nil {
 		return fmt.Errorf("Failed to call %q: %s", funcName, err)
 	}

--- a/cli/admin/help.go
+++ b/cli/admin/help.go
@@ -54,7 +54,7 @@ func getFuncHelpRawMap(funcName string, conn net.Conn) (map[interface{}]interfac
 		"FuncName":          funcName,
 	})
 
-	helpResRaw, err := common.EvalTarantoolConnNoTimeout(conn, adminHelpFuncBody)
+	helpResRaw, err := common.EvalTarantoolConn(conn, adminHelpFuncBody, common.ConnOpts{})
 	if err != nil {
 		return nil, fmt.Errorf("Failed to call %s(%q): %s", adminHelpFuncName, funcName, err)
 	}

--- a/cli/admin/list.go
+++ b/cli/admin/list.go
@@ -58,7 +58,7 @@ func getFuncListRawMap(conn net.Conn) (map[interface{}]interface{}, error) {
 		"AdminListFuncName": adminListFuncName,
 	})
 
-	listResRaw, err := common.EvalTarantoolConnNoTimeout(conn, adminListFuncBody)
+	listResRaw, err := common.EvalTarantoolConn(conn, adminListFuncBody, common.ConnOpts{})
 	if err != nil {
 		return nil, fmt.Errorf("Failed to call %s(): %s", adminListFuncName, err)
 	}

--- a/cli/common/tarantool.go
+++ b/cli/common/tarantool.go
@@ -94,7 +94,9 @@ func GetNextMajorVersion(versionStr string) (string, error) {
 }
 
 func GetMajorCartridgeVersion(conn net.Conn) (int, error) {
-	cartridgeVersionRaw, err := EvalTarantoolConn(conn, getCartridgeVersionBody, 3*time.Second)
+	cartridgeVersionRaw, err := EvalTarantoolConn(conn, getCartridgeVersionBody, ConnOpts{
+		ReadTimeout: 3 * time.Second,
+	})
 	if err != nil {
 		return 0, fmt.Errorf("Failed to eval get Cartridge version function")
 	}

--- a/cli/connect/plain_text.go
+++ b/cli/connect/plain_text.go
@@ -19,21 +19,21 @@ const (
 	successSetModeLua  = "true;"
 )
 
-type ReadFromConnFunc func(net.Conn, time.Duration) ([]byte, error)
+type ReadFromConnFunc func(net.Conn, common.ConnOpts) ([]byte, error)
 
 func plainTextEval(console *Console, funcBodyFmt string, args ...interface{}) (interface{}, error) {
-	var plainTextEvalFunc func(conn net.Conn, funcBody string) (interface{}, error)
+	var plainTextEvalFunc func(conn net.Conn, funcBody string, opts common.ConnOpts) (interface{}, error)
 
 	switch {
 	case console.outputMode == ConsoleYAMLOutput:
-		plainTextEvalFunc = common.EvalTarantoolConnNoTimeout
+		plainTextEvalFunc = common.EvalTarantoolConn
 	case console.outputMode == ConsoleLuaOutput:
-		plainTextEvalFunc = common.EvalTarantoolConnLuaNoTimeout
+		plainTextEvalFunc = common.EvalTarantoolConn
 	default:
 		return nil, fmt.Errorf("Unknown output mode: %s", console.outputMode)
 	}
 
-	return plainTextEvalFunc(console.conn, fmt.Sprintf(funcBodyFmt, args...))
+	return plainTextEvalFunc(console.conn, fmt.Sprintf(funcBodyFmt, args...), common.ConnOpts{})
 }
 
 func getPlainTextCompleter(console *Console) prompt.Completer {
@@ -79,37 +79,18 @@ func plainTextExecute(console *Console, in string) string {
 		log.Fatalf("Unknown output mode: %s", console.outputMode)
 	}
 
-	var data string
+	dataBytes, err := readFromConnFunc(console.conn, common.ConnOpts{
+		PushCallback: func(s string) {
+			fmt.Printf("%s", s)
+		},
+	})
 
-	for {
-		// data is read in cycle because of `box.session.push` command
-		// it prints a tag and returns pushed value, and then true is returned additionally
-		// e.g.
-		// myapp.router> box.session.push('xx')
-		// %TAG !push! tag:tarantool.io/push,2018
-		// --- xx
-		// ...
-		// ---
-		// - true
-		// ...
-		//
-		// So, when data portion starts with a tag prefix, we have to read one more value
-		//
-		dataPortionBytes, err := readFromConnFunc(console.conn, readFromConnExecTimeout)
-		if err != nil {
-			log.Debugf("Failed to read from instance socket: %s", err)
-			log.Fatalf("Connection was closed. Probably instance process isn't running anymore")
-		}
-
-		dataPortion := string(dataPortionBytes)
-		data += dataPortion
-
-		if !pushTagIsReceived(console, dataPortion) {
-			break
-		}
+	if err != nil {
+		log.Debugf(err.Error())
+		log.Fatalf("Connection was closed. Probably instance process isn't running anymore")
 	}
 
-	return data
+	return string(dataBytes)
 }
 
 func pushTagIsReceived(console *Console, dataPortion string) bool {
@@ -124,15 +105,15 @@ func pushTagIsReceived(console *Console, dataPortion string) bool {
 }
 
 func getReadFromConnSetMode(console *Console, newOutputMode ConsoleOutputMode) ReadFromConnFunc {
-	readFromConnFunc := func(conn net.Conn, readTimeout time.Duration) ([]byte, error) {
+	readFromConnFunc := func(conn net.Conn, opts common.ConnOpts) ([]byte, error) {
 		// This function handles only result of `\set output <mode>` commands.
 		// So, only encoded `true` value or error can be returned and we can
 		// simply read one portion of bytes to buffer of 1024 bytes.
 		// Of course, it works only if all other results are handled correctly,
 		// and it is so =).
 		//
-		if readTimeout > 0 {
-			conn.SetReadDeadline(time.Now().Add(readTimeout))
+		if opts.ReadTimeout > 0 {
+			conn.SetReadDeadline(time.Now().Add(opts.ReadTimeout))
 		} else {
 			conn.SetReadDeadline(time.Time{})
 		}

--- a/cli/repair/common.go
+++ b/cli/repair/common.go
@@ -137,7 +137,9 @@ func checkThatReloadIsPossible(instanceNames []string, ctx *context.Ctx) error {
 
 		defer conn.Close()
 
-		cartridgeVersionRaw, err := common.EvalTarantoolConn(conn, evalFunc, 3*time.Second)
+		cartridgeVersionRaw, err := common.EvalTarantoolConn(conn, evalFunc, common.ConnOpts{
+			ReadTimeout: 3 * time.Second,
+		})
 		if err != nil {
 			return fmt.Errorf("Failed to get cartridge version using %s socket: %s", consoleSock, err)
 		}

--- a/cli/repair/patch.go
+++ b/cli/repair/patch.go
@@ -148,7 +148,7 @@ func reloadConf(topologyConfPath string, instanceName string, ctx *context.Ctx) 
 		return resMessages, fmt.Errorf("Failed to instantiate reload config function template: %s", err)
 	}
 
-	reloadedRaw, err := common.EvalTarantoolConnNoTimeout(conn, evalFunc)
+	reloadedRaw, err := common.EvalTarantoolConn(conn, evalFunc, common.ConnOpts{})
 	if err != nil {
 		return resMessages, fmt.Errorf("Failed to call reload config function: %s", err)
 	}

--- a/cli/replicasets/bootstrap_vshard.go
+++ b/cli/replicasets/bootstrap_vshard.go
@@ -27,7 +27,7 @@ func BootstrapVshard(ctx *context.Ctx, args []string) error {
 }
 
 func bootstrapVshard(conn net.Conn) error {
-	_, err := common.EvalTarantoolConnNoTimeout(conn, bootstrapVshardBody)
+	_, err := common.EvalTarantoolConn(conn, bootstrapVshardBody, common.ConnOpts{})
 	if err != nil {
 		if strings.Contains(err.Error(), `Sharding config is empty`) {
 			// XXX: see https://github.com/tarantool/cartridge/issues/1148

--- a/cli/replicasets/completion.go
+++ b/cli/replicasets/completion.go
@@ -46,7 +46,9 @@ func GetReplicasetRolesToAddComp(ctx *context.Ctx) ([]string, error) {
 	}
 
 	// get all known roles
-	knownRolesRaw, err := common.EvalTarantoolConn(conn, getKnownRolesBody, completionEvalTimeout)
+	knownRolesRaw, err := common.EvalTarantoolConn(conn, getKnownRolesBody, common.ConnOpts{
+		ReadTimeout: completionEvalTimeout,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get known roles: %s", err)
 	}

--- a/cli/replicasets/edit_topology.go
+++ b/cli/replicasets/edit_topology.go
@@ -68,7 +68,7 @@ func editReplicasetsList(conn net.Conn, opts *EditReplicasetsListOpts) (*Topolog
 		return nil, project.InternalError("Failed to compute edit_topology call body: %s", err)
 	}
 
-	newTopologyReplicasetsRaw, err := common.EvalTarantoolConnNoTimeout(conn, editReplicasetsBody)
+	newTopologyReplicasetsRaw, err := common.EvalTarantoolConn(conn, editReplicasetsBody, common.ConnOpts{})
 	if err != nil {
 		return nil, fmt.Errorf("Failed to edit topology: %s", err)
 	}
@@ -116,7 +116,7 @@ func editInstances(conn net.Conn, opts *EditInstancesListOpts) (bool, error) {
 		return false, project.InternalError("Failed to get edit topology body by template: %s", err)
 	}
 
-	_, err = common.EvalTarantoolConnNoTimeout(conn, editInstanceBody)
+	_, err = common.EvalTarantoolConn(conn, editInstanceBody, common.ConnOpts{})
 	if err != nil {
 		return false, fmt.Errorf("Failed to edit topology: %s", err)
 	}
@@ -135,7 +135,7 @@ func waitForClusterIsHealthy(conn net.Conn) error {
 	}
 
 	checkClusterIsHealthyFunc := func() error {
-		isHealthyRaw, err := common.EvalTarantoolConnNoTimeout(conn, getClusterIsHealthyBody)
+		isHealthyRaw, err := common.EvalTarantoolConn(conn, getClusterIsHealthyBody, common.ConnOpts{})
 		if err != nil {
 			return fmt.Errorf("Failed to get replicaset status: %s", err)
 		}

--- a/cli/replicasets/membership.go
+++ b/cli/replicasets/membership.go
@@ -40,7 +40,7 @@ func connectToMembership(conn net.Conn, runningInstancesNames []string, instance
 		return project.InternalError("Failed to compute probe instances function body: %s", err)
 	}
 
-	if _, err := common.EvalTarantoolConnNoTimeout(conn, probeInstancesBody); err != nil {
+	if _, err := common.EvalTarantoolConn(conn, probeInstancesBody, common.ConnOpts{}); err != nil {
 		return fmt.Errorf("Failed to probe all instances mentioned in replica sets: %s", err)
 	}
 
@@ -48,7 +48,9 @@ func connectToMembership(conn net.Conn, runningInstancesNames []string, instance
 }
 
 func getMembershipInstancesFromConn(conn net.Conn) (*MembershipInstances, error) {
-	membershipInstancesRaw, err := common.EvalTarantoolConn(conn, getMembershipInstancesBody, SimpleOperationTimeout)
+	membershipInstancesRaw, err := common.EvalTarantoolConn(conn, getMembershipInstancesBody, common.ConnOpts{
+		ReadTimeout: SimpleOperationTimeout,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get membership members: %s", err)
 	}

--- a/cli/replicasets/roles.go
+++ b/cli/replicasets/roles.go
@@ -43,7 +43,9 @@ func ListRoles(ctx *context.Ctx, args []string) error {
 		return fmt.Errorf("Failed to connect to Tarantool instance: %s", err)
 	}
 
-	knownRolesRaw, err := common.EvalTarantoolConn(conn, getKnownRolesBody, SimpleOperationTimeout)
+	knownRolesRaw, err := common.EvalTarantoolConn(conn, getKnownRolesBody, common.ConnOpts{
+		ReadTimeout: SimpleOperationTimeout,
+	})
 	if err != nil {
 		return fmt.Errorf("Failed to get known roles: %s", err)
 	}

--- a/cli/replicasets/topology_replicasets.go
+++ b/cli/replicasets/topology_replicasets.go
@@ -70,7 +70,9 @@ func getTopologyReplicasets(conn net.Conn) (*TopologyReplicasets, error) {
 		return nil, project.InternalError("Failed to compute get topology replica set function body: %s", err)
 	}
 
-	topologyReplicasetsRaw, err := common.EvalTarantoolConn(conn, getTopologyReplicasetsBody, SimpleOperationTimeout)
+	topologyReplicasetsRaw, err := common.EvalTarantoolConn(conn, getTopologyReplicasetsBody, common.ConnOpts{
+		ReadTimeout: SimpleOperationTimeout,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get current topology: %s", err)
 	}

--- a/cli/replicasets/vshard_group.go
+++ b/cli/replicasets/vshard_group.go
@@ -15,7 +15,9 @@ func ListVshardGroups(ctx *context.Ctx, args []string) error {
 		return fmt.Errorf("Failed to connect to Tarantool instance: %s", err)
 	}
 
-	knownVshardGroupsRaw, err := common.EvalTarantoolConn(conn, getKnownVshardGroupsBody, SimpleOperationTimeout)
+	knownVshardGroupsRaw, err := common.EvalTarantoolConn(conn, getKnownVshardGroupsBody, common.ConnOpts{
+		ReadTimeout: SimpleOperationTimeout,
+	})
 	if err != nil {
 		return fmt.Errorf("Failed to get known vshard groups: %s", err)
 	}


### PR DESCRIPTION
Calling `box.session.push` on eval produces additional output that was
interpreted as a eval result before this patch. Now `ReadFromConn` function 
reads all data until non-pushed result is received. By default, pushed messages 
are ignored, but if `PushCallback` function is specified, it's called for each received
message. It's used for `connect` and `enter` commands.

Required for #434 