### PR TITLE
CI: Fix unexpected services running on Github Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,6 +55,9 @@ jobs:
           sudo systemctl disable tarantool@example || true
           sudo rm -rf /lib/systemd/system/tarantool@.service
 
+      - name: Stop mono server
+        run: sudo kill -9 $(sudo lsof -t -i tcp:8084) || true
+
       - name: Setup python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,6 +55,7 @@ jobs:
           sudo systemctl disable tarantool@example || true
           sudo rm -rf /lib/systemd/system/tarantool@.service
 
+      # This server starts and listen on 8084 port that is used for tests
       - name: Stop mono server
         run: sudo kill -9 $(sudo lsof -t -i tcp:8084) || true
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Stop and disable Taranool 1.10 example service
         if: matrix.tarantool-version == '1.10'
         run: |
-          sudo systemctl stop tarantool@example
-          sudo systemctl disable tarantool@example
+          sudo systemctl stop tarantool@example || true
+          sudo systemctl disable tarantool@example || true
           sudo rm -rf /lib/systemd/system/tarantool@.service
 
       - name: Setup python

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -146,6 +146,10 @@ jobs:
           echo "${SDK_PATH}" >> ${GITHUB_PATH}
           echo "TARANTOOL_SDK_PATH=${SDK_PATH}" >> ${GITHUB_ENV}
 
+      # This server starts and listen on 8084 port that is used for tests
+      - name: Stop mono server
+        run: sudo kill -9 $(sudo lsof -t -i tcp:8084) || true
+
       - name: Setup python
         uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
Fix unexpected services running on Github Actions

* Stop tarantool example service only if it exists
* Stop Mono service that uses 8084