### PR TITLE
USER instruction in Dockerfile uses UID and GID numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+<<<<<<< HEAD
 ## [2.7.2] - 2021-03-24
 
 ### Changed
@@ -16,6 +17,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Updated `cartridge-cli-extensions` to `1.1.1` in application template
 
 ## Added
+=======
+### Fixed
+
+- It is possible to run an image generated with the ``cartridge pack docker``
+  command in an unprivileged Kubernetes container. It became possible, because
+  tarantool user now always has ``UID = 1200`` and ``GID = 1200``.
+
+### Added
+>>>>>>> b91e15e (Changelog)
 
 - Variables ``TARANTOOL_WORKDIR``, ``TARANTOOL_PID_FILE`` and
   ``TARANTOOL_CONSOLE_SOCK`` can be customized when packing in docker via
@@ -28,7 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Updated `cartridge` to `2.5.0` in application template
 
-## Fixed
+### Fixed
 
 - Added interruption of an incomplete expression when pressing
   ``Ctrl-C`` in ``cartridge enter`` command.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-<<<<<<< HEAD
+### Fixed
+
+- It is possible to run an image generated with the ``cartridge pack docker``
+  command in an unprivileged Kubernetes container. It became possible, because
+  tarantool user now always has ``UID = 1200`` and ``GID = 1200``.
+
 ## [2.7.2] - 2021-03-24
 
 ### Changed
@@ -16,16 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Updated `metrics` to `0.7.1` in application template
 - Updated `cartridge-cli-extensions` to `1.1.1` in application template
 
-## Added
-=======
-### Fixed
-
-- It is possible to run an image generated with the ``cartridge pack docker``
-  command in an unprivileged Kubernetes container. It became possible, because
-  tarantool user now always has ``UID = 1200`` and ``GID = 1200``.
-
 ### Added
->>>>>>> b91e15e (Changelog)
 
 - Variables ``TARANTOOL_WORKDIR``, ``TARANTOOL_PID_FILE`` and
   ``TARANTOOL_CONSOLE_SOCK`` can be customized when packing in docker via

--- a/cli/pack/docker.go
+++ b/cli/pack/docker.go
@@ -12,6 +12,9 @@ import (
 	"github.com/tarantool/cartridge-cli/cli/project"
 )
 
