### PR TITLE
Added Ctrl-C behaviour in console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Fixed
+
+- Added interruption of an incomplete expression when pressing ``Ctrl-C`` in ``cartridge enter`` command.
+
 ## [2.7.0] - 2021-03-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Fixed
 
-- Added interruption of an incomplete expression when pressing ``Ctrl-C`` in ``cartridge enter`` command.
+- Added interruption of an incomplete expression when pressing
+  ``Ctrl-C`` in ``cartridge enter`` command.
 
 ## [2.7.0] - 2021-03-11
 

--- a/cli/connect/console.go
+++ b/cli/connect/console.go
@@ -341,6 +341,15 @@ func getPromptOptions(console *Console) []prompt.Option {
 				},
 			},
 		),
+
+		prompt.OptionAddKeyBind(
+			prompt.KeyBind{ // Interrupt current unfinished expression
+				Key: prompt.ControlC,
+				Fn: func(buf *prompt.Buffer) {
+					fmt.Println("^C")
+				},
+			},
+		),
 	}
 
 	return options

--- a/cli/connect/console.go
+++ b/cli/connect/console.go
@@ -346,6 +346,8 @@ func getPromptOptions(console *Console) []prompt.Option {
 			prompt.KeyBind{ // Interrupt current unfinished expression
 				Key: prompt.ControlC,
 				Fn: func(buf *prompt.Buffer) {
+					console.input = ""
+					console.livePrefixEnabled = false
 					fmt.Println("^C")
 				},
 			},


### PR DESCRIPTION
Added cancellation of unfinished expression in ```cartridge enter``` console when pressing ```Ctrl - C```. Closes #473 
