### PR TITLE
Ability to customize docker variables

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,11 +75,11 @@ jobs:
       - name: Linter
         run: mage lint
 
-      #- name: Unit tests
-      #  run: mage unit
+      - name: Unit tests
+        run: mage unit
 
-      #- name: Integration tests
-      #  run: mage integration
+      - name: Integration tests
+        run: mage integration
 
       - name: Examples tests
         run: mage testExamples
@@ -162,11 +162,11 @@ jobs:
       - name: Linter
         run: mage lint
 
-      #- name: Unit tests
-      #  run: mage unit
+      - name: Unit tests
+        run: mage unit
 
-      #- name: Integration tests
-      #  run: mage integration
+      - name: Integration tests
+        run: mage integration
 
       - name: Examples tests
         run: mage testExamples

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,8 +78,8 @@ jobs:
       - name: Unit tests
         run: mage unit
 
-      - name: Integration tests
-        run: mage integration
+      #- name: Integration tests
+      #  run: mage integration
 
       - name: Examples tests
         run: mage testExamples
@@ -165,8 +165,8 @@ jobs:
       - name: Unit tests
         run: mage unit
 
-      - name: Integration tests
-        run: mage integration
+      #- name: Integration tests
+      #  run: mage integration
 
       - name: Examples tests
         run: mage testExamples

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,8 +75,8 @@ jobs:
       - name: Linter
         run: mage lint
 
-      - name: Unit tests
-        run: mage unit
+      #- name: Unit tests
+      #  run: mage unit
 
       #- name: Integration tests
       #  run: mage integration
@@ -162,8 +162,8 @@ jobs:
       - name: Linter
         run: mage lint
 
-      - name: Unit tests
-        run: mage unit
+      #- name: Unit tests
+      #  run: mage unit
 
       #- name: Integration tests
       #  run: mage integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added interruption of an incomplete expression when pressing
   ``Ctrl-C`` in ``cartridge enter`` command.
 - Packing applications that use `cartridge 2.5.0` and higher
+- Variables ``TARANTOOL_WORKDIR``, ``TARANTOOL_PID_FILE`` and ``TARANTOOL_CONSOLE_SOCK``
+  can be customized when packing in docker via ``cartridge pack`` command.
+
 
 ## [2.7.0] - 2021-03-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Variables ``TARANTOOL_WORKDIR``, ``TARANTOOL_PID_FILE`` and ``TARANTOOL_CONSOLE_SOCK``
   can be customized when packing in docker via ``cartridge pack`` command.
 
-
 ## [2.7.0] - 2021-03-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added interruption of an incomplete expression when pressing
   ``Ctrl-C`` in ``cartridge enter`` command.
 - Packing applications that use `cartridge 2.5.0` and higher
-- Variables ``TARANTOOL_WORKDIR``, ``TARANTOOL_PID_FILE`` and ``TARANTOOL_CONSOLE_SOCK``
-  can be customized when packing in docker via ``cartridge pack`` command.
+
+## Added
+
+- Variables ``TARANTOOL_WORKDIR``, ``TARANTOOL_PID_FILE`` and
+  ``TARANTOOL_CONSOLE_SOCK`` can be customized when packing in docker via
+  ``cartridge pack`` command. Variables ``CARTRIDGE_RUN_DIR`` and
+  ``CARTRIDGE_DATA_DIR`` have also been added.
 
 ## [2.7.0] - 2021-03-11
 

--- a/README.rst
+++ b/README.rst
@@ -1214,6 +1214,43 @@ To start the ``instance-1`` instance of the ``myapp`` application, say:
 
 By default, ``TARANTOOL_INSTANCE_NAME`` is set to ``default``.
 
+You can set ``CARTRIDGE_RUN_DIR``, ``CARTRIDGE_DATA_DIR`` environment variables.
+
+.. code-block:: bash
+
+    docker run -d \
+                    --name instance-1 \
+                    -e CARTRIDGE_RUN_DIR=my-custom-run-dir \
+                    -e CARTRIDGE_DATA_DIR=my-custom-data-dir \
+                    -e TARANTOOL_ADVERTISE_URI=3302 \
+                    -e TARANTOOL_CLUSTER_COOKIE=secret \
+                    -e TARANTOOL_HTTP_PORT=8082 \
+                    -p 127.0.0.1:8082:8082 \
+                    myapp:1.0.0
+
+Variable ``CARTRIDGE_DATA_DIR`` is used as the root of the working directory.
+By default, ``CARTRIDGE_DATA_DIR`` is set to /var/lib/tarantool.
+
+Variable ``CARTRIDGE_RUN_DIR`` is used as the root of the directory, where
+will be stored pid file and console sock. By default, ``CARTRIDGE_RUN_DIR``
+is set to /var/run/tarantool.
+
+Also you can set ``TARANTOOL_WORKDIR``, ``TARANTOOL_PID_FILE`` and ``TARANTOOL_CONSOLE_SOCK``
+variables.
+
+.. code-block:: bash
+
+    docker run -d \
+                    --name instance-1 \
+                    -e TARANTOOL_WORKDIR=custom-workdir \
+                    -e TARANTOOL_PID_FILE=custom-pid-file \
+                    -e TARANTOOL_CONSOLE_SOCK=custom-console-sock \
+                    -e TARANTOOL_ADVERTISE_URI=3302 \
+                    -e TARANTOOL_CLUSTER_COOKIE=secret \
+                    -e TARANTOOL_HTTP_PORT=8082 \
+                    -p 127.0.0.1:8082:8082 \
+                    myapp:1.0.0
+
 To check the instance logs, say:
 
 .. code-block:: bash

--- a/cli/pack/docker.go
+++ b/cli/pack/docker.go
@@ -23,6 +23,9 @@ func packDocker(ctx *context.Ctx) error {
 		}
 	}
 
+	ctx.Running.RunDir = "${TARANTOOL_RUN_DIR}"
+	ctx.Running.DataDir = "${TARANTOOL_DATA_DIR}"
+
 	// app dir
 	appDirPath := filepath.Join(ctx.Pack.PackageFilesDir, ctx.Project.Name)
 	if err := initAppDir(appDirPath, ctx); err != nil {

--- a/cli/pack/docker.go
+++ b/cli/pack/docker.go
@@ -23,8 +23,8 @@ func packDocker(ctx *context.Ctx) error {
 		}
 	}
 
