### PR TITLE
Fix handling logs on interactive start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Using Tarantool console socket
   * end of Tarantool output data and read timeout are handled properly
   * Tarantool greeting is read once on connection creation
+- Logs writer used on interactive start: it become waiting forever on big output
+  received (such as curl verbose log)
 
 ### Changed
 

--- a/cli/running/process.go
+++ b/cli/running/process.go
@@ -183,10 +183,7 @@ func (process *Process) Start(daemonize bool) error {
 
 	// initialize logs writer
 	if !daemonize {
-		logsWriter, err := newColorizedWriter(process)
-		if err != nil {
-			return fmt.Errorf("Failed to create colorized logs writer: %s", err)
-		}
+		logsWriter := newColorizedWriter(process.ID)
 
 		process.cmd.Stdout = logsWriter
 		process.cmd.Stderr = logsWriter
@@ -411,10 +408,7 @@ func (process *Process) Log(follow bool, n int) error {
 		return fmt.Errorf("Failed to get logs tail: %s", err)
 	}
 
-	writer, err := newColorizedWriter(process)
-	if err != nil {
-		return fmt.Errorf("Failed to create colorized logs writer: %s", err)
-	}
+	writer := newColorizedWriter(process.ID)
 
 	for line := range t.Lines {
 		if _, err := writer.Write([]byte(line.Text + "\n")); err != nil {

--- a/cli/running/writer.go
+++ b/cli/running/writer.go
@@ -38,6 +38,7 @@ func init() {
 
 type ColorizedWriter struct {
 	prefix string
+	out    io.Writer
 }
 
 func (w *ColorizedWriter) Write(p []byte) (int, error) {
@@ -54,7 +55,7 @@ func (w *ColorizedWriter) Write(p []byte) (int, error) {
 		}
 
 		// prefix
-		if _, err := os.Stdout.Write([]byte(w.prefix)); err != nil {
+		if _, err := w.out.Write([]byte(w.prefix)); err != nil {
 			return n, err
 		}
 
@@ -69,7 +70,7 @@ func (w *ColorizedWriter) Write(p []byte) (int, error) {
 			}
 		}
 
-		lineN, err := os.Stdout.Write(lineBytes)
+		lineN, err := w.out.Write(lineBytes)
 		n += lineN
 
 		if err != nil {
@@ -93,10 +94,12 @@ func nexPrefixColor() *color.Color {
 	return c
 }
 
-func newColorizedWriter(process *Process) (*ColorizedWriter, error) {
-	writer := ColorizedWriter{}
+func newColorizedWriter(prefix string) *ColorizedWriter {
+	writer := ColorizedWriter{
+		out: os.Stdout,
+	}
 
 	prefixColor := nexPrefixColor()
-	writer.prefix = prefixColor.Sprintf("%s | ", process.ID)
-	return &writer, nil
+	writer.prefix = prefixColor.Sprintf("%s | ", prefix)
+	return &writer
 }

--- a/cli/running/writer.go
+++ b/cli/running/writer.go
@@ -46,16 +46,18 @@ func (w *ColorizedWriter) Write(p []byte) (int, error) {
 
 	n := 0
 	for {
-		lineBytes, err := buf.ReadBytes('\n')
-		if err == io.EOF {
+		// from the doc
+		// https://golang.org/pkg/bytes/#Buffer.ReadBytes
+		// > ReadBytes returns err != nil if and only if the returned data does not end in delim
+		// so, we read bytes until 0 bytes returned
+		lineBytes, _ := buf.ReadBytes('\n')
+		if len(lineBytes) == 0 {
 			break
-		}
-		if err != nil {
-			return n, err
 		}
 
 		// prefix
-		if _, err := w.out.Write([]byte(w.prefix)); err != nil {
+		if nPrefix, err := w.out.Write([]byte(w.prefix)); err != nil {
+			n += nPrefix
 			return n, err
 		}
 
@@ -70,8 +72,8 @@ func (w *ColorizedWriter) Write(p []byte) (int, error) {
 			}
 		}
 
-		lineN, err := w.out.Write(lineBytes)
-		n += lineN
+		nLine, err := w.out.Write(lineBytes)
+		n += nLine
 
 		if err != nil {
 			return n, err

--- a/cli/running/writer_test.go
+++ b/cli/running/writer_test.go
@@ -1,0 +1,64 @@
+package running
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func getLogsBytes(logs []string) []byte {
+	return []byte(strings.Join(logs, "\n"))
+}
+
+func getLogsWithPrefix(prefix string, logs []string) string {
+	resLines := make([]string, len(logs))
+	for i := range logs {
+		resLines[i] = fmt.Sprintf("%s | %s", prefix, logs[i])
+	}
+
+	return strings.Join(resLines, "\n")
+}
+
+func TestWrite(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+
+	out := bytes.NewBuffer(nil)
+	var logs []string
+	var logBytes []byte
+	var n int
+	var err error
+
+	id := "my-id"
+
+	writer := newColorizedWriter(id)
+	writer.out = out
+
+	// multiline
+	out.Reset()
+	logs = []string{
+		"Some long",
+		"multiline",
+		"log",
+	}
+	logBytes = getLogsBytes(logs)
+	n, err = writer.Write(logBytes)
+	assert.Nil(err)
+	assert.Equal(len(logBytes), n)
+	assert.Equal(getLogsWithPrefix(id, logs), out.String())
+
+	// one line (w/o \n)
+	out.Reset()
+	logs = []string{
+		"Some one-line log line",
+	}
+	logBytes = getLogsBytes(logs)
+	n, err = writer.Write(logBytes)
+	assert.Nil(err)
+	assert.Equal(len(logBytes), n)
+	assert.Equal(getLogsWithPrefix(id, logs), out.String())
+}


### PR DESCRIPTION
When instances are started in interactive mode, colorized log writer
is used to prettify log messages. After writing some big amount of data 
to log, this function become waiting forever.
This patch fixes `ColorizedWriter.Write` function to handle number
of bytes that was wrote correctly.