### PR TITLE
Remove tarantool process name check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   * Added README.md
   * And other cosmetic fixes
 - Allowed to use any base docker image for the ``cartridge pack`` command.
+- Executable with any name (not only ``tarantool``) can run processes.
 
 ## [2.6.0] - 2021-01-27
 

--- a/cli/running/process.go
+++ b/cli/running/process.go
@@ -91,7 +91,6 @@ func (process *Process) SetPidAndStatus() {
 	var err error
 
 	if process.pid == 0 {
-
 		pidFile, err := os.Open(process.pidFile)
 		if os.IsNotExist(err) {
 			process.Status = procStatusNotStarted

--- a/cli/running/process.go
+++ b/cli/running/process.go
@@ -133,13 +133,10 @@ func (process *Process) SetPidAndStatus() {
 	if err != nil {
 		process.Status = procStatusError
 		process.Error = fmt.Errorf("Failed to get process %d name: %s", process.pid, name)
-		return
 	}
 
 	if name != "tarantool" {
-		process.Status = procStatusError
-		process.Error = fmt.Errorf("Process %d does not seem to be tarantool", process.pid)
-		return
+		log.Warnf("Process %d does not seem to be tarantool", process.pid)
 	}
 
 	if err := process.osProcess.SendSignal(syscall.Signal(0)); err != nil {

--- a/cli/running/process.go
+++ b/cli/running/process.go
@@ -133,6 +133,7 @@ func (process *Process) SetPidAndStatus() {
 	if err != nil {
 		process.Status = procStatusError
 		process.Error = fmt.Errorf("Failed to get process %d name: %s", process.pid, name)
+		return
 	}
 
 	if name != "tarantool" {

--- a/cli/running/process.go
+++ b/cli/running/process.go
@@ -91,6 +91,7 @@ func (process *Process) SetPidAndStatus() {
 	var err error
 
 	if process.pid == 0 {
+
 		pidFile, err := os.Open(process.pidFile)
 		if os.IsNotExist(err) {
 			process.Status = procStatusNotStarted

--- a/cli/running/process.go
+++ b/cli/running/process.go
@@ -137,7 +137,7 @@ func (process *Process) SetPidAndStatus() {
 	}
 
 	if name != "tarantool" {
-		log.Warnf("Process %d does not seem to be tarantool", process.pid)
+		log.Warnf("Process %s does not seem to be tarantool", name)
 	}
 
 	if err := process.osProcess.SendSignal(syscall.Signal(0)); err != nil {

--- a/test/integration/running/test_running.py
+++ b/test/integration/running/test_running.py
@@ -5,7 +5,7 @@ import re
 
 from utils import check_instances_running, check_instances_stopped
 from utils import STATUS_NOT_STARTED, STATUS_RUNNING, STATUS_STOPPED
-from utils import write_conf
+from utils import write_conf, find_file_in_path
 
 from project import patch_init_to_send_statuses
 from project import patch_init_to_send_ready_after_timeout
@@ -410,7 +410,7 @@ def test_start_stop_custom_tararntool(start_stop_cli, project_without_dependenci
     # fake tarantool script is always higher than the original tarantool.
     # As a result, our process is not called a 'tarantool'.
 
-    real_tarantool_abs_path = '/usr/local/bin/tarantool'
+    real_tarantool_abs_path = find_file_in_path(os.environ['PATH'], 'tarantool')
     tarantool_substitution_script = f"#!/bin/sh\n{real_tarantool_abs_path} $1"
     with open('tarantool', 'w') as f:
         f.write(tarantool_substitution_script)

--- a/test/utils.py
+++ b/test/utils.py
@@ -118,7 +118,7 @@ class Cli():
 
     def start(self, project, instances=[], daemonized=False, stateboard=False, stateboard_only=False,
               cfg=None, script=None, run_dir=None, data_dir=None, log_dir=None, timeout=None,
-              capture_output=False, exp_rc=0):
+              capture_output=False, env=None, exp_rc=0):
         cmd = [self._cartridge_cmd, 'start']
         if daemonized:
             cmd.append('-d')
@@ -144,12 +144,14 @@ class Cli():
         if not capture_output:
             self._subprocess = subprocess.Popen(
                 cmd, cwd=project.path,
+                env=env,
                 stdout=sys.stdout,
                 stderr=sys.stderr,
             )
         else:
             self._subprocess = subprocess.Popen(
                 cmd, cwd=project.path,
+                env=env,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
             )
@@ -1229,10 +1231,3 @@ def get_admin_connection_params(connection_type, project):
         ]
 
     assert False, "Unknown connection type: %s" % connection_type
-
-
-def find_file_in_path(path_variable, name):
-    for path in path_variable.split(':'):
-        for root, dirs, files in os.walk(path):
-            if name in files:
-                return os.path.join(root, name)

--- a/test/utils.py
+++ b/test/utils.py
@@ -1229,3 +1229,10 @@ def get_admin_connection_params(connection_type, project):
         ]
 
     assert False, "Unknown connection type: %s" % connection_type
+
+
+def find_file_in_path(path_variable, name):
+    for path in path_variable.split(':'):
+        for root, dirs, files in os.walk(path):
+            if name in files:
+                return os.path.join(root, name)


### PR DESCRIPTION
Executable with any name (not only ``tarantool``) can run processes. Closes #476