-	ctx.Running.RunDir = "${TARANTOOL_RUN_DIR}"
-	ctx.Running.DataDir = "${TARANTOOL_DATA_DIR}"
+	ctx.Running.RunDir = "${CARTRIDGE_RUN_DIR}"
+	ctx.Running.DataDir = "${CARTRIDGE_DATA_DIR}"
 
 	// app dir
 	appDirPath := filepath.Join(ctx.Pack.PackageFilesDir, ctx.Project.Name)

--- a/cli/project/dockerfiles.go
+++ b/cli/project/dockerfiles.go
@@ -210,10 +210,10 @@ RUN echo '{{ .TmpFilesConf }}' > /usr/lib/tmpfiles.d/{{ .Name }}.conf \
     && chmod 644 /usr/lib/tmpfiles.d/{{ .Name }}.conf
 
 USER tarantool:tarantool
-ENV TARANTOOL_INSTANCE_NAME=default \
-	TARANTOOL_WORKDIR={{ .WorkDir }} \
-	TARANTOOL_PID_FILE={{ .PidFile }} \
-	TARANTOOL_CONSOLE_SOCK={{ .ConsoleSock }}
+ENV TARANTOOL_INSTANCE_NAME=default
+ENV TARANTOOL_WORKDIR={{ .WorkDir }}
+ENV TARANTOOL_PID_FILE={{ .PidFile }}
+ENV TARANTOOL_CONSOLE_SOCK={{ .ConsoleSock }}
 `
 
 	installTarantoolOpensourceLayers = `### Install opensource Tarantool

--- a/cli/project/dockerfiles.go
+++ b/cli/project/dockerfiles.go
@@ -247,9 +247,11 @@ ENV PATH="{{ .AppDir }}:${PATH}"
 `
 
 	cmdLayer = `### Runtime command
-CMD TARANTOOL_WORKDIR=${TARANTOOL_WORKDIR:-{{ .WorkDir}}} \
+CMD bash -c "mkdir -p ${TARANTOOL_CONSOLE_SOCK:-{{ .ConsoleSock }}} && \
+	mkdir -p ${TARANTOOL_PID_FILE:-{{ .PidFile }}} && \
+	TARANTOOL_WORKDIR=${TARANTOOL_WORKDIR:-{{ .WorkDir }}} \
 	TARANTOOL_PID_FILE=${TARANTOOL_PID_FILE:-{{ .PidFile }}} \
 	TARANTOOL_CONSOLE_SOCK=${TARANTOOL_CONSOLE_SOCK:-{{ .ConsoleSock }}} \
-	tarantool {{ .AppEntrypointPath }}
+	tarantool {{ .AppEntrypointPath }}"
 `
 )

--- a/cli/project/dockerfiles.go
+++ b/cli/project/dockerfiles.go
@@ -210,10 +210,9 @@ RUN echo '{{ .TmpFilesConf }}' > /usr/lib/tmpfiles.d/{{ .Name }}.conf \
     && chmod 644 /usr/lib/tmpfiles.d/{{ .Name }}.conf
 
 USER tarantool:tarantool
+ENV CARTRIDGE_RUN_DIR=/var/run/tarantool
+ENV CARTRIDGE_DATA_DIR=/var/lib/tarantool
 ENV TARANTOOL_INSTANCE_NAME=default
-ENV TARANTOOL_WORKDIR={{ .WorkDir }}
-ENV TARANTOOL_PID_FILE={{ .PidFile }}
-ENV TARANTOOL_CONSOLE_SOCK={{ .ConsoleSock }}
 `
 
 	installTarantoolOpensourceLayers = `### Install opensource Tarantool
@@ -248,9 +247,9 @@ ENV PATH="{{ .AppDir }}:${PATH}"
 `
 
 	cmdLayer = `### Runtime command
-CMD TARANTOOL_WORKDIR=$TARANTOOL_WORKDIR \
-	TARANTOOL_PID_FILE=$TARANTOOL_PID_FILE \
-	TARANTOOL_CONSOLE_SOCK=$TARANTOOL_CONSOLE_SOCK \
+CMD TARANTOOL_WORKDIR=${TARANTOOL_WORKDIR:-{{ .WorkDir}}} \
+	TARANTOOL_PID_FILE=${TARANTOOL_PID_FILE:-{{ .PidFile }}} \
+	TARANTOOL_CONSOLE_SOCK=${TARANTOOL_CONSOLE_SOCK:-{{ .ConsoleSock }}} \
 	tarantool {{ .AppEntrypointPath }}
 `
 )

--- a/cli/project/dockerfiles.go
+++ b/cli/project/dockerfiles.go
@@ -210,7 +210,10 @@ RUN echo '{{ .TmpFilesConf }}' > /usr/lib/tmpfiles.d/{{ .Name }}.conf \
     && chmod 644 /usr/lib/tmpfiles.d/{{ .Name }}.conf
 
 USER tarantool:tarantool
-ENV TARANTOOL_INSTANCE_NAME=default
+ENV TARANTOOL_INSTANCE_NAME=default \
+	TARANTOOL_WORKDIR={{ .WorkDir }} \
+	TARANTOOL_PID_FILE={{ .PidFile }} \
+	TARANTOOL_CONSOLE_SOCK={{ .ConsoleSock }}
 `
 
 	installTarantoolOpensourceLayers = `### Install opensource Tarantool
@@ -245,9 +248,9 @@ ENV PATH="{{ .AppDir }}:${PATH}"
 `
 
 	cmdLayer = `### Runtime command
