### PR TITLE
Bump Homebrew formula using GutHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,3 +112,13 @@ jobs:
           S3_BUCKET: ${{ secrets.S3_BUCKET }}
           S3_FOLDER: ${{ steps.set-s3-folder.outputs.S3_FOLDER }}
         run: mage publishS3
+
+  update-brew-formula:
+    name: Bump Homebrew formula
+    runs-on: macos-latest
+    steps:
+      - name: Homebrew bump formula
+        uses: dawidd6/action-homebrew-bump-formula@v3.7.1
+        with:
+          formula: cartridge-cli
+          token: ${{ secrets.BUMP_HOMEBREW_FORMULA_TOKEN }}


### PR DESCRIPTION
Updating Homebrew formula for Cartridge CLI was performed manually
on each release. Of course, sometimes we forgot to do this. But future 
is here - now we use GitHub Action dawidd6/action-homebrew-bump-formula
[1] to create formula update PR for new tags.

[1]: https://github.com/marketplace/actions/homebrew-bump-formula