### PR TITLE
Add --conn, -c option for admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `--conn, -c` option for `cartridge admin` command to specify instance address
+- `-l` shortcut for `--list` flag of `cartridge admin` command
+
 ### Fixed
 
 - Parsing cluster-wide config with empty roles list

--- a/cli/admin/admin.go
+++ b/cli/admin/admin.go
@@ -5,10 +5,8 @@ import (
 
 	"github.com/spf13/pflag"
 
-	"github.com/apex/log"
 	"github.com/tarantool/cartridge-cli/cli/connector"
 	"github.com/tarantool/cartridge-cli/cli/context"
-	"github.com/tarantool/cartridge-cli/cli/project"
 )
 
 const (
@@ -24,19 +22,13 @@ const (
 type ProcessAdminFuncType func(conn *connector.Conn, funcName string, flagSet *pflag.FlagSet, args []string) error
 
 func Run(processAdminFunc ProcessAdminFuncType, ctx *context.Ctx, funcName string, flagSet *pflag.FlagSet, args []string) error {
-	if ctx.Project.Name == "" {
-		return fmt.Errorf("Please, specify application name using --name")
+	if err := checkCtx(ctx); err != nil {
+		return err
 	}
-
-	if err := project.SetSystemRunningPaths(ctx); err != nil {
-		return fmt.Errorf("Failed to get default paths: %s", err)
-	}
-
-	log.Debugf("Run directory is set to: %s", ctx.Running.RunDir)
 
 	conn, err := getAvaliableConn(ctx)
 	if err != nil {
-		return fmt.Errorf("Failed to connect to application instance socket: %s", err)
+		return fmt.Errorf("Failed to connect to application instance: %s", err)
 	}
 	defer conn.Close()
 

--- a/cli/admin/common_test.go
+++ b/cli/admin/common_test.go
@@ -1,0 +1,138 @@
+package admin
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tarantool/cartridge-cli/cli/context"
+)
+
+func TestCheckCtx(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	var ctx context.Ctx
+
+	ctx.Project.Name = ""
+	ctx.Admin.ConnString = ""
+	ctx.Admin.InstanceName = ""
+	assert.EqualError(checkCtx(&ctx), "Please, specify one of --name, --instance or --conn")
+
+	ctx.Project.Name = "app-name"
+	ctx.Admin.ConnString = "conn-string"
+	ctx.Admin.InstanceName = "instance-name"
+	assert.EqualError(checkCtx(&ctx), "You can specify only one of --instance or --conn")
+
+	ctx.Project.Name = ""
+	ctx.Admin.ConnString = "conn-string"
+	ctx.Admin.InstanceName = "instance-name"
+	assert.EqualError(checkCtx(&ctx), "You can specify only one of --instance or --conn")
+
+	ctx.Project.Name = ""
+	ctx.Admin.ConnString = ""
+	ctx.Admin.InstanceName = "instance-name"
+	assert.EqualError(checkCtx(&ctx), "Please, specify --name")
+
+	ctx.Project.Name = "app-name"
+	ctx.Admin.ConnString = ""
+	ctx.Admin.InstanceName = ""
+	assert.Nil(checkCtx(&ctx))
+
+	ctx.Project.Name = "app-name"
+	ctx.Admin.ConnString = ""
+	ctx.Admin.InstanceName = "instance-name"
+	assert.Nil(checkCtx(&ctx))
+
+	ctx.Project.Name = ""
+	ctx.Admin.ConnString = "conn-string"
+	ctx.Admin.InstanceName = ""
+	assert.Nil(checkCtx(&ctx))
+}
+
+func cleanDir(dirPath string) {
+	files, err := ioutil.ReadDir(dirPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, file := range files {
+		if err := os.Remove(filepath.Join(dirPath, file.Name())); err != nil {
+			log.Fatal(err)
+		}
+	}
+}
+
+func createFiles(dirPath string, fileNames []string) {
+	for _, fileName := range fileNames {
+		filePath := filepath.Join(dirPath, fileName)
+		if _, err := os.Create(filePath); err != nil {
+			log.Fatal(err)
+		}
+	}
+}
+
+func TestGetInstanceSocketPaths(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	var ctx context.Ctx
+	var err error
+	var addresses []string
+
+	runDir, err := ioutil.TempDir("", "run")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.RemoveAll(runDir)
+
+	// run-dir is empty
+	cleanDir(runDir)
+	ctx.Project.Name = "myapp"
+	ctx.Running.RunDir = runDir
+	addresses, err = getInstanceSocketPaths(&ctx)
+	assert.Nil(addresses)
+	assert.EqualError(err, fmt.Sprintf("Run directory %s is empty", runDir))
+
+	// no control sockets
+	cleanDir(runDir)
+	createFiles(runDir, []string{
+		"myapp.router.pid",
+		"myapp.router.notify",
+		"some-wtf-file",
+	})
+
+	ctx.Project.Name = "myapp"
+	ctx.Running.RunDir = runDir
+	addresses, err = getInstanceSocketPaths(&ctx)
+	assert.Nil(addresses)
+	assert.EqualError(err, fmt.Sprintf("No instance sockets found in %s", runDir))
+
+	// control sockets of different apps and other files
+	cleanDir(runDir)
+	createFiles(runDir, []string{
+		"myapp.router.pid",
+		"myapp.router.notify",
+		"myapp.router.control",
+		"myapp.storage.pid",
+		"myapp.storage.notify",
+		"myapp.storage.control",
+		"other-app.router.pid",
+		"other-app.router.notify",
+		"other-app.router.control",
+		"some-wtf-file",
+	})
+
+	ctx.Project.Name = "myapp"
+	ctx.Running.RunDir = runDir
+	addresses, err = getInstanceSocketPaths(&ctx)
+	assert.Nil(err)
+	assert.EqualValues(addresses, []string{
+		filepath.Join(runDir, "myapp.router.control"),
+		filepath.Join(runDir, "myapp.storage.control"),
+	})
+}

--- a/cli/commands/admin.go
+++ b/cli/commands/admin.go
@@ -14,6 +14,7 @@ func init() {
 		Use:   "admin [ADMIN_FUNC_NAME]",
 		Short: "Call admin function",
 		Long: `Call admin function on application instance
+IF --conn flag is specified, CLI connects to instance by specified address.
 If --instance flag is specified, then <run-dir>/<app-name>.<instance>.control socket is used.
 Otherwise, first available socket from all <run-dir>/<app-name>.*.control is used.`,
 
@@ -38,13 +39,13 @@ func addAdminFlags(flagSet *pflag.FlagSet) {
 
 	// then, add `cartridge admin` flags
 	flagSet.StringVar(&ctx.Project.Name, "name", "", "Application name")
-	flagSet.BoolVarP(&ctx.Admin.List, "list", "", false, "List available admin functions")
+	flagSet.BoolVarP(&ctx.Admin.List, "list", "l", false, "List available admin functions")
 	flagSet.BoolVarP(&ctx.Admin.Help, "help", "h", false, "Help for admin function")
 
-	flagSet.StringVar(&ctx.Admin.InstanceName, "instance", "", "Instance name")
-	flagSet.StringVar(&ctx.Running.RunDir, "run-dir", "", prodRunDirUsage)
+	flagSet.StringVar(&ctx.Admin.InstanceName, "instance", "", "Instance to connect to")
+	flagSet.StringVarP(&ctx.Admin.ConnString, "conn", "c", "", "Address to connect to")
 
-	flagSet.StringVar(&timeoutStr, "timeout", "", timeoutUsage)
+	flagSet.StringVar(&ctx.Running.RunDir, "run-dir", "", prodRunDirUsage)
 
 	flagSet.SortFlags = false
 }

--- a/cli/connector/binary.go
+++ b/cli/connector/binary.go
@@ -48,7 +48,7 @@ func callBinary(conn *Conn, funcName string, args []interface{}, execOpts ExecOp
 func processTarantoolReqBinary(conn *Conn, req *tarantool.Request, execOpts ExecOpts) ([]interface{}, error) {
 	if execOpts.PushCallback != nil {
 		req.WithPush(func(r *tarantool.Response) {
-			execOpts.PushCallback(r.Data)
+			execOpts.PushCallback(r.Data[0])
 		})
 	}
 

--- a/cli/context/context.go
+++ b/cli/context/context.go
@@ -128,6 +128,7 @@ type AdminCtx struct {
 	List bool
 
 	InstanceName string
+	ConnString   string
 }
 
 type ReplicasetsCtx struct {

--- a/doc/admin.rst
+++ b/doc/admin.rst
@@ -20,6 +20,7 @@ Command flags:
 * ``--list`` - list available admin functions
 * ``--help`` - help for admin function
 * ``--instance`` - name of instance to connect to
+* ``--conn, -c`` - address to connect to
 * ``--run-dir`` - directory where instance's sockets are placed
   (defaults to ``/var/run/tarantool``)
 
@@ -57,6 +58,8 @@ function that probes the instance by specified the URI.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Connecting to instance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* If the ``--conn`` CLI connects to specified address.
 
 * If the ``--instance`` flag is specified, CLI checks if the
   ``<run-dir>/<name>.<instance>.control`` socket is *available* and if so,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -240,7 +240,7 @@ def custom_admin_running_instances(cartridge_cmd, start_stop_cli, custom_admin_p
     process = subprocess.run(cmd, cwd=project.path)
     assert process.returncode == 0, "Error during building the project"
 
-    start_instances(cartridge_cmd, start_stop_cli, project)
+    start_instances(cartridge_cmd, start_stop_cli, project, skip_env_checks=True)
 
     return {
         'project': project,

--- a/test/integration/admin/test_call.py
+++ b/test/integration/admin/test_call.py
@@ -1,17 +1,18 @@
+import pytest
+
 from utils import run_command_and_get_output
 from utils import get_log_lines
+from utils import get_admin_connection_params
 
 
-def test_call_many_args(cartridge_cmd, custom_admin_running_instances, tmpdir):
+@pytest.mark.parametrize('connection_type', ['find-socket', 'connect', 'instance'])
+def test_call_many_args(cartridge_cmd, custom_admin_running_instances, connection_type, tmpdir):
     project = custom_admin_running_instances['project']
-    run_dir = project.get_run_dir()
 
     base_cmd = [
-        cartridge_cmd, 'admin',
-        '--name', project.name,
-        '--run-dir', run_dir,
-        'echo_user',
+        cartridge_cmd, 'admin', 'echo_user',
     ]
+    base_cmd.extend(get_admin_connection_params(connection_type, project))
 
     # all args
     cmd = base_cmd + [
@@ -91,16 +92,16 @@ def test_func_long_arg(cartridge_cmd, custom_admin_running_instances, tmpdir):
     ]
 
 
-def test_func_rets_str(cartridge_cmd, custom_admin_running_instances, tmpdir):
+@pytest.mark.parametrize('connection_type', ['find-socket', 'connect'])
+def test_func_rets_str(cartridge_cmd, custom_admin_running_instances, connection_type, tmpdir):
     project = custom_admin_running_instances['project']
-    run_dir = project.get_run_dir()
 
     cmd = [
         cartridge_cmd, 'admin',
-        '--name', project.name,
-        '--run-dir', run_dir,
         'func_rets_str',
     ]
+    cmd.extend(get_admin_connection_params(connection_type, project))
+
     rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
     assert rc == 0
 
@@ -109,16 +110,16 @@ def test_func_rets_str(cartridge_cmd, custom_admin_running_instances, tmpdir):
     ]
 
 
-def test_func_rets_non_str(cartridge_cmd, custom_admin_running_instances, tmpdir):
+@pytest.mark.parametrize('connection_type', ['find-socket', 'connect'])
+def test_func_rets_non_str(cartridge_cmd, custom_admin_running_instances, connection_type, tmpdir):
     project = custom_admin_running_instances['project']
-    run_dir = project.get_run_dir()
 
     cmd = [
         cartridge_cmd, 'admin',
-        '--name', project.name,
-        '--run-dir', run_dir,
         'func_rets_non_str',
     ]
+    cmd.extend(get_admin_connection_params(connection_type, project))
+
     rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
     assert rc == 0
 
@@ -128,16 +129,16 @@ def test_func_rets_non_str(cartridge_cmd, custom_admin_running_instances, tmpdir
     ]
 
 
-def test_func_rets_err(cartridge_cmd, custom_admin_running_instances, tmpdir):
+@pytest.mark.parametrize('connection_type', ['find-socket', 'connect'])
+def test_func_rets_err(cartridge_cmd, custom_admin_running_instances, connection_type, tmpdir):
     project = custom_admin_running_instances['project']
-    run_dir = project.get_run_dir()
 
     cmd = [
         cartridge_cmd, 'admin',
-        '--name', project.name,
-        '--run-dir', run_dir,
         'func_rets_err',
     ]
+    cmd.extend(get_admin_connection_params(connection_type, project))
+
     rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
     assert rc == 1
 
@@ -146,16 +147,16 @@ def test_func_rets_err(cartridge_cmd, custom_admin_running_instances, tmpdir):
     ]
 
 
-def test_func_raises_err(cartridge_cmd, custom_admin_running_instances, tmpdir):
+@pytest.mark.parametrize('connection_type', ['find-socket', 'connect'])
+def test_func_raises_err(cartridge_cmd, custom_admin_running_instances, connection_type, tmpdir):
     project = custom_admin_running_instances['project']
-    run_dir = project.get_run_dir()
 
     cmd = [
         cartridge_cmd, 'admin',
-        '--name', project.name,
-        '--run-dir', run_dir,
         'func_raises_err',
     ]
+    cmd.extend(get_admin_connection_params(connection_type, project))
+
     rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
     assert rc == 1
 
@@ -163,19 +164,19 @@ def test_func_raises_err(cartridge_cmd, custom_admin_running_instances, tmpdir):
     assert 'Some horrible error raised' in output
 
 
-def test_print(cartridge_cmd, custom_admin_running_instances, tmpdir):
+@pytest.mark.parametrize('connection_type', ['find-socket', 'connect'])
+def test_print(cartridge_cmd, custom_admin_running_instances, connection_type, tmpdir):
     project = custom_admin_running_instances['project']
-    run_dir = project.get_run_dir()
 
     ITERATIONS_NUM = 3
 
     cmd = [
         cartridge_cmd, 'admin',
-        '--name', project.name,
-        '--run-dir', run_dir,
         'func_print',
         '--num', str(ITERATIONS_NUM),
     ]
+    cmd.extend(get_admin_connection_params(connection_type, project))
+
     rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
     assert rc == 0
 

--- a/test/integration/admin/test_common.py
+++ b/test/integration/admin/test_common.py
@@ -64,7 +64,7 @@ def test_bad_run_dir(cartridge_cmd, custom_admin_running_instances, admin_flow, 
 
 
 @pytest.mark.parametrize('admin_flow', ['list', 'help-func', 'call'])
-def test_app_name_missed(cartridge_cmd, custom_admin_running_instances, admin_flow, tmpdir):
+def test_connection_params_missed(cartridge_cmd, custom_admin_running_instances, admin_flow, tmpdir):
     project = custom_admin_running_instances['project']
     run_dir = project.get_run_dir()
 
@@ -78,7 +78,7 @@ def test_app_name_missed(cartridge_cmd, custom_admin_running_instances, admin_fl
 
     rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
     assert rc == 1
-    assert "Please, specify application name using --name" in output
+    assert "Please, specify one of --name, --instance or --conn" in output
 
 
 @pytest.mark.parametrize('admin_flow', ['help-func', 'call'])

--- a/test/integration/admin/test_default.py
+++ b/test/integration/admin/test_default.py
@@ -3,6 +3,7 @@ import subprocess
 
 from utils import run_command_and_get_output
 from utils import start_instances
+from utils import get_admin_connection_params
 from utils import get_log_lines
 
 from project import patch_cartridge_proc_titile
@@ -31,17 +32,18 @@ def default_admin_running_instances(cartridge_cmd, start_stop_cli, project_with_
     }
 
 
-def test_default_admin_func(cartridge_cmd, default_admin_running_instances, tmpdir):
+@pytest.mark.parametrize('connection_type', ['find-socket', 'connect', 'instance'])
+def test_default_admin_func(cartridge_cmd, default_admin_running_instances, connection_type, tmpdir):
     project = default_admin_running_instances['project']
     run_dir = project.get_run_dir()
 
     # list
     cmd = [
         cartridge_cmd, 'admin',
-        '--name', project.name,
-        '--run-dir', run_dir,
         '--list'
     ]
+    cmd.extend(get_admin_connection_params(connection_type, project))
+
     rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
     assert rc == 0
 

--- a/test/integration/admin/test_help.py
+++ b/test/integration/admin/test_help.py
@@ -1,17 +1,20 @@
+import pytest
+
 from utils import run_command_and_get_output
 from utils import get_log_lines
+from utils import get_admin_connection_params
 
 
-def test_help_many_args(cartridge_cmd, custom_admin_running_instances, tmpdir):
+@pytest.mark.parametrize('connection_type', ['find-socket', 'connect', 'instance'])
+def test_help_many_args(cartridge_cmd, custom_admin_running_instances, connection_type, tmpdir):
     project = custom_admin_running_instances['project']
-    run_dir = project.get_run_dir()
 
     cmd = [
         cartridge_cmd, 'admin',
-        '--name', project.name,
-        '--run-dir', run_dir,
         'echo_user', '--help',
     ]
+    cmd.extend(get_admin_connection_params(connection_type, project))
+
     rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
     assert rc == 0
 

--- a/test/integration/admin/test_list.py
+++ b/test/integration/admin/test_list.py
@@ -1,17 +1,20 @@
+import pytest
+
 from utils import run_command_and_get_output
 from utils import get_log_lines
+from utils import get_admin_connection_params
 
 
-def test_list(cartridge_cmd, custom_admin_running_instances, tmpdir):
+@pytest.mark.parametrize('connection_type', ['find-socket', 'connect', 'instance'])
+def test_list(cartridge_cmd, custom_admin_running_instances, connection_type, tmpdir):
     project = custom_admin_running_instances['project']
-    run_dir = project.get_run_dir()
 
     cmd = [
         cartridge_cmd, 'admin',
-        '--name', project.name,
-        '--run-dir', run_dir,
         '--list'
     ]
+    cmd.extend(get_admin_connection_params(connection_type, project))
+
     rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
     assert rc == 0
 


### PR DESCRIPTION
Added `--conn, -c` option for `cartridge admin`.
It allows to specify address of instance to run admin function on.
Also added missed `-l` shortcut for `--list` option of `cartridge admin`.

E.g.

```bash
cartridge admin --conn admin:passwd@localhost:3301 probe --help
cartridge admin --conn ./path/to/sock probe --help
```

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