-CMD TARANTOOL_WORKDIR={{ .WorkDir }} \
-    TARANTOOL_PID_FILE={{ .PidFile }} \
-    TARANTOOL_CONSOLE_SOCK={{ .ConsoleSock }} \
+CMD TARANTOOL_WORKDIR=$TARANTOOL_WORKDIR \
+	TARANTOOL_PID_FILE=$TARANTOOL_PID_FILE \
+	TARANTOOL_CONSOLE_SOCK=$TARANTOOL_CONSOLE_SOCK \
 	tarantool {{ .AppEntrypointPath }}
 `
 )

--- a/cli/project/dockerfiles.go
+++ b/cli/project/dockerfiles.go
@@ -247,8 +247,7 @@ ENV PATH="{{ .AppDir }}:${PATH}"
 `
 
 	cmdLayer = `### Runtime command
-CMD bash -c "mkdir -p ${TARANTOOL_CONSOLE_SOCK:-{{ .ConsoleSock }}} && \
-	mkdir -p ${TARANTOOL_PID_FILE:-{{ .PidFile }}} && \
+CMD bash -c "mkdir -p ${CARTRIDGE_RUN_DIR} ${CARTRIDGE_DATA_DIR} && \
 	TARANTOOL_WORKDIR=${TARANTOOL_WORKDIR:-{{ .WorkDir }}} \
 	TARANTOOL_PID_FILE=${TARANTOOL_PID_FILE:-{{ .PidFile }}} \
 	TARANTOOL_CONSOLE_SOCK=${TARANTOOL_CONSOLE_SOCK:-{{ .ConsoleSock }}} \

--- a/cli/project/dockerfiles_test.go
+++ b/cli/project/dockerfiles_test.go
@@ -332,10 +332,11 @@ COPY . {{ .AppDir }}
 ENV PATH="{{ .AppDir }}:${PATH}"
 
 ### Runtime command
-CMD TARANTOOL_WORKDIR=${TARANTOOL_WORKDIR:-{{ .WorkDir }}} \
+CMD bash -c "mkdir -p ${CARTRIDGE_RUN_DIR} ${CARTRIDGE_DATA_DIR} && \
+	TARANTOOL_WORKDIR=${TARANTOOL_WORKDIR:-{{ .WorkDir }}} \
 	TARANTOOL_PID_FILE=${TARANTOOL_PID_FILE:-{{ .PidFile }}} \
 	TARANTOOL_CONSOLE_SOCK=${TARANTOOL_CONSOLE_SOCK:-{{ .ConsoleSock }}} \
-	tarantool {{ .AppEntrypointPath }}
+	tarantool {{ .AppEntrypointPath }}"
 `
 
 	tmpl, err = GetRuntimeImageDockerfileTemplate(&ctx)
@@ -380,10 +381,11 @@ COPY . {{ .AppDir }}
 ENV PATH="{{ .AppDir }}:${PATH}"
 
 ### Runtime command
-CMD TARANTOOL_WORKDIR=${TARANTOOL_WORKDIR:-{{ .WorkDir }}} \
+CMD bash -c "mkdir -p ${CARTRIDGE_RUN_DIR} ${CARTRIDGE_DATA_DIR} && \
+	TARANTOOL_WORKDIR=${TARANTOOL_WORKDIR:-{{ .WorkDir }}} \
 	TARANTOOL_PID_FILE=${TARANTOOL_PID_FILE:-{{ .PidFile }}} \
 	TARANTOOL_CONSOLE_SOCK=${TARANTOOL_CONSOLE_SOCK:-{{ .ConsoleSock }}} \
-	tarantool {{ .AppEntrypointPath }}
+	tarantool {{ .AppEntrypointPath }}"
 `
 
 	tmpl, err = GetRuntimeImageDockerfileTemplate(&ctx)
@@ -431,10 +433,11 @@ ENV TARANTOOL_INSTANCE_NAME=default
 COPY . {{ .AppDir }}
 
 ### Runtime command
-CMD TARANTOOL_WORKDIR=${TARANTOOL_WORKDIR:-{{ .WorkDir }}} \
+CMD bash -c "mkdir -p ${CARTRIDGE_RUN_DIR} ${CARTRIDGE_DATA_DIR} && \
+	TARANTOOL_WORKDIR=${TARANTOOL_WORKDIR:-{{ .WorkDir }}} \
 	TARANTOOL_PID_FILE=${TARANTOOL_PID_FILE:-{{ .PidFile }}} \
 	TARANTOOL_CONSOLE_SOCK=${TARANTOOL_CONSOLE_SOCK:-{{ .ConsoleSock }}} \
-	tarantool {{ .AppEntrypointPath }}
+	tarantool {{ .AppEntrypointPath }}"
 `
 
 	tmpl, err = GetRuntimeImageDockerfileTemplate(&ctx)
@@ -471,9 +474,10 @@ ENV TARANTOOL_INSTANCE_NAME=default
 COPY . {{ .AppDir }}
 
 ### Runtime command
-CMD TARANTOOL_WORKDIR=${TARANTOOL_WORKDIR:-{{ .WorkDir }}} \
+CMD bash -c "mkdir -p ${CARTRIDGE_RUN_DIR} ${CARTRIDGE_DATA_DIR} && \
+	TARANTOOL_WORKDIR=${TARANTOOL_WORKDIR:-{{ .WorkDir }}} \
 	TARANTOOL_PID_FILE=${TARANTOOL_PID_FILE:-{{ .PidFile }}} \
 	TARANTOOL_CONSOLE_SOCK=${TARANTOOL_CONSOLE_SOCK:-{{ .ConsoleSock }}} \
-	tarantool {{ .AppEntrypointPath }}
+	tarantool {{ .AppEntrypointPath }}"
 `
 }

--- a/cli/project/dockerfiles_test.go
+++ b/cli/project/dockerfiles_test.go
@@ -321,7 +321,10 @@ RUN echo '{{ .TmpFilesConf }}' > /usr/lib/tmpfiles.d/{{ .Name }}.conf \
     && chmod 644 /usr/lib/tmpfiles.d/{{ .Name }}.conf
 
 USER tarantool:tarantool
-ENV TARANTOOL_INSTANCE_NAME=default
+ENV TARANTOOL_INSTANCE_NAME=default \
+	TARANTOOL_WORKDIR={{ .WorkDir }} \
+	TARANTOOL_PID_FILE={{ .PidFile }} \
+	TARANTOOL_CONSOLE_SOCK={{ .ConsoleSock }}
 
 ### Copy application code
 COPY . {{ .AppDir }}
@@ -330,9 +333,9 @@ COPY . {{ .AppDir }}
 ENV PATH="{{ .AppDir }}:${PATH}"
 
 ### Runtime command
-CMD TARANTOOL_WORKDIR={{ .WorkDir }} \
-    TARANTOOL_PID_FILE={{ .PidFile }} \
-    TARANTOOL_CONSOLE_SOCK={{ .ConsoleSock }} \
+CMD TARANTOOL_WORKDIR=$TARANTOOL_WORKDIR \
+	TARANTOOL_PID_FILE=$TARANTOOL_PID_FILE \
+	TARANTOOL_CONSOLE_SOCK=$TARANTOOL_CONSOLE_SOCK \
 	tarantool {{ .AppEntrypointPath }}
 `
 