+// We have to set constant UID and GID for Tarantool
+// user (see cli/project/dockerfiles.go for details).
+// The number 1200 was chosen at random.
 const (
 	tarantoolUID = 1200
 	tarantoolGID = 1200

--- a/cli/pack/docker.go
+++ b/cli/pack/docker.go
@@ -12,6 +12,11 @@ import (
 	"github.com/tarantool/cartridge-cli/cli/project"
 )
 
+const (
+	tarantoolUID = 1200
+	tarantoolGID = 1200
+)
+
 func packDocker(ctx *context.Ctx) error {
 	if err := docker.CheckMinServerVersion(); err != nil {
 		return err
@@ -36,6 +41,8 @@ func packDocker(ctx *context.Ctx) error {
 		"Name":              ctx.Project.Name,
 		"TmpFilesConf":      tmpFilesConfContent,
 		"AppDir":            ctx.Running.AppDir,
+		"TarantoolUID":      tarantoolUID,
+		"TarantoolGID":      tarantoolGID,
 		"AppEntrypointPath": project.GetAppEntrypointPath(ctx),
 		"WorkDir":           project.GetInstanceWorkDir(ctx, "${TARANTOOL_INSTANCE_NAME}"),
 		"PidFile":           project.GetInstancePidFile(ctx, "${TARANTOOL_INSTANCE_NAME}"),

--- a/cli/project/dockerfiles.go
+++ b/cli/project/dockerfiles.go
@@ -209,7 +209,7 @@ RUN groupadd -r tarantool \
 RUN echo '{{ .TmpFilesConf }}' > /usr/lib/tmpfiles.d/{{ .Name }}.conf \
     && chmod 644 /usr/lib/tmpfiles.d/{{ .Name }}.conf
 
-USER tarantool:tarantool
+USER $UID:$GID
 ENV CARTRIDGE_RUN_DIR=/var/run/tarantool
 ENV CARTRIDGE_DATA_DIR=/var/lib/tarantool
 ENV TARANTOOL_INSTANCE_NAME=default

--- a/cli/project/dockerfiles.go
+++ b/cli/project/dockerfiles.go
@@ -187,8 +187,7 @@ const (
 
 	containerSDKPath = "/usr/share/tarantool/sdk"
 
-	defaultBaseLayers = "FROM centos:7\n"
-
+	defaultBaseLayers          = "FROM centos:7\n"
 	installBuildPackagesLayers = `### Install packages required for build
 RUN yum install -y git-core gcc gcc-c++ make cmake unzip
 `

--- a/cli/project/dockerfiles.go
+++ b/cli/project/dockerfiles.go
@@ -199,7 +199,7 @@ RUN yum install -y git-core gcc gcc-c++ make cmake unzip
 RUN groupadd -r tarantool \
     && useradd -M -N -l -g tarantool -r -d /var/lib/tarantool -s /sbin/nologin \
         -c "Tarantool Server" tarantool \
-    && mkdir -p /var/lib/tarantool/ --mode 755 \
+    &&  mkdir -p /var/lib/tarantool/ --mode 755 \
     && chown tarantool:tarantool /var/lib/tarantool \
     && mkdir -p /var/run/tarantool/ --mode 755 \
 	&& chown tarantool:tarantool /var/run/tarantool
@@ -245,10 +245,9 @@ RUN if id -u {{ .UserID }} 2>/dev/null; then \
         USERNAME=cartridge; \
         useradd -l -u {{ .UserID }} ${USERNAME}; \
     fi \
-    && (usermod -a -G sudo ${USERNAME} 2>/dev/null || :) \
-    && (usermod -a -G wheel ${USERNAME} 2>/dev/null || :) \
+	&& (usermod -a -G sudo ${USERNAME} 2>/dev/null || :) \
+	&& (usermod -a -G wheel ${USERNAME} 2>/dev/null || :) \
 	&& (usermod -a -G adm ${USERNAME} 2>/dev/null || :)
-
 USER {{ .UserID }}
 `
 

--- a/cli/project/dockerfiles.go
+++ b/cli/project/dockerfiles.go
@@ -192,6 +192,12 @@ const (
 	installBuildPackagesLayers = `### Install packages required for build
 RUN yum install -y git-core gcc gcc-c++ make cmake unzip
 `
+	// We have to set USER instruction in the form of <UID:GID>
+	// (see https://github.com/tarantool/cartridge-cli/issues/481).
+	// Since we cannot find out the already set UID and GID for the tarantool
+	// user using command shell (see https://github.com/moby/moby/issues/29110),
+	// we recreate the user and the tarantool group with a constant UID and GID value.
+
 	createTarantoolUser = `RUN groupadd -r -g {{ .TarantoolGID }} tarantool \
 	&& useradd -M -N -l -u {{ .TarantoolUID }} -g tarantool -r -d /var/lib/tarantool -s /sbin/nologin \
 	 -c "Tarantool Server" tarantool

--- a/cli/project/dockerfiles_test.go
+++ b/cli/project/dockerfiles_test.go
@@ -308,8 +308,8 @@ func TestGetRuntimeImageDockerfileTemplateEnterprise(t *testing.T) {
 	expLayers = `FROM centos:7
 
 ### Create Tarantool user and directories
-RUN groupadd -r tarantool \
-    && useradd -M -N -l -g tarantool -r -d /var/lib/tarantool -s /sbin/nologin \
+RUN groupadd -r -g {{ .TarantoolGID }} tarantool \
+    && useradd -M -N -l -u {{ .TarantoolUID }} -g tarantool -r -d /var/lib/tarantool -s /sbin/nologin \
         -c "Tarantool Server" tarantool \
     &&  mkdir -p /var/lib/tarantool/ --mode 755 \
     && chown tarantool:tarantool /var/lib/tarantool \
@@ -320,18 +320,7 @@ RUN groupadd -r tarantool \
 RUN echo '{{ .TmpFilesConf }}' > /usr/lib/tmpfiles.d/{{ .Name }}.conf \
 	&& chmod 644 /usr/lib/tmpfiles.d/{{ .Name }}.conf
 
-ARG TARANTOOL_UID=888
-ARG TARANTOOL_GID=888
-
-RUN usermod -u ${TARANTOOL_UID} tarantool \
-	&& groupmod -g ${TARANTOOL_GID} tarantool
-
-RUN find / -user ${TARANTOOL_UID} -xdev -exec chgrp -h tarantool {} \; \
-	&& find / -group ${TARANTOOL_GID} -xdev -exec chown -h tarantool {} \; \
-	&& chown ${TARANTOOL_UID}:${TARANTOOL_GID} /var/run/tarantool \
-	&& chown ${TARANTOOL_UID}:${TARANTOOL_GID} /var/lib/tarantool
-
-USER ${TARANTOOL_UID}:${TARANTOOL_GID}
+USER {{ .TarantoolUID }}:{{ .TarantoolGID }}
 
 ENV CARTRIDGE_RUN_DIR=/var/run/tarantool
 ENV CARTRIDGE_DATA_DIR=/var/lib/tarantool
@@ -369,8 +358,8 @@ RUN yum install -y zip
 RUN yum install -y zip
 
 ### Create Tarantool user and directories
-RUN groupadd -r tarantool \
-    && useradd -M -N -l -g tarantool -r -d /var/lib/tarantool -s /sbin/nologin \
+RUN groupadd -r -g {{ .TarantoolGID }} tarantool \
+    && useradd -M -N -l -u {{ .TarantoolUID }} -g tarantool -r -d /var/lib/tarantool -s /sbin/nologin \
         -c "Tarantool Server" tarantool \
     &&  mkdir -p /var/lib/tarantool/ --mode 755 \
     && chown tarantool:tarantool /var/lib/tarantool \
@@ -381,18 +370,7 @@ RUN groupadd -r tarantool \
 RUN echo '{{ .TmpFilesConf }}' > /usr/lib/tmpfiles.d/{{ .Name }}.conf \
 	&& chmod 644 /usr/lib/tmpfiles.d/{{ .Name }}.conf
 
-ARG TARANTOOL_UID=888
-ARG TARANTOOL_GID=888
-
-RUN usermod -u ${TARANTOOL_UID} tarantool \
-	&& groupmod -g ${TARANTOOL_GID} tarantool
-
-RUN find / -user ${TARANTOOL_UID} -xdev -exec chgrp -h tarantool {} \; \
-	&& find / -group ${TARANTOOL_GID} -xdev -exec chown -h tarantool {} \; \
-	&& chown ${TARANTOOL_UID}:${TARANTOOL_GID} /var/run/tarantool \
-	&& chown ${TARANTOOL_UID}:${TARANTOOL_GID} /var/lib/tarantool
-
-USER ${TARANTOOL_UID}:${TARANTOOL_GID}
+USER {{ .TarantoolUID }}:{{ .TarantoolGID }}
 
 ENV CARTRIDGE_RUN_DIR=/var/run/tarantool
 ENV CARTRIDGE_DATA_DIR=/var/lib/tarantool
@@ -440,6 +418,10 @@ func TestGetRuntimeImageDockerfileTemplateOpensource(t *testing.T) {
 
 	expLayers = `FROM centos:7
 
+RUN groupadd -r -g {{ .TarantoolGID }} tarantool \
+	&& useradd -M -N -l -u {{ .TarantoolUID }} -g tarantool -r -d /var/lib/tarantool -s /sbin/nologin \
+	 -c "Tarantool Server" tarantool
+
 ### Install opensource Tarantool
 RUN curl -L https://tarantool.io/installer.sh | VER=1.10 bash \
     && yum -y install tarantool-devel
@@ -448,18 +430,7 @@ RUN curl -L https://tarantool.io/installer.sh | VER=1.10 bash \
 RUN echo '{{ .TmpFilesConf }}' > /usr/lib/tmpfiles.d/{{ .Name }}.conf \
 	&& chmod 644 /usr/lib/tmpfiles.d/{{ .Name }}.conf
 
-ARG TARANTOOL_UID=888
-ARG TARANTOOL_GID=888
-
-RUN usermod -u ${TARANTOOL_UID} tarantool \
-	&& groupmod -g ${TARANTOOL_GID} tarantool
-
-RUN find / -user ${TARANTOOL_UID} -xdev -exec chgrp -h tarantool {} \; \
-	&& find / -group ${TARANTOOL_GID} -xdev -exec chown -h tarantool {} \; \
-	&& chown ${TARANTOOL_UID}:${TARANTOOL_GID} /var/run/tarantool \
-	&& chown ${TARANTOOL_UID}:${TARANTOOL_GID} /var/lib/tarantool
-
-USER ${TARANTOOL_UID}:${TARANTOOL_GID}
+USER {{ .TarantoolUID }}:{{ .TarantoolGID }}
 
 ENV CARTRIDGE_RUN_DIR=/var/run/tarantool
 ENV CARTRIDGE_DATA_DIR=/var/lib/tarantool
@@ -501,18 +472,7 @@ RUN curl -L https://tarantool.io/installer.sh | VER=1.10 bash \
 RUN echo '{{ .TmpFilesConf }}' > /usr/lib/tmpfiles.d/{{ .Name }}.conf \
     && chmod 644 /usr/lib/tmpfiles.d/{{ .Name }}.conf
 
-ARG TARANTOOL_UID=888
-ARG TARANTOOL_GID=888
-
-RUN usermod -u ${TARANTOOL_UID} tarantool \
-	&& groupmod -g ${TARANTOOL_GID} tarantool
-
-RUN find / -user ${TARANTOOL_UID} -xdev -exec chgrp -h tarantool {} \; \
-	&& find / -group ${TARANTOOL_GID} -xdev -exec chown -h tarantool {} \; \
-	&& chown ${TARANTOOL_UID}:${TARANTOOL_GID} /var/run/tarantool \
-	&& chown ${TARANTOOL_UID}:${TARANTOOL_GID} /var/lib/tarantool
-
-USER ${TARANTOOL_UID}:${TARANTOOL_GID}
+USER {{ .TarantoolUID }}:{{ .TarantoolGID }}
 
 ENV CARTRIDGE_RUN_DIR=/var/run/tarantool
 ENV CARTRIDGE_DATA_DIR=/var/lib/tarantool

--- a/cli/project/dockerfiles_test.go
+++ b/cli/project/dockerfiles_test.go
@@ -153,9 +153,9 @@ RUN if id -u {{ .UserID }} 2>/dev/null; then \
         USERNAME=cartridge; \
         useradd -l -u {{ .UserID }} ${USERNAME}; \
     fi \
-    && (usermod -a -G sudo ${USERNAME} 2>/dev/null || :) \
-    && (usermod -a -G wheel ${USERNAME} 2>/dev/null || :) \
-    && (usermod -a -G adm ${USERNAME} 2>/dev/null || :)
+	&& (usermod -a -G sudo ${USERNAME} 2>/dev/null || :) \
+	&& (usermod -a -G wheel ${USERNAME} 2>/dev/null || :) \
+	&& (usermod -a -G adm ${USERNAME} 2>/dev/null || :)
 USER {{ .UserID }}
 `
 
@@ -190,9 +190,9 @@ RUN if id -u {{ .UserID }} 2>/dev/null; then \
         USERNAME=cartridge; \
         useradd -l -u {{ .UserID }} ${USERNAME}; \
     fi \
-    && (usermod -a -G sudo ${USERNAME} 2>/dev/null || :) \
-    && (usermod -a -G wheel ${USERNAME} 2>/dev/null || :) \
-    && (usermod -a -G adm ${USERNAME} 2>/dev/null || :)
+	&& (usermod -a -G sudo ${USERNAME} 2>/dev/null || :) \
+	&& (usermod -a -G wheel ${USERNAME} 2>/dev/null || :) \
+	&& (usermod -a -G adm ${USERNAME} 2>/dev/null || :)
 USER {{ .UserID }}
 `
 
@@ -237,9 +237,9 @@ RUN if id -u {{ .UserID }} 2>/dev/null; then \
         USERNAME=cartridge; \
         useradd -l -u {{ .UserID }} ${USERNAME}; \
     fi \
-    && (usermod -a -G sudo ${USERNAME} 2>/dev/null || :) \
-    && (usermod -a -G wheel ${USERNAME} 2>/dev/null || :) \
-    && (usermod -a -G adm ${USERNAME} 2>/dev/null || :)
+	&& (usermod -a -G sudo ${USERNAME} 2>/dev/null || :) \
+	&& (usermod -a -G wheel ${USERNAME} 2>/dev/null || :) \
+	&& (usermod -a -G adm ${USERNAME} 2>/dev/null || :)
 USER {{ .UserID }}
 `
 
@@ -274,9 +274,9 @@ RUN if id -u {{ .UserID }} 2>/dev/null; then \
         USERNAME=cartridge; \
         useradd -l -u {{ .UserID }} ${USERNAME}; \
     fi \
-    && (usermod -a -G sudo ${USERNAME} 2>/dev/null || :) \
-    && (usermod -a -G wheel ${USERNAME} 2>/dev/null || :) \
-    && (usermod -a -G adm ${USERNAME} 2>/dev/null || :)
+	&& (usermod -a -G sudo ${USERNAME} 2>/dev/null || :) \
+	&& (usermod -a -G wheel ${USERNAME} 2>/dev/null || :) \
+	&& (usermod -a -G adm ${USERNAME} 2>/dev/null || :)
 USER {{ .UserID }}
 `
 
@@ -318,9 +318,21 @@ RUN groupadd -r tarantool \
 
 ### Prepare for runtime
 RUN echo '{{ .TmpFilesConf }}' > /usr/lib/tmpfiles.d/{{ .Name }}.conf \
-    && chmod 644 /usr/lib/tmpfiles.d/{{ .Name }}.conf
+	&& chmod 644 /usr/lib/tmpfiles.d/{{ .Name }}.conf
 
-USER tarantool:tarantool
+ARG TARANTOOL_UID=888
+ARG TARANTOOL_GID=888
+
+RUN usermod -u ${TARANTOOL_UID} tarantool \
+	&& groupmod -g ${TARANTOOL_GID} tarantool
+
+RUN find / -user ${TARANTOOL_UID} -xdev -exec chgrp -h tarantool {} \; \
+	&& find / -group ${TARANTOOL_GID} -xdev -exec chown -h tarantool {} \; \
+	&& chown ${TARANTOOL_UID}:${TARANTOOL_GID} /var/run/tarantool \
+	&& chown ${TARANTOOL_UID}:${TARANTOOL_GID} /var/lib/tarantool
+
+USER ${TARANTOOL_UID}:${TARANTOOL_GID}
+
 ENV CARTRIDGE_RUN_DIR=/var/run/tarantool
 ENV CARTRIDGE_DATA_DIR=/var/lib/tarantool
 ENV TARANTOOL_INSTANCE_NAME=default
@@ -367,9 +379,21 @@ RUN groupadd -r tarantool \
 
 ### Prepare for runtime
 RUN echo '{{ .TmpFilesConf }}' > /usr/lib/tmpfiles.d/{{ .Name }}.conf \
-    && chmod 644 /usr/lib/tmpfiles.d/{{ .Name }}.conf
+	&& chmod 644 /usr/lib/tmpfiles.d/{{ .Name }}.conf
 
-USER tarantool:tarantool
+ARG TARANTOOL_UID=888
+ARG TARANTOOL_GID=888
+
+RUN usermod -u ${TARANTOOL_UID} tarantool \
+	&& groupmod -g ${TARANTOOL_GID} tarantool
+
+RUN find / -user ${TARANTOOL_UID} -xdev -exec chgrp -h tarantool {} \; \
+	&& find / -group ${TARANTOOL_GID} -xdev -exec chown -h tarantool {} \; \
+	&& chown ${TARANTOOL_UID}:${TARANTOOL_GID} /var/run/tarantool \
+	&& chown ${TARANTOOL_UID}:${TARANTOOL_GID} /var/lib/tarantool
+
+USER ${TARANTOOL_UID}:${TARANTOOL_GID}
+
 ENV CARTRIDGE_RUN_DIR=/var/run/tarantool
 ENV CARTRIDGE_DATA_DIR=/var/lib/tarantool
 ENV TARANTOOL_INSTANCE_NAME=default
@@ -422,9 +446,21 @@ RUN curl -L https://tarantool.io/installer.sh | VER=1.10 bash \
 
 ### Prepare for runtime
 RUN echo '{{ .TmpFilesConf }}' > /usr/lib/tmpfiles.d/{{ .Name }}.conf \
-    && chmod 644 /usr/lib/tmpfiles.d/{{ .Name }}.conf
+	&& chmod 644 /usr/lib/tmpfiles.d/{{ .Name }}.conf
 
-USER tarantool:tarantool
+ARG TARANTOOL_UID=888
+ARG TARANTOOL_GID=888
+
+RUN usermod -u ${TARANTOOL_UID} tarantool \
+	&& groupmod -g ${TARANTOOL_GID} tarantool
+
+RUN find / -user ${TARANTOOL_UID} -xdev -exec chgrp -h tarantool {} \; \
+	&& find / -group ${TARANTOOL_GID} -xdev -exec chown -h tarantool {} \; \
+	&& chown ${TARANTOOL_UID}:${TARANTOOL_GID} /var/run/tarantool \
+	&& chown ${TARANTOOL_UID}:${TARANTOOL_GID} /var/lib/tarantool
+
+USER ${TARANTOOL_UID}:${TARANTOOL_GID}
+
 ENV CARTRIDGE_RUN_DIR=/var/run/tarantool
 ENV CARTRIDGE_DATA_DIR=/var/lib/tarantool
 ENV TARANTOOL_INSTANCE_NAME=default
@@ -465,7 +501,19 @@ RUN curl -L https://tarantool.io/installer.sh | VER=1.10 bash \
 RUN echo '{{ .TmpFilesConf }}' > /usr/lib/tmpfiles.d/{{ .Name }}.conf \
     && chmod 644 /usr/lib/tmpfiles.d/{{ .Name }}.conf
 
-USER tarantool:tarantool
+ARG TARANTOOL_UID=888
+ARG TARANTOOL_GID=888
+
+RUN usermod -u ${TARANTOOL_UID} tarantool \
+	&& groupmod -g ${TARANTOOL_GID} tarantool
+
+RUN find / -user ${TARANTOOL_UID} -xdev -exec chgrp -h tarantool {} \; \
+	&& find / -group ${TARANTOOL_GID} -xdev -exec chown -h tarantool {} \; \
+	&& chown ${TARANTOOL_UID}:${TARANTOOL_GID} /var/run/tarantool \
+	&& chown ${TARANTOOL_UID}:${TARANTOOL_GID} /var/lib/tarantool
+
+USER ${TARANTOOL_UID}:${TARANTOOL_GID}
+
 ENV CARTRIDGE_RUN_DIR=/var/run/tarantool
 ENV CARTRIDGE_DATA_DIR=/var/lib/tarantool
 ENV TARANTOOL_INSTANCE_NAME=default

--- a/cli/project/dockerfiles_test.go
+++ b/cli/project/dockerfiles_test.go
@@ -153,9 +153,9 @@ RUN if id -u {{ .UserID }} 2>/dev/null; then \
         USERNAME=cartridge; \
         useradd -l -u {{ .UserID }} ${USERNAME}; \
     fi \
-	&& (usermod -a -G sudo ${USERNAME} 2>/dev/null || :) \
-	&& (usermod -a -G wheel ${USERNAME} 2>/dev/null || :) \
-	&& (usermod -a -G adm ${USERNAME} 2>/dev/null || :)
+    && (usermod -a -G sudo ${USERNAME} 2>/dev/null || :) \
+    && (usermod -a -G wheel ${USERNAME} 2>/dev/null || :) \
+    && (usermod -a -G adm ${USERNAME} 2>/dev/null || :)
 USER {{ .UserID }}
 `
 
@@ -190,9 +190,9 @@ RUN if id -u {{ .UserID }} 2>/dev/null; then \
         USERNAME=cartridge; \
         useradd -l -u {{ .UserID }} ${USERNAME}; \
     fi \
-	&& (usermod -a -G sudo ${USERNAME} 2>/dev/null || :) \
-	&& (usermod -a -G wheel ${USERNAME} 2>/dev/null || :) \
-	&& (usermod -a -G adm ${USERNAME} 2>/dev/null || :)
+    && (usermod -a -G sudo ${USERNAME} 2>/dev/null || :) \
+    && (usermod -a -G wheel ${USERNAME} 2>/dev/null || :) \
+    && (usermod -a -G adm ${USERNAME} 2>/dev/null || :)
 USER {{ .UserID }}
 `
 
@@ -237,9 +237,9 @@ RUN if id -u {{ .UserID }} 2>/dev/null; then \
         USERNAME=cartridge; \
         useradd -l -u {{ .UserID }} ${USERNAME}; \
     fi \
-	&& (usermod -a -G sudo ${USERNAME} 2>/dev/null || :) \
-	&& (usermod -a -G wheel ${USERNAME} 2>/dev/null || :) \
-	&& (usermod -a -G adm ${USERNAME} 2>/dev/null || :)
+    && (usermod -a -G sudo ${USERNAME} 2>/dev/null || :) \
+    && (usermod -a -G wheel ${USERNAME} 2>/dev/null || :) \
+    && (usermod -a -G adm ${USERNAME} 2>/dev/null || :)
 USER {{ .UserID }}
 `
 
@@ -274,9 +274,9 @@ RUN if id -u {{ .UserID }} 2>/dev/null; then \
         USERNAME=cartridge; \
         useradd -l -u {{ .UserID }} ${USERNAME}; \
     fi \
-	&& (usermod -a -G sudo ${USERNAME} 2>/dev/null || :) \
-	&& (usermod -a -G wheel ${USERNAME} 2>/dev/null || :) \
-	&& (usermod -a -G adm ${USERNAME} 2>/dev/null || :)
+    && (usermod -a -G sudo ${USERNAME} 2>/dev/null || :) \
+    && (usermod -a -G wheel ${USERNAME} 2>/dev/null || :) \
+    && (usermod -a -G adm ${USERNAME} 2>/dev/null || :)
 USER {{ .UserID }}
 `
 
@@ -307,18 +307,20 @@ func TestGetRuntimeImageDockerfileTemplateEnterprise(t *testing.T) {
 
 	expLayers = `FROM centos:7
 
-### Create Tarantool user and directories
+### Create Tarantool user
 RUN groupadd -r -g {{ .TarantoolGID }} tarantool \
     && useradd -M -N -l -u {{ .TarantoolUID }} -g tarantool -r -d /var/lib/tarantool -s /sbin/nologin \
-        -c "Tarantool Server" tarantool \
-    &&  mkdir -p /var/lib/tarantool/ --mode 755 \
+        -c "Tarantool Server" tarantool
+
+### Create directories
+RUN mkdir -p /var/lib/tarantool/ --mode 755 \
     && chown tarantool:tarantool /var/lib/tarantool \
     && mkdir -p /var/run/tarantool/ --mode 755 \
-	&& chown tarantool:tarantool /var/run/tarantool
+    && chown tarantool:tarantool /var/run/tarantool
 
 ### Prepare for runtime
 RUN echo '{{ .TmpFilesConf }}' > /usr/lib/tmpfiles.d/{{ .Name }}.conf \
-	&& chmod 644 /usr/lib/tmpfiles.d/{{ .Name }}.conf
+    && chmod 644 /usr/lib/tmpfiles.d/{{ .Name }}.conf
 
 USER {{ .TarantoolUID }}:{{ .TarantoolGID }}
 
@@ -357,18 +359,20 @@ RUN yum install -y zip
 	expLayers = `FROM centos:7
 RUN yum install -y zip
 
-### Create Tarantool user and directories
+### Create Tarantool user
 RUN groupadd -r -g {{ .TarantoolGID }} tarantool \
     && useradd -M -N -l -u {{ .TarantoolUID }} -g tarantool -r -d /var/lib/tarantool -s /sbin/nologin \
-        -c "Tarantool Server" tarantool \
-    &&  mkdir -p /var/lib/tarantool/ --mode 755 \
+        -c "Tarantool Server" tarantool
+
+### Create directories
+RUN mkdir -p /var/lib/tarantool/ --mode 755 \
     && chown tarantool:tarantool /var/lib/tarantool \
     && mkdir -p /var/run/tarantool/ --mode 755 \
-	&& chown tarantool:tarantool /var/run/tarantool
+    && chown tarantool:tarantool /var/run/tarantool
 
 ### Prepare for runtime
 RUN echo '{{ .TmpFilesConf }}' > /usr/lib/tmpfiles.d/{{ .Name }}.conf \
-	&& chmod 644 /usr/lib/tmpfiles.d/{{ .Name }}.conf
+    && chmod 644 /usr/lib/tmpfiles.d/{{ .Name }}.conf
 
 USER {{ .TarantoolUID }}:{{ .TarantoolGID }}
 
@@ -418,9 +422,10 @@ func TestGetRuntimeImageDockerfileTemplateOpensource(t *testing.T) {
 
 	expLayers = `FROM centos:7
 
+### Create Tarantool user
 RUN groupadd -r -g {{ .TarantoolGID }} tarantool \
-	&& useradd -M -N -l -u {{ .TarantoolUID }} -g tarantool -r -d /var/lib/tarantool -s /sbin/nologin \
-	 -c "Tarantool Server" tarantool
+    && useradd -M -N -l -u {{ .TarantoolUID }} -g tarantool -r -d /var/lib/tarantool -s /sbin/nologin \
+        -c "Tarantool Server" tarantool
 
 ### Install opensource Tarantool
 RUN curl -L https://tarantool.io/installer.sh | VER=1.10 bash \
@@ -428,7 +433,7 @@ RUN curl -L https://tarantool.io/installer.sh | VER=1.10 bash \
 
 ### Prepare for runtime
 RUN echo '{{ .TmpFilesConf }}' > /usr/lib/tmpfiles.d/{{ .Name }}.conf \
-	&& chmod 644 /usr/lib/tmpfiles.d/{{ .Name }}.conf
+    && chmod 644 /usr/lib/tmpfiles.d/{{ .Name }}.conf
 
 USER {{ .TarantoolUID }}:{{ .TarantoolGID }}
 

--- a/test/integration/pack/test_pack_docker.py
+++ b/test/integration/pack/test_pack_docker.py
@@ -309,3 +309,20 @@ def test_customized_data_and_run_dir(docker_image_print_environment, docker_clie
     container_message = f"{console_sock_path}\n{workdir_path}\n{pidfile_path}\n"
 
     wait_for_container_start(container, time.time(), message=container_message)
+
+
+def test_tarantool_uid_and_gid(docker_image, docker_client):
+    image_name = docker_image.name
+    docker_client.containers.create(docker_image.name)
+
+    command = 'whoami'
+    output = run_command_on_image(docker_client, image_name, command)
+    assert output == 'tarantool'
+
+    command = 'id -u tarantool'
+    output = run_command_on_image(docker_client, image_name, command)
+    assert output == '1200'
+
+    command = 'id -g tarantool'
+    output = run_command_on_image(docker_client, image_name, command)
+    assert output == '1200'


### PR DESCRIPTION
 It is possible to run an image generated with the ``cartridge pack docker`` command in an unprivileged Kubernetes container. It became possible, because tarantool user now always has ``UID = 1200`` and ``GID = 1200``. Closes #481 
