### PR TITLE
Custom centos repo support for `cartridge pack` command added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   * Changed standard port of the ``stateboard``
   * Added README.md
   * And other cosmetic fixes
+- Allowed to use any base docker image for the ``cartridge pack`` command.
 
 ## [2.6.0] - 2021-01-27
 

--- a/README.rst
+++ b/README.rst
@@ -1221,6 +1221,8 @@ can specify base layers for build and runtime images:
 The Dockerfile of the base image should be started with the ``FROM centos:8``
 or ``FROM centos:7`` line (except comments).
 
+We expect the base docker image to be ``centos:8`` or ``centos:7``, but you can use any other.
+
 For example, if your application requires ``gcc-c++`` for build and ``zip`` for
 runtime, customize the Dockerfiles as follows:
 

--- a/cli/create/templates/cartridge/Dockerfile.build.cartridge
+++ b/cli/create/templates/cartridge/Dockerfile.build.cartridge
@@ -2,7 +2,7 @@
 # Used by "pack" command as a base for build image
 # when --use-docker option is specified
 #
-# The base image must be centos:8
+# Image based on centos:8 is expected to be used
 FROM centos:8
 
 # Here you can install some packages required

--- a/cli/create/templates/cartridge/Dockerfile.cartridge
+++ b/cli/create/templates/cartridge/Dockerfile.cartridge
@@ -1,7 +1,7 @@
 # Simple Dockerfile
 # Used by "pack docker" command as a base for runtime image
 #
-# The base image must be centos:8
+# Image based on centos:8 is expected to be used
 FROM centos:8
 
 # Here you can install some packages required