@@ -367,7 +370,10 @@ RUN echo '{{ .TmpFilesConf }}' > /usr/lib/tmpfiles.d/{{ .Name }}.conf \
     && chmod 644 /usr/lib/tmpfiles.d/{{ .Name }}.conf
 
 USER tarantool:tarantool
-ENV TARANTOOL_INSTANCE_NAME=default
+ENV TARANTOOL_INSTANCE_NAME=default \
+	TARANTOOL_WORKDIR={{ .WorkDir }} \
+	TARANTOOL_PID_FILE={{ .PidFile }} \
+	TARANTOOL_CONSOLE_SOCK={{ .ConsoleSock }}
 
 ### Copy application code
 COPY . {{ .AppDir }}
@@ -376,9 +382,9 @@ COPY . {{ .AppDir }}
 ENV PATH="{{ .AppDir }}:${PATH}"
 
 ### Runtime command
-CMD TARANTOOL_WORKDIR={{ .WorkDir }} \
-    TARANTOOL_PID_FILE={{ .PidFile }} \
-    TARANTOOL_CONSOLE_SOCK={{ .ConsoleSock }} \
+CMD TARANTOOL_WORKDIR=$TARANTOOL_WORKDIR \
+	TARANTOOL_PID_FILE=$TARANTOOL_PID_FILE \
+	TARANTOOL_CONSOLE_SOCK=$TARANTOOL_CONSOLE_SOCK \
 	tarantool {{ .AppEntrypointPath }}
 `
 
@@ -419,15 +425,18 @@ RUN echo '{{ .TmpFilesConf }}' > /usr/lib/tmpfiles.d/{{ .Name }}.conf \
     && chmod 644 /usr/lib/tmpfiles.d/{{ .Name }}.conf
 
 USER tarantool:tarantool
-ENV TARANTOOL_INSTANCE_NAME=default
+ENV TARANTOOL_INSTANCE_NAME=default \
+	TARANTOOL_WORKDIR={{ .WorkDir }} \
+	TARANTOOL_PID_FILE={{ .PidFile }} \
+	TARANTOOL_CONSOLE_SOCK={{ .ConsoleSock }}
 
 ### Copy application code
 COPY . {{ .AppDir }}
 
 ### Runtime command
-CMD TARANTOOL_WORKDIR={{ .WorkDir }} \
-    TARANTOOL_PID_FILE={{ .PidFile }} \
-    TARANTOOL_CONSOLE_SOCK={{ .ConsoleSock }} \
+CMD TARANTOOL_WORKDIR=$TARANTOOL_WORKDIR \
+	TARANTOOL_PID_FILE=$TARANTOOL_PID_FILE \
+	TARANTOOL_CONSOLE_SOCK=$TARANTOOL_CONSOLE_SOCK \
 	tarantool {{ .AppEntrypointPath }}
 `
 
@@ -465,7 +474,7 @@ COPY . {{ .AppDir }}
 ### Runtime command
 CMD TARANTOOL_WORKDIR={{ .WorkDir }} \
     TARANTOOL_PID_FILE={{ .PidFile }} \
-    TARANTOOL_CONSOLE_SOCK={{ .ConsoleSock }} \
+	TARANTOOL_CONSOLE_SOCK={{ .ConsoleSock }} \
 	tarantool {{ .AppEntrypointPath }}
 `
 }

--- a/cli/project/dockerfiles_test.go
+++ b/cli/project/dockerfiles_test.go
@@ -321,10 +321,9 @@ RUN echo '{{ .TmpFilesConf }}' > /usr/lib/tmpfiles.d/{{ .Name }}.conf \
     && chmod 644 /usr/lib/tmpfiles.d/{{ .Name }}.conf
 
 USER tarantool:tarantool
+ENV CARTRIDGE_RUN_DIR=/var/run/tarantool
+ENV CARTRIDGE_DATA_DIR=/var/lib/tarantool
 ENV TARANTOOL_INSTANCE_NAME=default
-ENV TARANTOOL_WORKDIR={{ .WorkDir }}
-ENV TARANTOOL_PID_FILE={{ .PidFile }}
-ENV TARANTOOL_CONSOLE_SOCK={{ .ConsoleSock }}
 
 ### Copy application code
 COPY . {{ .AppDir }}
@@ -333,9 +332,9 @@ COPY . {{ .AppDir }}
 ENV PATH="{{ .AppDir }}:${PATH}"
 
 ### Runtime command
-CMD TARANTOOL_WORKDIR=$TARANTOOL_WORKDIR \
-	TARANTOOL_PID_FILE=$TARANTOOL_PID_FILE \
-	TARANTOOL_CONSOLE_SOCK=$TARANTOOL_CONSOLE_SOCK \
+CMD TARANTOOL_WORKDIR=${TARANTOOL_WORKDIR:-{{ .WorkDir}}} \
+	TARANTOOL_PID_FILE=${TARANTOOL_PID_FILE:-{{ .PidFile }}} \
+	TARANTOOL_CONSOLE_SOCK=${TARANTOOL_CONSOLE_SOCK:-{{ .ConsoleSock }}} \
 	tarantool {{ .AppEntrypointPath }}
 `
 
@@ -370,10 +369,9 @@ RUN echo '{{ .TmpFilesConf }}' > /usr/lib/tmpfiles.d/{{ .Name }}.conf \
     && chmod 644 /usr/lib/tmpfiles.d/{{ .Name }}.conf
 
 USER tarantool:tarantool
