### PR TITLE
github-ci: add --skip-validate option for goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,9 +42,9 @@ jobs:
         id: set-goreleaser-flags
         run: |
           if ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }} ; then
-            echo "::set-output name=GORELEASER_FLAGS::--rm-dist"
+            echo "::set-output name=GORELEASER_FLAGS::--rm-dist --skip-validate"
           else
-            echo "::set-output name=GORELEASER_FLAGS::--rm-dist --snapshot --skip-publish"
+            echo "::set-output name=GORELEASER_FLAGS::--rm-dist --snapshot --skip-publish --skip-validate"
           fi
 
       - name: Build packages


### PR DESCRIPTION
We faced with follwing issue:
```
release failed after 0.02s error=git is currently in a dirty state, please check in your pipeline what can be changing the following files:
?? mage/
```

Skipping validation should solve our problems. However in future
we should provide more proper fix.

Co-authored-by: Elizaveta Dokshina <eldokshina@mail.ru>
