### PR TITLE
Cartridge template app improved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Ability to specify dependencies for the RPM and DEB (command
   ``cartridge pack``), using the ``--deps`` and ``--deps-file`` flags.
 
+### Fixed
+
+- Improved ``cartridge create`` template:
+  * Removed extra http-endpoint ``metrics`` in ``app.roles.custom.lua.``
+  * Removed mix of spaces and tabs in ``.rockspec`` file.
+
 ## [2.8.0] - 2021-04-07
 
 ### Added

--- a/cli/create/templates/cartridge/app/roles/custom.lua
+++ b/cli/create/templates/cartridge/app/roles/custom.lua
@@ -9,11 +9,6 @@ local function init(opts) -- luacheck: no unused args
         return {body = 'Hello world!'}
     end)
 
-    local http_handler = require('metrics.plugins.prometheus').collect_http
-    httpd:route({path = '/metrics'}, function(...)
-        return http_handler(...)
-    end)
-
     return true
 end
 

--- a/cli/create/templates/cartridge/{{ .Name }}-scm-1.rockspec
+++ b/cli/create/templates/cartridge/{{ .Name }}-scm-1.rockspec
@@ -1,7 +1,7 @@
 package = '{{ .Name }}'
 version = 'scm-1'
 source  = {
-	url = '/dev/null',
+    url = '/dev/null',
 }
 -- Put any modules your app depends on here
 dependencies = {
@@ -13,5 +13,5 @@ dependencies = {
     'cartridge-cli-extensions == 1.1.1-1',
 }
 build = {
-	type = 'none';
+    type = 'none';
 }


### PR DESCRIPTION
Removed a mix of spaces and tabs in ``.rockspec`` file. 
Removed a extra http-endpoint ``metrics`` in ``app.roles.custom.lua.``
Closes #532 and closes #533. 