+ENV CARTRIDGE_RUN_DIR=/var/run/tarantool
+ENV CARTRIDGE_DATA_DIR=/var/lib/tarantool
 ENV TARANTOOL_INSTANCE_NAME=default
-ENV TARANTOOL_WORKDIR={{ .WorkDir }}
-ENV TARANTOOL_PID_FILE={{ .PidFile }}
-ENV TARANTOOL_CONSOLE_SOCK={{ .ConsoleSock }}
 
 ### Copy application code
 COPY . {{ .AppDir }}
@@ -382,9 +380,9 @@ COPY . {{ .AppDir }}
 ENV PATH="{{ .AppDir }}:${PATH}"
 
 ### Runtime command
-CMD TARANTOOL_WORKDIR=$TARANTOOL_WORKDIR \
-	TARANTOOL_PID_FILE=$TARANTOOL_PID_FILE \
-	TARANTOOL_CONSOLE_SOCK=$TARANTOOL_CONSOLE_SOCK \
+CMD TARANTOOL_WORKDIR=${TARANTOOL_WORKDIR:-{{ .WorkDir}}} \
+	TARANTOOL_PID_FILE=${TARANTOOL_PID_FILE:-{{ .PidFile }}} \
+	TARANTOOL_CONSOLE_SOCK=${TARANTOOL_CONSOLE_SOCK:-{{ .ConsoleSock }}} \
 	tarantool {{ .AppEntrypointPath }}
 `
 
@@ -425,18 +423,17 @@ RUN echo '{{ .TmpFilesConf }}' > /usr/lib/tmpfiles.d/{{ .Name }}.conf \
     && chmod 644 /usr/lib/tmpfiles.d/{{ .Name }}.conf
 
 USER tarantool:tarantool
+ENV CARTRIDGE_RUN_DIR=/var/run/tarantool
+ENV CARTRIDGE_DATA_DIR=/var/lib/tarantool
 ENV TARANTOOL_INSTANCE_NAME=default
-ENV TARANTOOL_WORKDIR={{ .WorkDir }}
-ENV TARANTOOL_PID_FILE={{ .PidFile }}
-ENV TARANTOOL_CONSOLE_SOCK={{ .ConsoleSock }}
 
 ### Copy application code
 COPY . {{ .AppDir }}
 
 ### Runtime command
-CMD TARANTOOL_WORKDIR=$TARANTOOL_WORKDIR \
-	TARANTOOL_PID_FILE=$TARANTOOL_PID_FILE \
-	TARANTOOL_CONSOLE_SOCK=$TARANTOOL_CONSOLE_SOCK \
+CMD TARANTOOL_WORKDIR=${TARANTOOL_WORKDIR:-{{ .WorkDir}}} \
+	TARANTOOL_PID_FILE=${TARANTOOL_PID_FILE:-{{ .PidFile }}} \
+	TARANTOOL_CONSOLE_SOCK=${TARANTOOL_CONSOLE_SOCK:-{{ .ConsoleSock }}} \
 	tarantool {{ .AppEntrypointPath }}
 `
 
@@ -466,15 +463,17 @@ RUN echo '{{ .TmpFilesConf }}' > /usr/lib/tmpfiles.d/{{ .Name }}.conf \
     && chmod 644 /usr/lib/tmpfiles.d/{{ .Name }}.conf
 
 USER tarantool:tarantool
+ENV CARTRIDGE_RUN_DIR=/var/run/tarantool
+ENV CARTRIDGE_DATA_DIR=/var/lib/tarantool
 ENV TARANTOOL_INSTANCE_NAME=default
 
 ### Copy application code
 COPY . {{ .AppDir }}
 
 ### Runtime command