--- a/cli/project/dockerfiles.go
+++ b/cli/project/dockerfiles.go
@@ -16,7 +16,7 @@ var (
 )
 
 func init() {
-	fromLayerRegexp = regexp.MustCompile(`^from\s+centos:[78]$`)
+	fromLayerRegexp = regexp.MustCompile(`^from\s+.*centos:[78]$`)
 }
 
 type opensourseCtx struct {

--- a/cli/project/dockerfiles.go
+++ b/cli/project/dockerfiles.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/apex/log"
 	"github.com/tarantool/cartridge-cli/cli/common"
 	"github.com/tarantool/cartridge-cli/cli/context"
 	"github.com/tarantool/cartridge-cli/cli/templates"
@@ -145,7 +146,7 @@ func CheckBaseDockerfile(dockerfilePath string) error {
 
 	fromLine = strings.ToLower(fromLine)
 	if !fromLayerRegexp.MatchString(fromLine) {
-		return fmt.Errorf("The base image must be centos:8")
+		log.Warnf("The centos:8 image is expected to be used")
 	}
 
 	return nil

--- a/cli/project/dockerfiles.go
+++ b/cli/project/dockerfiles.go
@@ -146,7 +146,7 @@ func CheckBaseDockerfile(dockerfilePath string) error {
 
 	fromLine = strings.ToLower(fromLine)
 	if !fromLayerRegexp.MatchString(fromLine) {
-		log.Warnf("The centos:8 image is expected to be used")
+		log.Warnf("Image based on centos:8 is expected to be used")
 	}
 
 	return nil

--- a/cli/project/dockerfiles_test.go
+++ b/cli/project/dockerfiles_test.go
@@ -23,7 +23,6 @@ func TestCheckBaseDockerfile(t *testing.T) {
 	assert := assert.New(t)
 
 	var err error
-	baseImageError := "The base image must be centos:8"
 
 	// create tmp Dockerfile
 	f, err := ioutil.TempFile("", "Dockerfile")
@@ -64,21 +63,21 @@ FROM centos:8`)
 	err = CheckBaseDockerfile(f.Name())
 	assert.Nil(err)
 
-	// Error
+	// Warnings
 
 	writeDockerfile(f, ``)
 	err = CheckBaseDockerfile(f.Name())
-	assert.EqualError(err, baseImageError)
+	assert.Nil(err)
 
 	writeDockerfile(f, `# from centos:8`)
 	err = CheckBaseDockerfile(f.Name())
-	assert.EqualError(err, baseImageError)
+	assert.Nil(err)
 
 	writeDockerfile(f, `
 # comment
 FROM ubuntu:eoan`)
 	err = CheckBaseDockerfile(f.Name())
-	assert.EqualError(err, baseImageError)
+	assert.Nil(err)
 }
 
 func TestGetBaseLayers(t *testing.T) {

--- a/cli/project/dockerfiles_test.go
+++ b/cli/project/dockerfiles_test.go
@@ -34,50 +34,6 @@ func TestCheckBaseDockerfile(t *testing.T) {
 	// non existing file
 	err = CheckBaseDockerfile("bad-path")
 	assert.EqualError(err, "open bad-path: no such file or directory")
-
-	// OK
-	writeDockerfile(f, `FROM centos:8`)
-	err = CheckBaseDockerfile(f.Name())
-	assert.Nil(err)
-
-	writeDockerfile(f, `from centos:8`)
-	err = CheckBaseDockerfile(f.Name())
-	assert.Nil(err)
-
-	writeDockerfile(f, `FROM centos:7`)
-	err = CheckBaseDockerfile(f.Name())
-	assert.Nil(err)
-
-	writeDockerfile(f, `
-# comment
-FROM centos:8`)
-	err = CheckBaseDockerfile(f.Name())
-	assert.Nil(err)
-
-	writeDockerfile(f, `FROM centos:8 # comment`)
-	err = CheckBaseDockerfile(f.Name())
-	assert.Nil(err)
-
-	writeDockerfile(f, `# FROM ubuntu:eoan
-FROM centos:8`)
-	err = CheckBaseDockerfile(f.Name())
-	assert.Nil(err)
-
-	// Warnings
-
-	writeDockerfile(f, ``)
-	err = CheckBaseDockerfile(f.Name())
-	assert.Nil(err)
-
-	writeDockerfile(f, `# from centos:8`)
-	err = CheckBaseDockerfile(f.Name())
-	assert.Nil(err)
-
-	writeDockerfile(f, `
-# comment
-FROM ubuntu:eoan`)
-	err = CheckBaseDockerfile(f.Name())
-	assert.Nil(err)
 }
 
 func TestGetBaseLayers(t *testing.T) {

--- a/test/integration/pack/test_pack.py
+++ b/test/integration/pack/test_pack.py
@@ -94,7 +94,7 @@ def deb_archive(cartridge_cmd, tmpdir, light_project, request):
 
 
 @pytest.fixture(scope="session")
-def docker_custom_image(session_tmpdir, request, docker_client):
+def custom_base_image(session_tmpdir, request, docker_client):
     custom_image_path = os.path.join(session_tmpdir, 'Dockerfile')
     with open(custom_image_path, 'w') as f:
         f.write("FROM centos:8")
@@ -588,7 +588,7 @@ def test_project_without_build_dockerfile(cartridge_cmd, project_without_depende
 
 @pytest.mark.parametrize('pack_format', ['tgz'])
 def test_custom_base_image_build_dockerfile(
-    cartridge_cmd, project_without_dependencies, pack_format, docker_custom_image, tmpdir
+    cartridge_cmd, project_without_dependencies, pack_format, custom_base_image, tmpdir
 ):
     custom_base_image_dockerfile = "FROM my-custom-centos-8"
 
@@ -606,7 +606,7 @@ def test_custom_base_image_build_dockerfile(
 
     rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
     assert rc == 0
-    assert 'The centos:8 image is expected to be used' in output
+    assert 'Image based on centos:8 is expected to be used' in output
 
 
 @pytest.mark.parametrize('pack_format', ['tgz'])

--- a/test/integration/pack/test_pack.py
+++ b/test/integration/pack/test_pack.py
@@ -598,8 +598,8 @@ def test_invalid_base_build_dockerfile(cartridge_cmd, project_without_dependenci
 
         rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
         assert rc == 1
-        assert 'Invalid base build Dockerfile' in output
-        assert 'base image must be centos:8' in output
+        assert 'Failed to build base image' in output
+        assert 'The centos:8 image is expected to be used' in output
 
 
 @pytest.mark.parametrize('pack_format', ['tgz'])

--- a/test/integration/pack/test_pack.py
+++ b/test/integration/pack/test_pack.py
@@ -18,6 +18,7 @@ from utils import check_package_files
 from utils import assert_tarantool_dependency_deb
 from utils import assert_tarantool_dependency_rpm
 from utils import run_command_and_get_output
+from utils import build_image
 
 
 # ########
@@ -90,6 +91,15 @@ def deb_archive(cartridge_cmd, tmpdir, light_project, request):
     assert filepath is not None, "DEB archive isn't found in work directory"
 
     return Archive(filepath=filepath, project=project)
+
+
+@pytest.fixture(scope="session")
+def docker_custom_image(session_tmpdir, request, docker_client):
+    custom_image_path = os.path.join(session_tmpdir, 'Dockerfile')
+    with open(custom_image_path, 'w') as f:
+        f.write("FROM centos:8")
+
+    build_image(session_tmpdir, 'my-custom-centos-8')
 
 
 # ########
@@ -577,29 +587,26 @@ def test_project_without_build_dockerfile(cartridge_cmd, project_without_depende
 
 
 @pytest.mark.parametrize('pack_format', ['tgz'])
-def test_invalid_base_build_dockerfile(cartridge_cmd, project_without_dependencies, pack_format, tmpdir):
-    bad_dockerfiles = [
-        "FROM ubuntu:xenial\n",
-        "I am FROM centos:8",
+def test_custom_base_image_build_dockerfile(
+    cartridge_cmd, project_without_dependencies, pack_format, docker_custom_image, tmpdir
+):
+    custom_base_image_dockerfile = "FROM my-custom-centos-8"
+
+    custom_dockerfile_path = os.path.join(tmpdir, 'Dockerfile')
+    with open(custom_dockerfile_path, 'w') as f:
+        f.write(custom_base_image_dockerfile)
+
+    cmd = [
+        cartridge_cmd,
+        "pack", pack_format,
+        "--use-docker",
+        "--build-from", custom_dockerfile_path,
+        project_without_dependencies.path,
     ]
 
-    invalid_dockerfile_path = os.path.join(tmpdir, 'Dockerfile')
-    for bad_dockerfile in bad_dockerfiles:
-        with open(invalid_dockerfile_path, 'w') as f:
-            f.write(bad_dockerfile)
-
-        cmd = [
-            cartridge_cmd,
-            "pack", pack_format,
-            "--use-docker",
-            "--build-from", invalid_dockerfile_path,
-            project_without_dependencies.path,
-        ]
-
-        rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
-        assert rc == 1
-        assert 'Failed to build base image' in output
-        assert 'The centos:8 image is expected to be used' in output
+    rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
+    assert rc == 0
+    assert 'The centos:8 image is expected to be used' in output
 
 
 @pytest.mark.parametrize('pack_format', ['tgz'])

--- a/test/integration/pack/test_pack_docker.py
+++ b/test/integration/pack/test_pack_docker.py
@@ -146,25 +146,24 @@ def test_pack(docker_image, tmpdir, docker_client):
         assert installed_version == expected_version
 
 
-def test_invalid_base_runtime_dockerfile(cartridge_cmd, project_without_dependencies, module_tmpdir, tmpdir):
-    invalid_dockerfile_path = os.path.join(tmpdir, 'Dockerfile')
-    with open(invalid_dockerfile_path, 'w') as f:
+def test_non_standard_base_runtime_dockerfile(cartridge_cmd, project_without_dependencies, module_tmpdir, tmpdir):
+    non_standard_base_dockerfile_path = os.path.join(tmpdir, 'Dockerfile')
+    with open(non_standard_base_dockerfile_path, 'w') as f:
         f.write('''
-            # Invalid dockerfile
-            FROM ubuntu:xenial
+            # Non standard dockerfile
+            FROM centos:6
         ''')
 
     cmd = [
         cartridge_cmd,
         "pack", "docker",
-        "--from", invalid_dockerfile_path,
+        "--from", non_standard_base_dockerfile_path,
         project_without_dependencies.path,
     ]
 
     rc, output = run_command_and_get_output(cmd, cwd=module_tmpdir)
-    assert rc == 1
-    assert 'Invalid base runtime Dockerfile' in output
-    assert 'base image must be centos:8' in output
+    assert rc == 0
+    assert 'The centos:8 image is expected to be used' in output
 
 
 def test_project_witout_runtime_dockerfile(cartridge_cmd, project_without_dependencies, tmpdir):

--- a/test/integration/pack/test_pack_docker.py
+++ b/test/integration/pack/test_pack_docker.py
@@ -150,7 +150,7 @@ def test_custom_base_runtime_dockerfile(cartridge_cmd, project_without_dependenc
     custom_base_dockerfile_path = os.path.join(tmpdir, 'Dockerfile')
     with open(custom_base_dockerfile_path, 'w') as f:
         f.write('''
-            # Non standard dockerfile
+            # Non standard base image
             FROM my-custom-centos-8
         ''')
 
@@ -163,7 +163,7 @@ def test_custom_base_runtime_dockerfile(cartridge_cmd, project_without_dependenc
 
     rc, output = run_command_and_get_output(cmd, cwd=module_tmpdir)
     assert rc == 0
-    assert 'The centos:8 image is expected to be used' in output
+    assert 'Image based on centos:8 is expected to be used' in output
 
 
 def test_project_witout_runtime_dockerfile(cartridge_cmd, project_without_dependencies, tmpdir):

--- a/test/integration/pack/test_pack_docker.py
+++ b/test/integration/pack/test_pack_docker.py
@@ -146,18 +146,18 @@ def test_pack(docker_image, tmpdir, docker_client):
         assert installed_version == expected_version
 
 
-def test_non_standard_base_runtime_dockerfile(cartridge_cmd, project_without_dependencies, module_tmpdir, tmpdir):
-    non_standard_base_dockerfile_path = os.path.join(tmpdir, 'Dockerfile')
-    with open(non_standard_base_dockerfile_path, 'w') as f:
+def test_custom_base_runtime_dockerfile(cartridge_cmd, project_without_dependencies, module_tmpdir, tmpdir):
+    custom_base_dockerfile_path = os.path.join(tmpdir, 'Dockerfile')
+    with open(custom_base_dockerfile_path, 'w') as f:
         f.write('''
             # Non standard dockerfile
-            FROM centos:6
+            FROM alexeymrvz/my-custom-centos8
         ''')
 
     cmd = [
         cartridge_cmd,
         "pack", "docker",
-        "--from", non_standard_base_dockerfile_path,
+        "--from", custom_base_dockerfile_path,
         project_without_dependencies.path,
     ]
 

--- a/test/integration/pack/test_pack_docker.py
+++ b/test/integration/pack/test_pack_docker.py
@@ -151,7 +151,7 @@ def test_custom_base_runtime_dockerfile(cartridge_cmd, project_without_dependenc
     with open(custom_base_dockerfile_path, 'w') as f:
         f.write('''
             # Non standard dockerfile
-            FROM alexeymrvz/my-custom-centos8
+            FROM my-custom-centos-8
         ''')
 
     cmd = [


### PR DESCRIPTION
Allowed to use any base docker image for the ``cartridge pack`` command. Closes #469