### PR TITLE
Allowed to pack RPM and DEB packages without default dependencies file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Allowed to pack RPM and DEB packages with ``cartridge pack``
-  comamnd without default dependencies file.
+  command without default dependencies file.
 
 ## [2.9.0] - 2021-04-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Allowed to pack RPM and DEB packages with ``cartridge pack``
+  comamnd without default dependencies file.
+
 ## [2.9.0] - 2021-04-26
 
 ### Changed

--- a/cli/commands/pack.go
+++ b/cli/commands/pack.go
@@ -82,15 +82,11 @@ func parsePackageDeps(deps []string, depsFile string) (common.PackDependencies, 
 
 	if depsFile == "" && len(deps) == 0 {
 		defaultPackDepsFilePath := filepath.Join(ctx.Project.Path, defaultPackageDepsFile)
-		if _, err := os.Stat(defaultPackDepsFilePath); err != nil {
-			if os.IsNotExist(err) {
-				defaultPackDepsFilePath = ""
-			} else {
-				return nil, fmt.Errorf("Failed to use default package dependencies file: %s", err)
-			}
+		if _, err := os.Stat(defaultPackDepsFilePath); err == nil {
+			depsFile = defaultPackDepsFilePath
+		} else if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("Failed to use default package dependencies file: %s", err)
 		}
-
-		depsFile = defaultPackDepsFilePath
 	}
 
 	if depsFile != "" {

--- a/cli/commands/pack.go
+++ b/cli/commands/pack.go
@@ -81,12 +81,13 @@ func parsePackageDeps(deps []string, depsFile string) (common.PackDependencies, 
 	}
 
 	if depsFile == "" && len(deps) == 0 {
-		defaultPackeDepsFilePath := filepath.Join(ctx.Project.Path, defaultPackageDepsFile)
-		if _, err := os.Stat(defaultPackeDepsFilePath); err != nil {
-			return nil, fmt.Errorf("Failed to use default package dependencies file: %s", err)
+		defaultPackDepsFilePath := filepath.Join(ctx.Project.Path, defaultPackageDepsFile)
+		if _, err := os.Stat(defaultPackDepsFilePath); err != nil {
+			log.Warnf("Failed to use default package dependencies file: %s", err)
+			defaultPackDepsFilePath = ""
 		}
 
-		depsFile = defaultPackeDepsFilePath
+		depsFile = defaultPackDepsFilePath
 	}
 
 	if depsFile != "" {

--- a/cli/commands/pack.go
+++ b/cli/commands/pack.go
@@ -83,8 +83,11 @@ func parsePackageDeps(deps []string, depsFile string) (common.PackDependencies, 
 	if depsFile == "" && len(deps) == 0 {
 		defaultPackDepsFilePath := filepath.Join(ctx.Project.Path, defaultPackageDepsFile)
 		if _, err := os.Stat(defaultPackDepsFilePath); err != nil {
-			log.Warnf("Failed to use default package dependencies file: %s", err)
-			defaultPackDepsFilePath = ""
+			if os.IsNotExist(err) {
+				defaultPackDepsFilePath = ""
+			} else {
+				return nil, fmt.Errorf("Failed to use default package dependencies file: %s", err)
+			}
 		}
 
 		depsFile = defaultPackDepsFilePath

--- a/test/integration/pack/test_pack.py
+++ b/test/integration/pack/test_pack.py
@@ -1178,10 +1178,8 @@ def test_no_default_deps_file(cartridge_cmd, project_without_dependencies, pack_
     if platform.system() == 'Darwin':
         cmd.append('--use-docker')
 
-    warning_message = "Failed to use default package dependencies file"
     rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
     assert rc == 0
-    assert warning_message in output
 
 
 @pytest.mark.parametrize('pack_format', ['deb', 'rpm'])

--- a/test/integration/pack/test_pack.py
+++ b/test/integration/pack/test_pack.py
@@ -1165,6 +1165,26 @@ def test_dependencies_not_rpm_deb(cartridge_cmd, project_without_dependencies, p
 
 
 @pytest.mark.parametrize('pack_format', ['deb', 'rpm'])
+def test_no_default_deps_file(cartridge_cmd, project_without_dependencies, pack_format, tmpdir):
+    project = project_without_dependencies
+    os.remove(os.path.join(project.path, 'package-deps.txt'))
+
+    cmd = [
+        cartridge_cmd,
+        "pack", pack_format,
+        project.path,
+    ]
+
+    if platform.system() == 'Darwin':
+        cmd.append('--use-docker')
+
+    warning_message = "Failed to use default package dependencies file"
+    rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
+    assert rc == 0
+    assert warning_message in output
+
+
+@pytest.mark.parametrize('pack_format', ['deb', 'rpm'])
 def test_dependencies_same_flags(cartridge_cmd, project_without_dependencies, pack_format, tmpdir):
     project = project_without_dependencies
 


### PR DESCRIPTION
Allowed to pack `RPM` and `DEB` packages with ``cartridge pack``
comamnd without default dependencies file.