-CMD TARANTOOL_WORKDIR={{ .WorkDir }} \
-	TARANTOOL_PID_FILE={{ .PidFile }} \
-	TARANTOOL_CONSOLE_SOCK={{ .ConsoleSock }} \
+CMD TARANTOOL_WORKDIR=${TARANTOOL_WORKDIR:-{{ .WorkDir}}} \
+	TARANTOOL_PID_FILE=${TARANTOOL_PID_FILE:-{{ .PidFile }}} \
+	TARANTOOL_CONSOLE_SOCK=${TARANTOOL_CONSOLE_SOCK:-{{ .ConsoleSock }}} \
 	tarantool {{ .AppEntrypointPath }}
 `
 }

--- a/cli/project/dockerfiles_test.go
+++ b/cli/project/dockerfiles_test.go
@@ -321,10 +321,10 @@ RUN echo '{{ .TmpFilesConf }}' > /usr/lib/tmpfiles.d/{{ .Name }}.conf \
     && chmod 644 /usr/lib/tmpfiles.d/{{ .Name }}.conf
 
 USER tarantool:tarantool
-ENV TARANTOOL_INSTANCE_NAME=default \
-	TARANTOOL_WORKDIR={{ .WorkDir }} \
-	TARANTOOL_PID_FILE={{ .PidFile }} \
-	TARANTOOL_CONSOLE_SOCK={{ .ConsoleSock }}
+ENV TARANTOOL_INSTANCE_NAME=default
+ENV TARANTOOL_WORKDIR={{ .WorkDir }}
+ENV TARANTOOL_PID_FILE={{ .PidFile }}
+ENV TARANTOOL_CONSOLE_SOCK={{ .ConsoleSock }}
 
 ### Copy application code
 COPY . {{ .AppDir }}
@@ -370,10 +370,10 @@ RUN echo '{{ .TmpFilesConf }}' > /usr/lib/tmpfiles.d/{{ .Name }}.conf \
     && chmod 644 /usr/lib/tmpfiles.d/{{ .Name }}.conf
 
 USER tarantool:tarantool
-ENV TARANTOOL_INSTANCE_NAME=default \
-	TARANTOOL_WORKDIR={{ .WorkDir }} \
-	TARANTOOL_PID_FILE={{ .PidFile }} \
-	TARANTOOL_CONSOLE_SOCK={{ .ConsoleSock }}
+ENV TARANTOOL_INSTANCE_NAME=default
+ENV TARANTOOL_WORKDIR={{ .WorkDir }}
+ENV TARANTOOL_PID_FILE={{ .PidFile }}
+ENV TARANTOOL_CONSOLE_SOCK={{ .ConsoleSock }}
 
 ### Copy application code
 COPY . {{ .AppDir }}
@@ -425,10 +425,10 @@ RUN echo '{{ .TmpFilesConf }}' > /usr/lib/tmpfiles.d/{{ .Name }}.conf \
     && chmod 644 /usr/lib/tmpfiles.d/{{ .Name }}.conf
 
 USER tarantool:tarantool
-ENV TARANTOOL_INSTANCE_NAME=default \
-	TARANTOOL_WORKDIR={{ .WorkDir }} \
-	TARANTOOL_PID_FILE={{ .PidFile }} \
-	TARANTOOL_CONSOLE_SOCK={{ .ConsoleSock }}
+ENV TARANTOOL_INSTANCE_NAME=default
+ENV TARANTOOL_WORKDIR={{ .WorkDir }}
+ENV TARANTOOL_PID_FILE={{ .PidFile }}
+ENV TARANTOOL_CONSOLE_SOCK={{ .ConsoleSock }}
 
 ### Copy application code
 COPY . {{ .AppDir }}

--- a/cli/project/dockerfiles_test.go
+++ b/cli/project/dockerfiles_test.go
@@ -332,7 +332,7 @@ COPY . {{ .AppDir }}
 ENV PATH="{{ .AppDir }}:${PATH}"
 
 ### Runtime command
-CMD TARANTOOL_WORKDIR=${TARANTOOL_WORKDIR:-{{ .WorkDir}}} \
+CMD TARANTOOL_WORKDIR=${TARANTOOL_WORKDIR:-{{ .WorkDir }}} \
 	TARANTOOL_PID_FILE=${TARANTOOL_PID_FILE:-{{ .PidFile }}} \
 	TARANTOOL_CONSOLE_SOCK=${TARANTOOL_CONSOLE_SOCK:-{{ .ConsoleSock }}} \
 	tarantool {{ .AppEntrypointPath }}
@@ -380,7 +380,7 @@ COPY . {{ .AppDir }}
 ENV PATH="{{ .AppDir }}:${PATH}"
 
 ### Runtime command
-CMD TARANTOOL_WORKDIR=${TARANTOOL_WORKDIR:-{{ .WorkDir}}} \
+CMD TARANTOOL_WORKDIR=${TARANTOOL_WORKDIR:-{{ .WorkDir }}} \
 	TARANTOOL_PID_FILE=${TARANTOOL_PID_FILE:-{{ .PidFile }}} \
 	TARANTOOL_CONSOLE_SOCK=${TARANTOOL_CONSOLE_SOCK:-{{ .ConsoleSock }}} \
 	tarantool {{ .AppEntrypointPath }}
@@ -431,7 +431,7 @@ ENV TARANTOOL_INSTANCE_NAME=default
 COPY . {{ .AppDir }}
 
 ### Runtime command
-CMD TARANTOOL_WORKDIR=${TARANTOOL_WORKDIR:-{{ .WorkDir}}} \
+CMD TARANTOOL_WORKDIR=${TARANTOOL_WORKDIR:-{{ .WorkDir }}} \
 	TARANTOOL_PID_FILE=${TARANTOOL_PID_FILE:-{{ .PidFile }}} \
 	TARANTOOL_CONSOLE_SOCK=${TARANTOOL_CONSOLE_SOCK:-{{ .ConsoleSock }}} \
 	tarantool {{ .AppEntrypointPath }}
@@ -471,7 +471,7 @@ ENV TARANTOOL_INSTANCE_NAME=default
 COPY . {{ .AppDir }}
 
 ### Runtime command
-CMD TARANTOOL_WORKDIR=${TARANTOOL_WORKDIR:-{{ .WorkDir}}} \
+CMD TARANTOOL_WORKDIR=${TARANTOOL_WORKDIR:-{{ .WorkDir }}} \
 	TARANTOOL_PID_FILE=${TARANTOOL_PID_FILE:-{{ .PidFile }}} \
 	TARANTOOL_CONSOLE_SOCK=${TARANTOOL_CONSOLE_SOCK:-{{ .ConsoleSock }}} \
 	tarantool {{ .AppEntrypointPath }}

--- a/cli/project/dockerfiles_test.go
+++ b/cli/project/dockerfiles_test.go
@@ -473,7 +473,7 @@ COPY . {{ .AppDir }}
 
 ### Runtime command
 CMD TARANTOOL_WORKDIR={{ .WorkDir }} \
-    TARANTOOL_PID_FILE={{ .PidFile }} \
+	TARANTOOL_PID_FILE={{ .PidFile }} \
 	TARANTOOL_CONSOLE_SOCK={{ .ConsoleSock }} \
 	tarantool {{ .AppEntrypointPath }}
 `

--- a/test/e2e/test_docker.py
+++ b/test/e2e/test_docker.py
@@ -13,7 +13,7 @@ def docker_image_with_cartridge(cartridge_cmd, tmpdir, project_with_cartridge, r
     project = project_with_cartridge
 
     cmd = [cartridge_cmd, "pack", "docker", project.path]
-    process = subprocess.run(cmd, cwd=tmpdir, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    process = subprocess.run(cmd, cwd=tmpdir)
     assert process.returncode == 0, \
         "Error during creating of docker image"
 

--- a/test/e2e/test_docker.py
+++ b/test/e2e/test_docker.py
@@ -65,7 +65,7 @@ def test_docker(docker_image_with_cartridge, tmpdir, docker_client, request):
     container.stop()
 
 
-def test_custom_directories_docker(docker_image_with_cartridge, tmpdir, docker_client, request):
+def test_custom_directories(docker_image_with_cartridge, tmpdir, docker_client, request):
     image_name = docker_image_with_cartridge.name
     project = docker_image_with_cartridge.project
 

--- a/test/files/init_print_environment.lua
+++ b/test/files/init_print_environment.lua
@@ -1,0 +1,7 @@
+require('strict').on()
+
+local log = require('log')
+
+log.info(os.getenv('TARANTOOL_CONSOLE_SOCK'))
+log.info(os.getenv('TARANTOOL_WORKDIR'))
+log.info(os.getenv('TARANTOOL_PID_FILE'))

--- a/test/integration/pack/test_pack_docker.py
+++ b/test/integration/pack/test_pack_docker.py
@@ -236,7 +236,6 @@ def test_image_tag_without_git(cartridge_cmd, project_without_dependencies, tmpd
 
 def test_customized_environment_variables(docker_image_print_environment, docker_client, request, tmpdir):
     project = docker_image_print_environment.project
-    # image_name = docker_image_print_environment.name
 
     instance_name = 'instance-1'
     http_port = '8182'
@@ -275,7 +274,6 @@ def test_customized_environment_variables(docker_image_print_environment, docker
 
 def test_customized_data_and_run_dir(docker_image_print_environment, docker_client, request, tmpdir):
     project = docker_image_print_environment.project
-    # image_name = docker_image_print_environment.name
 
     instance_name = 'instance-1'
     http_port = '8182'

--- a/test/integration/pack/test_pack_docker.py
+++ b/test/integration/pack/test_pack_docker.py
@@ -258,7 +258,6 @@ def test_customized_environment_variables(cartridge_cmd, project_without_depende
 
     wait_for_container_start(container, time.time(), message=container_message)
     container.stop()
-    container.remove()
 
     # Custom CARTRIDGE_RUN_DIR and CARTRIDGE_DATA_DIR
     run_dir = "/var/lib/tarantool/custom_run"
@@ -273,21 +272,21 @@ def test_customized_environment_variables(cartridge_cmd, project_without_depende
         f"CARTRIDGE_RUN_DIR={run_dir}"
     ]
 
-    container = docker_client.containers.run(
+    new_container = docker_client.containers.run(
         project.name,
         environment=environment,
         ports={http_port: http_port},
-        name='{}-{}'.format(project.name, instance_name),
+        name='new-{}-{}'.format(project.name, instance_name),
         detach=True,
     )
 
-    request.addfinalizer(lambda: container.remove(force=True))
-    assert container.status == 'created'
+    request.addfinalizer(lambda: new_container.remove(force=True))
+    assert new_container.status == 'created'
 
     console_sock_path = f"{run_dir}/{project.name}.{instance_name}.control"
     pidfile_path = f"{run_dir}/{project.name}.{instance_name}.pid"
     work_dir_path = f"{data_dir}/{project.name}.{instance_name}"
     container_message = f"{console_sock_path}\n{work_dir_path}\n{pidfile_path}\n"
 
-    wait_for_container_start(container, time.time(), message=container_message)
-    container.stop()
+    wait_for_container_start(new_container, time.time(), message=container_message)
+    new_container.stop()

--- a/test/integration/pack/test_pack_docker.py
+++ b/test/integration/pack/test_pack_docker.py
@@ -151,7 +151,6 @@ def test_pack(docker_image, tmpdir, docker_client):
 
 
 def test_custom_base_runtime_dockerfile(cartridge_cmd, project_without_dependencies, module_tmpdir, tmpdir):
-    return
     custom_base_dockerfile_path = os.path.join(tmpdir, 'Dockerfile')
     with open(custom_base_dockerfile_path, 'w') as f:
         f.write('''

--- a/test/integration/pack/test_pack_docker.py
+++ b/test/integration/pack/test_pack_docker.py
@@ -228,7 +228,8 @@ def test_customized_environment_variables(cartridge_cmd, project_without_depende
     http_port = '8182'
     advertise_port = '3302'
 
-    workdir = "test_workdir"
+    # Custom TARANTOOL_WORKDIR, TARANTOOL_PID_FILE and TARANTOOL_CONSOLE_SOCK
+    work_dir = "test_workdir"
     pidfile = "test_pidfile"
     console_sock = "test_console_sock"
 
@@ -237,7 +238,7 @@ def test_customized_environment_variables(cartridge_cmd, project_without_depende
         f"TARANTOOL_INSTANCE_NAME={instance_name}",
         f"TARANTOOL_ADVERTISE_URI={advertise_port}",
         f"TARANTOOL_HTTP_PORT={http_port}",
-        f"TARANTOOL_WORKDIR={workdir}",
+        f"TARANTOOL_WORKDIR={work_dir}",
         f"TARANTOOL_PID_FILE={pidfile}",
         f"TARANTOOL_CONSOLE_SOCK={console_sock}",
     ]
@@ -253,7 +254,40 @@ def test_customized_environment_variables(cartridge_cmd, project_without_depende
     request.addfinalizer(lambda: container.remove(force=True))
 
     assert container.status == 'created'
-    container_message = f"{console_sock}\n{workdir}\n{pidfile}\n"
+    container_message = f"{console_sock}\n{work_dir}\n{pidfile}\n"
 
-    wait_for_container_start(container, container_message, time.time())
+    wait_for_container_start(container, time.time(), message=container_message)
+    container.stop()
+    container.remove()
+
+    # Custom CARTRIDGE_RUN_DIR and CARTRIDGE_DATA_DIR
+    run_dir = "/var/lib/tarantool/custom_run"
+    data_dir = "/var/lib/tarantool/custom_data"
+
+    environment = [
+        f"TARANTOOL_APP_NAME={project.name}",
+        f"TARANTOOL_INSTANCE_NAME={instance_name}",
+        f"TARANTOOL_ADVERTISE_URI={advertise_port}",
+        f"TARANTOOL_HTTP_PORT={http_port}",
+        f"CARTRIDGE_DATA_DIR={data_dir}",
+        f"CARTRIDGE_RUN_DIR={run_dir}"
+    ]
+
+    container = docker_client.containers.run(
+        project.name,
+        environment=environment,
+        ports={http_port: http_port},
+        name='{}-{}'.format(project.name, instance_name),
+        detach=True,
+    )
+
+    request.addfinalizer(lambda: container.remove(force=True))
+    assert container.status == 'created'
+
+    console_sock_path = f"{run_dir}/{project.name}.{instance_name}.control"
+    pidfile_path = f"{run_dir}/{project.name}.{instance_name}.pid"
+    work_dir_path = f"{data_dir}/{project.name}.{instance_name}"
+    container_message = f"{console_sock_path}\n{work_dir_path}\n{pidfile_path}\n"
+
+    wait_for_container_start(container, time.time(), message=container_message)
     container.stop()

--- a/test/integration/pack/test_pack_docker.py
+++ b/test/integration/pack/test_pack_docker.py
@@ -229,7 +229,7 @@ def test_customized_environment_variables(cartridge_cmd, project_without_depende
     advertise_port = '3302'
 
     # Custom TARANTOOL_WORKDIR, TARANTOOL_PID_FILE and TARANTOOL_CONSOLE_SOCK
-    work_dir = "test_workdir"
+    workdir = "test_workdir"
     pidfile = "test_pidfile"
     console_sock = "test_console_sock"
 
@@ -238,7 +238,7 @@ def test_customized_environment_variables(cartridge_cmd, project_without_depende
         f"TARANTOOL_INSTANCE_NAME={instance_name}",
         f"TARANTOOL_ADVERTISE_URI={advertise_port}",
         f"TARANTOOL_HTTP_PORT={http_port}",
-        f"TARANTOOL_WORKDIR={work_dir}",
+        f"TARANTOOL_WORKDIR={workdir}",
         f"TARANTOOL_PID_FILE={pidfile}",
         f"TARANTOOL_CONSOLE_SOCK={console_sock}",
     ]
@@ -254,7 +254,7 @@ def test_customized_environment_variables(cartridge_cmd, project_without_depende
     request.addfinalizer(lambda: container.remove(force=True))
 
     assert container.status == 'created'
-    container_message = f"{console_sock}\n{work_dir}\n{pidfile}\n"
+    container_message = f"{console_sock}\n{workdir}\n{pidfile}\n"
 
     wait_for_container_start(container, time.time(), message=container_message)
     container.stop()
@@ -285,8 +285,8 @@ def test_customized_environment_variables(cartridge_cmd, project_without_depende
 
     console_sock_path = f"{run_dir}/{project.name}.{instance_name}.control"
     pidfile_path = f"{run_dir}/{project.name}.{instance_name}.pid"
-    work_dir_path = f"{data_dir}/{project.name}.{instance_name}"
-    container_message = f"{console_sock_path}\n{work_dir_path}\n{pidfile_path}\n"
+    workdir_path = f"{data_dir}/{project.name}.{instance_name}"
+    container_message = f"{console_sock_path}\n{workdir_path}\n{pidfile_path}\n"
 
     wait_for_container_start(new_container, time.time(), message=container_message)
     new_container.stop()

--- a/test/project.py
+++ b/test/project.py
@@ -12,6 +12,7 @@ FILES_DIR = 'test/files'
 INIT_NO_CARTRIDGE_FILEPATH = os.path.join(FILES_DIR, 'init_no_cartridge.lua')
 INIT_IGNORE_SIGTERM_FILEPATH = os.path.join(FILES_DIR, 'init_ignore_sigterm.lua')
 INIT_ADMIN_FUNCS_FILEPATH = os.path.join(FILES_DIR, 'init_admin_funcs.lua')
+INIT_PRINT_ENV_FILEPATH = os.path.join(FILES_DIR, 'init_print_environment.lua')
 
 CLI_CONF = '.cartridge.yml'
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -970,15 +970,14 @@ def is_instance_expelled(admin_api_url, instance_name):
 
 
 @tenacity.retry(stop=tenacity.stop_after_delay(15), wait=tenacity.wait_fixed(1))
-def wait_for_container_start(container, container_message, time_start):
+def wait_for_container_start(container, time_start, message='entering the event loop'):
     container_logs = container.logs(since=int(time_start)).decode('utf-8')
-    assert container_message in container_logs
+    assert message in container_logs
 
 
 def examine_application_instance_container(instance_container):
     container = instance_container.container
-    container_message = 'entering the event loop'
-    wait_for_container_start(container, container_message, time.time())
+    wait_for_container_start(container, time.time())
 
     container_logs = container.logs().decode('utf-8')
     m = re.search(r'Auto-detected IP to be "(\d+\.\d+\.\d+\.\d+)', container_logs)
@@ -994,7 +993,7 @@ def examine_application_instance_container(instance_container):
 
     # restart instance
     container.restart()
-    wait_for_container_start(container, container_message, time.time())
+    wait_for_container_start(container, time.time())
 
     # check instance restarted
     wait_for_replicaset_is_healthy(admin_api_url, replicaset_uuid)

--- a/test/utils.py
+++ b/test/utils.py
@@ -970,14 +970,15 @@ def is_instance_expelled(admin_api_url, instance_name):
 
 
 @tenacity.retry(stop=tenacity.stop_after_delay(15), wait=tenacity.wait_fixed(1))
-def wait_for_container_start(container, time_start):
+def wait_for_container_start(container, container_message, time_start):
     container_logs = container.logs(since=int(time_start)).decode('utf-8')
-    assert 'entering the event loop' in container_logs
+    assert container_message in container_logs
 
 
 def examine_application_instance_container(instance_container):
     container = instance_container.container
-    wait_for_container_start(container, time.time())
+    container_message = 'entering the event loop'
+    wait_for_container_start(container, container_message, time.time())
 
     container_logs = container.logs().decode('utf-8')
     m = re.search(r'Auto-detected IP to be "(\d+\.\d+\.\d+\.\d+)', container_logs)
@@ -993,7 +994,7 @@ def examine_application_instance_container(instance_container):
 
     # restart instance
     container.restart()
-    wait_for_container_start(container, time.time())
+    wait_for_container_start(container, container_message, time.time())
 
     # check instance restarted
     wait_for_replicaset_is_healthy(admin_api_url, replicaset_uuid)


### PR DESCRIPTION
Variables ``TARANTOOL_WORKDIR``, ``TARANTOOL_PID_FILE`` and ``TARANTOOL_CONSOLE_SOCK`` can be customized when packing in docker via ``cartridge pack`` command. Variables ``CARTRIDGE_RUN_DIR`` and ``CARTRIDGE_DATA_DIR`` have also been added. Closes #466 
