### PR TITLE
Change ``cartridge version`` behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Removed setting `cluster_cookie` on `cartridge.cfg` in application template
 - Updated `metrics` to `0.9.0` in application template
+- ``cartridge version`` and ``cartridge --version`` commands
+  now show Cartridge CLI and Cartridge versions. Moreover, they
+  can show version of the project rocks.
 
 ## [2.9.1] - 2021-05-13
 

--- a/cli/commands/cartridge.go
+++ b/cli/commands/cartridge.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"fmt"
+
 	"github.com/apex/log"
 	"github.com/apex/log/handlers/cli"
 	"github.com/spf13/cobra"
@@ -9,15 +11,18 @@ import (
 )
 
 var (
-	ctx context.Ctx
-
-	rootCmd = &cobra.Command{
+	ctx         context.Ctx
+	needVersion bool
+	rootCmd     = &cobra.Command{
 		Use:   "cartridge",
 		Short: "Tarantool Cartridge command-line interface",
 
-		Version: version.BuildCliVersionString(),
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			setLogLevel()
+		},
+
+		Run: func(cmd *cobra.Command, args []string) {
+			printVersion()
 		},
 	}
 )
@@ -28,6 +33,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&ctx.Cli.Verbose, "verbose", false, "Verbose output")
 	rootCmd.PersistentFlags().BoolVar(&ctx.Cli.Quiet, "quiet", false, "Hide build commands output")
 	rootCmd.PersistentFlags().BoolVar(&ctx.Cli.Debug, "debug", false, "Debug mode")
+	rootCmd.PersistentFlags().BoolVar(&needVersion, "version", false, "Show version information")
 
 	initLogger()
 }
@@ -53,5 +59,11 @@ func setLogLevel() {
 
 	if ctx.Cli.Quiet {
 		log.SetLevel(log.ErrorLevel)
+	}
+}
+
+func printVersion() {
+	if needVersion {
+		fmt.Println(version.BuildVersionString(".", false))
 	}
 }

--- a/cli/commands/cartridge.go
+++ b/cli/commands/cartridge.go
@@ -1,8 +1,6 @@
 package commands
 
 import (
-	"os"
-
 	"github.com/apex/log"
 	"github.com/apex/log/handlers/cli"
 	"github.com/spf13/cobra"
@@ -68,6 +66,6 @@ func setLogLevel() {
 
 func printVersion(cmd *cobra.Command) {
 	if err := version.PrintVersionString(projectPath, cmd.Flags().Changed("project-path"), showRocksVersion); err != nil {
-		os.Exit(1)
+		log.Fatalf(err.Error())
 	}
 }

--- a/cli/commands/cartridge.go
+++ b/cli/commands/cartridge.go
@@ -67,5 +67,12 @@ func setLogLevel() {
 }
 
 func printVersion() {
-	fmt.Println(version.BuildVersionString(".", false))
+	versionString, err := version.BuildVersionString(projectPath, showRocksVersion)
+	fmt.Println(versionString)
+
+	if err != nil && showRocksVersion {
+		log.Errorf("%s", err)
+	} else if err != nil {
+		log.Warnf("%s", err)
+	}
 }

--- a/cli/commands/cartridge.go
+++ b/cli/commands/cartridge.go
@@ -65,7 +65,8 @@ func setLogLevel() {
 }
 
 func printVersion(cmd *cobra.Command) {
-	if err := version.PrintVersionString(projectPath, cmd.Flags().Changed("project-path"), showRocksVersion); err != nil {
+	projectPathIsSet := cmd.Flags().Changed("project-path")
+	if err := version.PrintVersionString(projectPath, projectPathIsSet, showRocksVersions); err != nil {
 		log.Fatalf(err.Error())
 	}
 }

--- a/cli/commands/cartridge.go
+++ b/cli/commands/cartridge.go
@@ -1,7 +1,7 @@
 package commands
 
 import (
-	"fmt"
+	"os"
 
 	"github.com/apex/log"
 	"github.com/apex/log/handlers/cli"
@@ -25,7 +25,7 @@ var (
 			if len(args) == 0 && !needVersion {
 				cmd.Help()
 			} else {
-				printVersion()
+				printVersion(cmd)
 			}
 		},
 	}
@@ -66,13 +66,8 @@ func setLogLevel() {
 	}
 }
 
-func printVersion() {
-	versionString, err := version.BuildVersionString(projectPath, showRocksVersion)
-	fmt.Println(versionString)
-
-	if err != nil && showRocksVersion {
-		log.Errorf("%s", err)
-	} else if err != nil {
-		log.Warnf("%s", err)
+func printVersion(cmd *cobra.Command) {
+	if err := version.PrintVersionString(projectPath, cmd.Flags().Changed("project-path"), showRocksVersion); err != nil {
+		os.Exit(1)
 	}
 }

--- a/cli/commands/cartridge.go
+++ b/cli/commands/cartridge.go
@@ -36,6 +36,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&ctx.Cli.Quiet, "quiet", false, "Hide build commands output")
 	rootCmd.PersistentFlags().BoolVar(&ctx.Cli.Debug, "debug", false, "Debug mode")
 	rootCmd.Flags().BoolVarP(&needVersion, "version", "v", false, "Show version information")
+	addVersionFlags(rootCmd.Flags())
 
 	initLogger()
 }

--- a/cli/commands/cartridge.go
+++ b/cli/commands/cartridge.go
@@ -33,7 +33,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&ctx.Cli.Verbose, "verbose", false, "Verbose output")
 	rootCmd.PersistentFlags().BoolVar(&ctx.Cli.Quiet, "quiet", false, "Hide build commands output")
 	rootCmd.PersistentFlags().BoolVar(&ctx.Cli.Debug, "debug", false, "Debug mode")
-	rootCmd.PersistentFlags().BoolVar(&needVersion, "version", false, "Show version information")
+	rootCmd.PersistentFlags().BoolVarP(&needVersion, "version", "v", false, "Show version information")
 
 	initLogger()
 }

--- a/cli/commands/cartridge.go
+++ b/cli/commands/cartridge.go
@@ -22,7 +22,11 @@ var (
 		},
 
 		Run: func(cmd *cobra.Command, args []string) {
-			printVersion()
+			if len(args) == 0 && !needVersion {
+				cmd.Help()
+			} else {
+				printVersion()
+			}
 		},
 	}
 )
@@ -33,7 +37,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&ctx.Cli.Verbose, "verbose", false, "Verbose output")
 	rootCmd.PersistentFlags().BoolVar(&ctx.Cli.Quiet, "quiet", false, "Hide build commands output")
 	rootCmd.PersistentFlags().BoolVar(&ctx.Cli.Debug, "debug", false, "Debug mode")
-	rootCmd.PersistentFlags().BoolVarP(&needVersion, "version", "v", false, "Show version information")
+	rootCmd.Flags().BoolVarP(&needVersion, "version", "v", false, "Show version information")
 
 	initLogger()
 }
@@ -63,7 +67,5 @@ func setLogLevel() {
 }
 
 func printVersion() {
-	if needVersion {
-		fmt.Println(version.BuildVersionString(".", false))
-	}
+	fmt.Println(version.BuildVersionString(".", false))
 }

--- a/cli/commands/cartridge.go
+++ b/cli/commands/cartridge.go
@@ -15,7 +15,7 @@ var (
 		Use:   "cartridge",
 		Short: "Tarantool Cartridge command-line interface",
 
-		Version: version.BuildVersionString(),
+		Version: version.BuildCliVersionString(),
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			setLogLevel()
 		},

--- a/cli/commands/usage.go
+++ b/cli/commands/usage.go
@@ -142,6 +142,12 @@ const (
 	connectPasswordUsage = `Password`
 )
 
+// VERSION
+const (
+	projectPathUsage = `Path to the root directory of the project
+to get the version of the cartridge.`
+)
+
 var (
 	timeoutUsage = fmt.Sprintf(`Time to wait for instance(s) start
 defaults to %s`, defaultStartTimeout.String())

--- a/cli/commands/usage.go
+++ b/cli/commands/usage.go
@@ -145,7 +145,9 @@ const (
 // VERSION
 const (
 	projectPathUsage = `Path to the root directory of the project
-to get the version of the cartridge.`
+to get the rocks versions`
+
+	needRocksUsage = `Show information about project rocks versions`
 )
 
 var (

--- a/cli/commands/version.go
+++ b/cli/commands/version.go
@@ -1,8 +1,7 @@
 package commands
 
 import (
-	"os"
-
+	"github.com/apex/log"
 	"github.com/spf13/cobra"
 	"github.com/tarantool/cartridge-cli/cli/version"
 )
@@ -19,7 +18,7 @@ func init() {
 		Args:  cobra.MaximumNArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := version.PrintVersionString(projectPath, cmd.Flags().Changed("project-path"), showRocksVersion); err != nil {
-				os.Exit(1)
+				log.Fatalf(err.Error())
 			}
 		},
 	}

--- a/cli/commands/version.go
+++ b/cli/commands/version.go
@@ -19,8 +19,7 @@ func init() {
 		Long:  `Show version information`,
 		Args:  cobra.MaximumNArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
-			version := version.BuildVersionString(projectPath, needRocks)
-			fmt.Println(version)
+			fmt.Println(version.BuildVersionString(projectPath, needRocks))
 		},
 	}
 

--- a/cli/commands/version.go
+++ b/cli/commands/version.go
@@ -7,16 +7,24 @@ import (
 	"github.com/tarantool/cartridge-cli/cli/version"
 )
 
+var (
+	projectPath string
+	needRocks   bool
+)
+
 func init() {
 	var versionCmd = &cobra.Command{
 		Use:   "version",
-		Short: "Print the version number of Cartridge CLI",
-		Long:  `All software has versions. This is Cartridge CLI's`,
+		Short: "Show the Tarantool Cartridge version information",
+		Long:  `Show the Tarantool Cartridge version information`,
 		Args:  cobra.MaximumNArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println(version.BuildVersionString())
+			fmt.Println(version.BuildVersionString(projectPath, needRocks))
 		},
 	}
 
 	rootCmd.AddCommand(versionCmd)
+
+	versionCmd.Flags().StringVar(&projectPath, "project-path", ".", projectPathUsage)
+	versionCmd.Flags().BoolVar(&needRocks, "rocks", false, "123")
 }

--- a/cli/commands/version.go
+++ b/cli/commands/version.go
@@ -3,28 +3,35 @@ package commands
 import (
 	"fmt"
 
+	"github.com/apex/log"
 	"github.com/spf13/cobra"
 	"github.com/tarantool/cartridge-cli/cli/version"
 )
 
 var (
-	projectPath string
-	needRocks   bool
+	projectPath      string
+	showRocksVersion bool
 )
 
 func init() {
 	var versionCmd = &cobra.Command{
 		Use:   "version",
 		Short: "Show version information",
-		Long:  `Show version information`,
 		Args:  cobra.MaximumNArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println(version.BuildVersionString(projectPath, needRocks))
+			versionString, err := version.BuildVersionString(projectPath, showRocksVersion)
+			fmt.Println(versionString)
+
+			if err != nil && showRocksVersion {
+				log.Errorf("%s", err)
+			} else if err != nil {
+				log.Warnf("%s", err)
+			}
 		},
 	}
 
 	rootCmd.AddCommand(versionCmd)
 
-	versionCmd.Flags().BoolVar(&needRocks, "rocks", false, needRocksUsage)
+	versionCmd.Flags().BoolVar(&showRocksVersion, "rocks", false, needRocksUsage)
 	versionCmd.Flags().StringVar(&projectPath, "project-path", ".", projectPathUsage)
 }

--- a/cli/commands/version.go
+++ b/cli/commands/version.go
@@ -19,7 +19,8 @@ func init() {
 		Long:  `Show version information`,
 		Args:  cobra.MaximumNArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println(version.BuildVersionString(projectPath, needRocks))
+			version := version.BuildVersionString(projectPath, needRocks)
+			fmt.Println(version)
 		},
 	}
 

--- a/cli/commands/version.go
+++ b/cli/commands/version.go
@@ -15,8 +15,8 @@ var (
 func init() {
 	var versionCmd = &cobra.Command{
 		Use:   "version",
-		Short: "Show the Tarantool Cartridge version information",
-		Long:  `Show the Tarantool Cartridge version information`,
+		Short: "Show version information",
+		Long:  `Show version information`,
 		Args:  cobra.MaximumNArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Println(version.BuildVersionString(projectPath, needRocks))
@@ -25,6 +25,6 @@ func init() {
 
 	rootCmd.AddCommand(versionCmd)
 
+	versionCmd.Flags().BoolVar(&needRocks, "rocks", false, needRocksUsage)
 	versionCmd.Flags().StringVar(&projectPath, "project-path", ".", projectPathUsage)
-	versionCmd.Flags().BoolVar(&needRocks, "rocks", false, "123")
 }

--- a/cli/commands/version.go
+++ b/cli/commands/version.go
@@ -1,9 +1,8 @@
 package commands
 
 import (
-	"fmt"
+	"os"
 
-	"github.com/apex/log"
 	"github.com/spf13/cobra"
 	"github.com/tarantool/cartridge-cli/cli/version"
 )
@@ -19,19 +18,13 @@ func init() {
 		Short: "Show version information",
 		Args:  cobra.MaximumNArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
-			versionString, err := version.BuildVersionString(projectPath, showRocksVersion)
-			fmt.Println(versionString)
-
-			if err != nil && showRocksVersion {
-				log.Errorf("%s", err)
-			} else if err != nil {
-				log.Warnf("%s", err)
+			if err := version.PrintVersionString(projectPath, cmd.Flags().Changed("project-path"), showRocksVersion); err != nil {
+				os.Exit(1)
 			}
 		},
 	}
 
 	rootCmd.AddCommand(versionCmd)
-
 	versionCmd.Flags().BoolVar(&showRocksVersion, "rocks", false, needRocksUsage)
 	versionCmd.Flags().StringVar(&projectPath, "project-path", ".", projectPathUsage)
 }

--- a/cli/commands/version.go
+++ b/cli/commands/version.go
@@ -3,12 +3,13 @@ package commands
 import (
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/tarantool/cartridge-cli/cli/version"
 )
 
 var (
-	projectPath      string
-	showRocksVersion bool
+	projectPath       string
+	showRocksVersions bool
 )
 
 func init() {
@@ -17,13 +18,18 @@ func init() {
 		Short: "Show version information",
 		Args:  cobra.MaximumNArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := version.PrintVersionString(projectPath, cmd.Flags().Changed("project-path"), showRocksVersion); err != nil {
+			projectPathIsSet := cmd.Flags().Changed("project-path")
+			if err := version.PrintVersionString(projectPath, projectPathIsSet, showRocksVersions); err != nil {
 				log.Fatalf(err.Error())
 			}
 		},
 	}
 
 	rootCmd.AddCommand(versionCmd)
-	versionCmd.Flags().BoolVar(&showRocksVersion, "rocks", false, needRocksUsage)
-	versionCmd.Flags().StringVar(&projectPath, "project-path", ".", projectPathUsage)
+	addVersionFlags(versionCmd.Flags())
+}
+
+func addVersionFlags(flagSet *pflag.FlagSet) {
+	flagSet.BoolVar(&showRocksVersions, "rocks", false, needRocksUsage)
+	flagSet.StringVar(&projectPath, "project-path", ".", projectPathUsage)
 }

--- a/cli/project/project.go
+++ b/cli/project/project.go
@@ -85,5 +85,5 @@ Stacktrace:
 %s
 `
 	msg := fmt.Sprintf(format, a...)
-	return fmt.Errorf(internalErrorFmt, msg, version.BuildVersionString(), debug.Stack())
+	return fmt.Errorf(internalErrorFmt, msg, version.BuildCliVersionString(), debug.Stack())
 }

--- a/cli/project/project.go
+++ b/cli/project/project.go
@@ -85,5 +85,5 @@ Stacktrace:
 %s
 `
 	msg := fmt.Sprintf(format, a...)
-	return fmt.Errorf(internalErrorFmt, msg, version.BuildCliVersionString(), debug.Stack())
+	return fmt.Errorf(internalErrorFmt, msg, version.BuildVersionString(".", false), debug.Stack())
 }

--- a/cli/project/project.go
+++ b/cli/project/project.go
@@ -85,5 +85,5 @@ Stacktrace:
 %s
 `
 	msg := fmt.Sprintf(format, a...)
-	return fmt.Errorf(internalErrorFmt, msg, version.BuildVersionString(".", false), debug.Stack())
+	return fmt.Errorf(internalErrorFmt, msg, version.BuildCliVersionString(), debug.Stack())
 }

--- a/cli/version/version.go
+++ b/cli/version/version.go
@@ -145,12 +145,17 @@ func printCliVersion() {
 func PrintVersionString(projectPath string, projectPathIsSet bool, showRocksVersion bool) error {
 	printCliVersion()
 	if err := printCartridgeVersion(projectPath); err != nil {
+		currentErrorString := cartridgeVersionGetError
+		if showRocksVersion {
+			currentErrorString = rocksVersionsGetError
+		}
+
 		if projectPathIsSet {
-			log.Errorf("%s: %s", cartridgeVersionGetError, err)
+			log.Errorf("%s: %s", currentErrorString, err)
 			return err
 		}
 
-		log.Warnf("%s: %s", cartridgeVersionGetError, err)
+		log.Warnf("%s: %s", currentErrorString, err)
 		return nil
 	}
 

--- a/cli/version/version.go
+++ b/cli/version/version.go
@@ -19,9 +19,32 @@ var (
 const (
 	unknownVersion = "<unknown>"
 	cliName        = "Tarantool Cartridge CLI"
+	cartridgeName  = "Tarantool Cartridge"
 )
 
-func BuildVersionString() string {
+func buildRocksVersionString(projectPath string) string {
+	var versionParts []string
+	var rocksVersionsMap map[string]string
+	var err error
+
+	if rocksVersionsMap, err = common.LuaGetRocksVersions(projectPath); err != nil {
+		versionParts = append(versionParts, fmt.Sprintf("%s. See --project-path flag", err))
+		return strings.Join(versionParts, "\n ")
+	}
+
+	if len(rocksVersionsMap) == 0 {
+		versionParts = append(versionParts, fmt.Sprintf("Specify project path to see rocks version. See --project-path flag"))
+		return strings.Join(versionParts, "\n ")
+	}
+
+	for k, v := range rocksVersionsMap {
+		versionParts = append(versionParts, fmt.Sprintf("%s version: %s", k, v))
+	}
+
+	return strings.Join(versionParts, "\n")
+}
+
+func BuildCliVersionString() string {
 	var version string
 
 	var versionParts []string
@@ -41,16 +64,26 @@ func BuildVersionString() string {
 		}
 	}
 
-	versionStr := fmt.Sprintf("v%s", version)
+	versionStr := fmt.Sprintf("Version:\t%s", version)
 	versionParts = append(versionParts, versionStr)
 
-	osArchStr := fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)
+	osArchStr := fmt.Sprintf("OS/Arch:\t%s/%s", runtime.GOOS, runtime.GOARCH)
 	versionParts = append(versionParts, osArchStr)
 
 	if gitCommit != "" {
-		gitCommitStr := fmt.Sprintf("commit: %s", gitCommit)
+		gitCommitStr := fmt.Sprintf("Git commit:\t%s", gitCommit)
 		versionParts = append(versionParts, gitCommitStr)
 	}
 
-	return strings.Join(versionParts, " ")
+	return strings.Join(versionParts, "\n ")
+}
+
+func BuildVersionString(projectPath string, needRocks bool) string {
+	var versionParts []string
+	versionParts = append(versionParts, BuildCliVersionString())
+	if needRocks {
+		versionParts = append(versionParts, buildRocksVersionString(projectPath))
+	}
+
+	return strings.Join(versionParts, "\n\n")
 }

--- a/cli/version/version.go
+++ b/cli/version/version.go
@@ -2,6 +2,8 @@ package version
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -27,18 +29,24 @@ func buildRocksVersionString(projectPath string) string {
 	var rocksVersionsMap map[string]string
 	var err error
 
+	if _, err := os.Stat(filepath.Join(projectPath)); os.IsNotExist(err) {
+		versionParts = append(versionParts, fmt.Sprintf("Your project path is invalid"))
+		return strings.Join(versionParts, "\n ")
+	}
+
 	if rocksVersionsMap, err = common.LuaGetRocksVersions(projectPath); err != nil {
 		versionParts = append(versionParts, fmt.Sprintf("%s. See --project-path flag", err))
 		return strings.Join(versionParts, "\n ")
 	}
 
 	if len(rocksVersionsMap) == 0 {
-		versionParts = append(versionParts, fmt.Sprintf("Specify project path to see rocks version. See --project-path flag"))
+		versionParts = append(versionParts, fmt.Sprintf(`Looks like your project directory does not contain a .rocks directory...
+See --project-path flag`))
 		return strings.Join(versionParts, "\n ")
 	}
 
 	for k, v := range rocksVersionsMap {
-		versionParts = append(versionParts, fmt.Sprintf("%s version: %s", k, v))
+		versionParts = append(versionParts, fmt.Sprintf("%s v%s", k, v))
 	}
 
 	return strings.Join(versionParts, "\n")

--- a/cli/version/version.go
+++ b/cli/version/version.go
@@ -53,12 +53,12 @@ func BuildCliVersionString() string {
 	})
 }
 
-func PrintVersionString(projectPath string, projectPathIsSet bool, showRocksVersion bool) error {
+func PrintVersionString(projectPath string, projectPathIsSet bool, showRocksVersions bool) error {
 	fmt.Println(BuildCliVersionString())
 
 	if err := printCartridgeVersion(projectPath); err != nil {
 		currentErrorString := cartridgeVersionGetError
-		if showRocksVersion {
+		if showRocksVersions {
 			currentErrorString = rocksVersionsGetError
 		}
 
@@ -66,11 +66,11 @@ func PrintVersionString(projectPath string, projectPathIsSet bool, showRocksVers
 			return fmt.Errorf("%s: %s", currentErrorString, err)
 		}
 
-		log.Warnf("%s: %s", currentErrorString, err)
+		log.Warnf("%s: %s. See --project-path flag, to specify path to project", currentErrorString, err)
 		return nil
 	}
 
-	if showRocksVersion {
+	if showRocksVersions {
 		if err := printRocksVersion(projectPath); err != nil {
 			return fmt.Errorf("%s: %s", rocksVersionsGetError, err)
 		}

--- a/cli/version/version.go
+++ b/cli/version/version.go
@@ -132,7 +132,7 @@ func printCartridgeVersion(projectPath string) error {
 		"Version": version,
 	})
 
-	fmt.Println(cartridgeVersion)
+	fmt.Print(cartridgeVersion)
 	return err
 }
 
@@ -172,5 +172,6 @@ var (
 `
 
 	cartridgeVersionTmpl = `{{ .Title }}
- Version:	{{ .Version }}`
+ Version:	{{ .Version }}
+`
 )

--- a/cli/version/version.go
+++ b/cli/version/version.go
@@ -50,19 +50,6 @@ does not contain a .rocks directory... See --project-path flag`, errorStr)
 	return rocksVersionsMap, nil
 }
 
-func buildRocksVersionString(rocksVersions map[string]string) string {
-	var versionParts []string
-	versionParts = append(versionParts, "Rocks")
-
-	for k, v := range rocksVersions {
-		if k != "cartridge" {
-			versionParts = append(versionParts, fmt.Sprintf("%s v%s", k, v))
-		}
-	}
-
-	return strings.Join(versionParts, "\n ")
-}
-
 func buildCartridgeVersionString(rocksVersions map[string]string) string {
 	var versionParts []string
 	versionParts = append(versionParts, cartridgeName)
@@ -72,6 +59,23 @@ func buildCartridgeVersionString(rocksVersions map[string]string) string {
 		versionParts = append(versionParts, fmt.Sprintf("Version:\t%s", unknownVersion))
 	} else {
 		versionParts = append(versionParts, fmt.Sprintf("Version:\t%s", version))
+	}
+
+	return strings.Join(versionParts, "\n ")
+}
+
+func buildRocksVersionString(rocksVersions map[string]string) string {
+	var versionParts []string
+	versionParts = append(versionParts, "Rocks")
+
+	for rock, version := range rocksVersions {
+		// We have to skip cartridge rock - we print info about
+		// this rock in function above. Also, we have to check
+		// that the rock is really the rock because the manifest
+		// file contains the project itself (for example: myapp - scm1)
+		if rock != "cartridge" && version[0] >= '0' && version[0] <= '9' {
+			versionParts = append(versionParts, fmt.Sprintf("%s v%s", rock, version))
+		}
 	}
 
 	return strings.Join(versionParts, "\n ")
@@ -118,6 +122,8 @@ func BuildVersionString(projectPath string, needRocks bool) string {
 
 	versionParts = append(versionParts, BuildCliVersionString())
 	rocksVersions, err = getRocksVersions(projectPath)
+	// If we get error, we anyway have to print <unknow>
+	// version of Cartridge. And only after this, we return from this function.
 	versionParts = append(versionParts, buildCartridgeVersionString(rocksVersions))
 
 	if err != nil {

--- a/test/integration/cli/test_version.py
+++ b/test/integration/cli/test_version.py
@@ -8,8 +8,7 @@ def test_version_command(cartridge_cmd):
         rc, output = run_command_and_get_output([cartridge_cmd, version_cmd])
         assert rc == 0
         assert 'Tarantool Cartridge CLI\n Version:\t2' in output
-        assert 'Tarantool Cartridge\n Version:\t<unknown>' in output
-        assert 'Failed to get the version of the Cartridge. Project path . is not a project' in output
+        assert 'Failed to show current Cartridge version: Project path . is not a project' in output
 
 
 def test_version_command_with_project(project_with_cartridge, cartridge_cmd, tmpdir):
@@ -74,8 +73,8 @@ def test_version_command_invalid_project(project_without_dependencies, cartridge
     ]
 
     rc, output = run_command_and_get_output(cmd)
-    assert rc == 0
-    assert f'Failed to get the version of the Cartridge. Project path {tmpdir} is not a project' in output
+    assert rc == 1
+    assert f'Project path {tmpdir} is not a project' in output
 
 
 def test_version_command_nonbuilded_project(project_without_dependencies, cartridge_cmd, tmpdir):
@@ -87,8 +86,8 @@ def test_version_command_nonbuilded_project(project_without_dependencies, cartri
     ]
 
     rc, output = run_command_and_get_output(cmd)
-    assert rc == 0
-    assert 'Looks like your project directory\ndoes not contain a .rocks directory' in output
+    assert rc == 1
+    assert 'Are dependencies in .rocks directory correct?' in output
 
 
 def test_version_command_invalid_path(cartridge_cmd):
@@ -98,5 +97,5 @@ def test_version_command_invalid_path(cartridge_cmd):
     ]
 
     rc, output = run_command_and_get_output(cmd)
-    assert rc == 0
-    assert 'Failed to get the version of the Cartridge. Your project path is invalid' in output
+    assert rc == 1
+    assert 'Your project path is invalid' in output

--- a/test/integration/cli/test_version.py
+++ b/test/integration/cli/test_version.py
@@ -74,7 +74,7 @@ def test_version_command_invalid_project(project_without_dependencies, cartridge
 
     rc, output = run_command_and_get_output(cmd)
     assert rc == 1
-    assert f'Project path {tmpdir} is not a project' in output
+    assert f'Failed to show rocks versions: Project path {tmpdir} is not a project' in output
 
 
 def test_version_command_nonbuilded_project(project_without_dependencies, cartridge_cmd, tmpdir):
@@ -87,7 +87,7 @@ def test_version_command_nonbuilded_project(project_without_dependencies, cartri
 
     rc, output = run_command_and_get_output(cmd)
     assert rc == 1
-    assert 'Are dependencies in .rocks directory correct?' in output
+    assert 'Failed to show rocks versions: Are dependencies in .rocks directory correct?' in output
 
 
 def test_version_command_invalid_path(cartridge_cmd):
@@ -98,4 +98,4 @@ def test_version_command_invalid_path(cartridge_cmd):
 
     rc, output = run_command_and_get_output(cmd)
     assert rc == 1
-    assert 'Your project path is invalid' in output
+    assert 'Failed to show current Cartridge version: Your project path is invalid' in output

--- a/test/integration/cli/test_version.py
+++ b/test/integration/cli/test_version.py
@@ -83,6 +83,7 @@ def test_version_command_invalid_project(project_without_dependencies, cartridge
 
 def test_version_command_nonbuilded_project(project_without_dependencies, cartridge_cmd, tmpdir):
     project = project_without_dependencies
+
     for version_cmd in ["version", "-v", "--version"]:
         cmd = [
             cartridge_cmd,
@@ -92,7 +93,8 @@ def test_version_command_nonbuilded_project(project_without_dependencies, cartri
 
         rc, output = run_command_and_get_output(cmd)
         assert rc == 1
-        assert 'Failed to show Cartridge and other rocks versions: Are dependencies in .rocks directory correct?' in output
+        assert 'Failed to show Cartridge and other rocks versions: ' \
+            'Are dependencies in .rocks directory correct?' in output
 
 
 def test_version_command_invalid_path(cartridge_cmd):

--- a/test/integration/cli/test_version.py
+++ b/test/integration/cli/test_version.py
@@ -5,4 +5,4 @@ def test_version_command(cartridge_cmd):
     for version_cmd in ["version", "-v", "--version"]:
         rc, output = run_command_and_get_output([cartridge_cmd, version_cmd])
         assert rc == 0
-        assert 'Tarantool Cartridge CLI v2' in output
+        assert 'Tarantool Cartridge CLI\n Version:\t2' in output

--- a/test/integration/cli/test_version.py
+++ b/test/integration/cli/test_version.py
@@ -23,16 +23,17 @@ def test_version_command_with_project(project_with_cartridge, cartridge_cmd, tmp
     process = subprocess.run(cmd, cwd=tmpdir)
     assert process.returncode == 0
 
-    cmd = [
-        cartridge_cmd, "version",
-        f"--project-path={project.path}"
-    ]
+    for version_cmd in ["version", "-v", "--version"]:
+        cmd = [
+            cartridge_cmd, version_cmd,
+            f"--project-path={project.path}"
+        ]
 
-    rc, output = run_command_and_get_output(cmd)
-    assert rc == 0
+        rc, output = run_command_and_get_output(cmd)
+        assert rc == 0
 
-    assert 'Tarantool Cartridge CLI\n Version:\t2' in output
-    assert 'Tarantool Cartridge\n Version:\t2' in output
+        assert 'Tarantool Cartridge CLI\n Version:\t2' in output
+        assert 'Tarantool Cartridge\n Version:\t2' in output
 
 
 def test_version_command_with_rocks(project_with_cartridge, cartridge_cmd, tmpdir):
@@ -46,56 +47,61 @@ def test_version_command_with_rocks(project_with_cartridge, cartridge_cmd, tmpdi
 
     process = subprocess.run(cmd, cwd=tmpdir)
     assert process.returncode == 0
-    cmd = [
-        cartridge_cmd,
-        "version", "--rocks",
-        f"--project-path={project.path}"
-    ]
 
-    rc, output = run_command_and_get_output(cmd)
-    assert rc == 0
-    assert 'Tarantool Cartridge CLI\n Version:\t2' in output
-    assert 'Tarantool Cartridge\n Version:\t2' in output
-    assert 'Rocks' in output
-    assert 'metrics ' in output
-    assert 'checks ' in output
-    assert project.name in output
+    for version_cmd in ["version", "-v", "--version"]:
+        cmd = [
+            cartridge_cmd,
+            version_cmd, "--rocks",
+            f"--project-path={project.path}"
+        ]
+
+        rc, output = run_command_and_get_output(cmd)
+        assert rc == 0
+        assert 'Tarantool Cartridge CLI\n Version:\t2' in output
+        assert 'Tarantool Cartridge\n Version:\t2' in output
+        assert 'Rocks' in output
+        assert 'metrics ' in output
+        assert 'checks ' in output
+        assert project.name in output
 
 
 def test_version_command_invalid_project(project_without_dependencies, cartridge_cmd, tmpdir):
     project = project_without_dependencies
     remove_project_file(project, f'{project.name}-scm-1.rockspec')
 
-    cmd = [
-        cartridge_cmd,
-        "version", "--rocks",
-        f"--project-path={tmpdir}"
-    ]
+    for version_cmd in ["version", "-v", "--version"]:
+        cmd = [
+            cartridge_cmd,
+            version_cmd, "--rocks",
+            f"--project-path={tmpdir}"
+        ]
 
-    rc, output = run_command_and_get_output(cmd)
-    assert rc == 1
-    assert f'Failed to show Cartridge and other rocks versions: Project path {tmpdir} is not a project' in output
+        rc, output = run_command_and_get_output(cmd)
+        assert rc == 1
+        assert f'Failed to show Cartridge and other rocks versions: Project path {tmpdir} is not a project' in output
 
 
 def test_version_command_nonbuilded_project(project_without_dependencies, cartridge_cmd, tmpdir):
     project = project_without_dependencies
-    cmd = [
-        cartridge_cmd,
-        "version", "--rocks",
-        f"--project-path={project.path}"
-    ]
+    for version_cmd in ["version", "-v", "--version"]:
+        cmd = [
+            cartridge_cmd,
+            version_cmd, "--rocks",
+            f"--project-path={project.path}"
+        ]
 
-    rc, output = run_command_and_get_output(cmd)
-    assert rc == 1
-    assert 'Failed to show Cartridge and other rocks versions: Are dependencies in .rocks directory correct?' in output
+        rc, output = run_command_and_get_output(cmd)
+        assert rc == 1
+        assert 'Failed to show Cartridge and other rocks versions: Are dependencies in .rocks directory correct?' in output
 
 
 def test_version_command_invalid_path(cartridge_cmd):
-    cmd = [
-        cartridge_cmd, "version",
-        "--project-path=invalid_path"
-    ]
+    for version_cmd in ["version", "-v", "--version"]:
+        cmd = [
+            cartridge_cmd, version_cmd,
+            "--project-path=invalid_path"
+        ]
 
-    rc, output = run_command_and_get_output(cmd)
-    assert rc == 1
-    assert 'Failed to show Cartridge version: Specified project path doesn\'t exist' in output
+        rc, output = run_command_and_get_output(cmd)
+        assert rc == 1
+        assert 'Failed to show Cartridge version: Specified project path doesn\'t exist' in output

--- a/test/integration/cli/test_version.py
+++ b/test/integration/cli/test_version.py
@@ -1,17 +1,19 @@
+import pytest
 import subprocess
 from utils import run_command_and_get_output
 from project import remove_project_file
 
 
-def test_version_command(cartridge_cmd):
-    for version_cmd in ["version", "-v", "--version"]:
-        rc, output = run_command_and_get_output([cartridge_cmd, version_cmd])
-        assert rc == 0
-        assert 'Tarantool Cartridge CLI\n Version:\t2' in output
-        assert 'Failed to show Cartridge version: Project path . is not a project' in output
+@pytest.mark.parametrize('version_cmd', ['version', '-v', '--version'])
+def test_version_command(cartridge_cmd, version_cmd):
+    rc, output = run_command_and_get_output([cartridge_cmd, version_cmd])
+    assert rc == 0
+    assert 'Tarantool Cartridge CLI\n Version:\t2' in output
+    assert 'Failed to show Cartridge version: Project path . is not a project' in output
 
 
-def test_version_command_with_project(project_with_cartridge, cartridge_cmd, tmpdir):
+@pytest.mark.parametrize('version_cmd', ['version', '-v', '--version'])
+def test_version_command_with_project(project_with_cartridge, version_cmd, cartridge_cmd, tmpdir):
     project = project_with_cartridge
 
     cmd = [
@@ -23,20 +25,21 @@ def test_version_command_with_project(project_with_cartridge, cartridge_cmd, tmp
     process = subprocess.run(cmd, cwd=tmpdir)
     assert process.returncode == 0
 
-    for version_cmd in ["version", "-v", "--version"]:
-        cmd = [
-            cartridge_cmd, version_cmd,
-            f"--project-path={project.path}"
-        ]
+    cmd = [
+        cartridge_cmd, version_cmd,
+        f"--project-path={project.path}"
+    ]
 
-        rc, output = run_command_and_get_output(cmd)
-        assert rc == 0
+    rc, output = run_command_and_get_output(cmd)
+    assert rc == 0
 
-        assert 'Tarantool Cartridge CLI\n Version:\t2' in output
-        assert 'Tarantool Cartridge\n Version:\t2' in output
+    assert 'Tarantool Cartridge CLI\n Version:\t2' in output
+    assert 'Tarantool Cartridge\n Version:\t2' in output
+    assert 'Rocks' not in output
 
 
-def test_version_command_with_rocks(project_with_cartridge, cartridge_cmd, tmpdir):
+@pytest.mark.parametrize('version_cmd', ['version', '-v', '--version'])
+def test_version_command_with_rocks(project_with_cartridge, version_cmd, cartridge_cmd, tmpdir):
     project = project_with_cartridge
 
     cmd = [
@@ -48,62 +51,61 @@ def test_version_command_with_rocks(project_with_cartridge, cartridge_cmd, tmpdi
     process = subprocess.run(cmd, cwd=tmpdir)
     assert process.returncode == 0
 
-    for version_cmd in ["version", "-v", "--version"]:
-        cmd = [
-            cartridge_cmd,
-            version_cmd, "--rocks",
-            f"--project-path={project.path}"
-        ]
+    cmd = [
+        cartridge_cmd,
+        version_cmd, "--rocks",
+        f"--project-path={project.path}"
+    ]
 
-        rc, output = run_command_and_get_output(cmd)
-        assert rc == 0
-        assert 'Tarantool Cartridge CLI\n Version:\t2' in output
-        assert 'Tarantool Cartridge\n Version:\t2' in output
-        assert 'Rocks' in output
-        assert 'metrics ' in output
-        assert 'checks ' in output
-        assert project.name in output
+    rc, output = run_command_and_get_output(cmd)
+    assert rc == 0
+    assert 'Tarantool Cartridge CLI\n Version:\t2' in output
+    assert 'Tarantool Cartridge\n Version:\t2' in output
+    assert 'Rocks' in output
+    assert 'metrics ' in output
+    assert 'checks ' in output
+    assert project.name in output
 
 
-def test_version_command_invalid_project(project_without_dependencies, cartridge_cmd, tmpdir):
+@pytest.mark.parametrize('version_cmd', ['version', '-v', '--version'])
+def test_version_command_invalid_project(project_without_dependencies, version_cmd, cartridge_cmd, tmpdir):
     project = project_without_dependencies
     remove_project_file(project, f'{project.name}-scm-1.rockspec')
 
-    for version_cmd in ["version", "-v", "--version"]:
-        cmd = [
-            cartridge_cmd,
-            version_cmd, "--rocks",
-            f"--project-path={tmpdir}"
-        ]
+    cmd = [
+        cartridge_cmd,
+        version_cmd, "--rocks",
+        f"--project-path={tmpdir}"
+    ]
 
-        rc, output = run_command_and_get_output(cmd)
-        assert rc == 1
-        assert f'Failed to show Cartridge and other rocks versions: Project path {tmpdir} is not a project' in output
+    rc, output = run_command_and_get_output(cmd)
+    assert rc == 1
+    assert f'Failed to show Cartridge and other rocks versions: Project path {tmpdir} is not a project' in output
 
 
-def test_version_command_nonbuilded_project(project_without_dependencies, cartridge_cmd, tmpdir):
+@pytest.mark.parametrize('version_cmd', ['version', '-v', '--version'])
+def test_version_command_nonbuilded_project(project_without_dependencies, version_cmd, cartridge_cmd, tmpdir):
     project = project_without_dependencies
 
-    for version_cmd in ["version", "-v", "--version"]:
-        cmd = [
-            cartridge_cmd,
-            version_cmd, "--rocks",
-            f"--project-path={project.path}"
-        ]
+    cmd = [
+        cartridge_cmd,
+        version_cmd, "--rocks",
+        f"--project-path={project.path}"
+    ]
 
-        rc, output = run_command_and_get_output(cmd)
-        assert rc == 1
-        assert 'Failed to show Cartridge and other rocks versions: ' \
-            'Are dependencies in .rocks directory correct?' in output
+    rc, output = run_command_and_get_output(cmd)
+    assert rc == 1
+    assert 'Failed to show Cartridge and other rocks versions: ' \
+        'Are dependencies in .rocks directory correct?' in output
 
 
-def test_version_command_invalid_path(cartridge_cmd):
-    for version_cmd in ["version", "-v", "--version"]:
-        cmd = [
-            cartridge_cmd, version_cmd,
-            "--project-path=invalid_path"
-        ]
+@pytest.mark.parametrize('version_cmd', ['version', '-v', '--version'])
+def test_version_command_invalid_path(cartridge_cmd, version_cmd):
+    cmd = [
+        cartridge_cmd, version_cmd,
+        "--project-path=invalid_path"
+    ]
 
-        rc, output = run_command_and_get_output(cmd)
-        assert rc == 1
-        assert 'Failed to show Cartridge version: Specified project path doesn\'t exist' in output
+    rc, output = run_command_and_get_output(cmd)
+    assert rc == 1
+    assert 'Failed to show Cartridge version: Specified project path doesn\'t exist' in output

--- a/test/integration/cli/test_version.py
+++ b/test/integration/cli/test_version.py
@@ -8,7 +8,7 @@ def test_version_command(cartridge_cmd):
         rc, output = run_command_and_get_output([cartridge_cmd, version_cmd])
         assert rc == 0
         assert 'Tarantool Cartridge CLI\n Version:\t2' in output
-        assert 'Failed to show current Cartridge version: Project path . is not a project' in output
+        assert 'Failed to show Cartridge version: Project path . is not a project' in output
 
 
 def test_version_command_with_project(project_with_cartridge, cartridge_cmd, tmpdir):
@@ -74,7 +74,7 @@ def test_version_command_invalid_project(project_without_dependencies, cartridge
 
     rc, output = run_command_and_get_output(cmd)
     assert rc == 1
-    assert f'Failed to show rocks versions: Project path {tmpdir} is not a project' in output
+    assert f'Failed to show Cartridge and other rocks versions: Project path {tmpdir} is not a project' in output
 
 
 def test_version_command_nonbuilded_project(project_without_dependencies, cartridge_cmd, tmpdir):
@@ -87,7 +87,7 @@ def test_version_command_nonbuilded_project(project_without_dependencies, cartri
 
     rc, output = run_command_and_get_output(cmd)
     assert rc == 1
-    assert 'Failed to show rocks versions: Are dependencies in .rocks directory correct?' in output
+    assert 'Failed to show Cartridge and other rocks versions: Are dependencies in .rocks directory correct?' in output
 
 
 def test_version_command_invalid_path(cartridge_cmd):
@@ -98,4 +98,4 @@ def test_version_command_invalid_path(cartridge_cmd):
 
     rc, output = run_command_and_get_output(cmd)
     assert rc == 1
-    assert 'Failed to show current Cartridge version: Your project path is invalid' in output
+    assert 'Failed to show Cartridge version: Specified project path doesn\'t exist' in output

--- a/test/integration/cli/test_version.py
+++ b/test/integration/cli/test_version.py
@@ -57,8 +57,9 @@ def test_version_command_with_rocks(project_with_cartridge, cartridge_cmd, tmpdi
     assert 'Tarantool Cartridge CLI\n Version:\t2' in output
     assert 'Tarantool Cartridge\n Version:\t2' in output
     assert 'Rocks' in output
-    assert 'metrics v' in output
-    assert 'checks v' in output
+    assert 'metrics ' in output
+    assert 'checks ' in output
+    assert project.name in output
 
 
 def test_version_command_invalid_project(cartridge_cmd):

--- a/test/integration/cli/test_version.py
+++ b/test/integration/cli/test_version.py
@@ -1,3 +1,4 @@
+import subprocess
 from utils import run_command_and_get_output
 
 
@@ -6,3 +7,66 @@ def test_version_command(cartridge_cmd):
         rc, output = run_command_and_get_output([cartridge_cmd, version_cmd])
         assert rc == 0
         assert 'Tarantool Cartridge CLI\n Version:\t2' in output
+        assert 'Tarantool Cartridge\n Version:\t<unknown>' in output
+        assert 'Failed to get the version of the Cartridge' in output
+
+
+def test_version_command_with_project(project_with_cartridge, cartridge_cmd, tmpdir):
+    project = project_with_cartridge
+
+    cmd = [
+        cartridge_cmd,
+        "build",
+        project.path
+    ]
+
+    process = subprocess.run(cmd, cwd=tmpdir)
+    assert process.returncode == 0
+
+    cmd = [
+        cartridge_cmd, "version",
+        f"--project-path={project.path}"
+    ]
+
+    rc, output = run_command_and_get_output(cmd)
+    assert rc == 0
+
+    assert 'Tarantool Cartridge CLI\n Version:\t2' in output
+    assert 'Tarantool Cartridge\n Version:\t2' in output
+
+
+def test_version_command_with_rocks(project_with_cartridge, cartridge_cmd, tmpdir):
+    project = project_with_cartridge
+
+    cmd = [
+        cartridge_cmd,
+        "build",
+        project.path
+    ]
+
+    process = subprocess.run(cmd, cwd=tmpdir)
+    assert process.returncode == 0
+    cmd = [
+        cartridge_cmd,
+        "version", "--rocks",
+        f"--project-path={project.path}"
+    ]
+
+    rc, output = run_command_and_get_output(cmd)
+    assert rc == 0
+    assert 'Tarantool Cartridge CLI\n Version:\t2' in output
+    assert 'Tarantool Cartridge\n Version:\t2' in output
+    assert 'Rocks' in output
+    assert 'metrics v' in output
+    assert 'checks v' in output
+
+
+def test_version_command_invalid_project(cartridge_cmd):
+    cmd = [
+        cartridge_cmd, "version",
+        "--project-path=invalid_path"
+    ]
+
+    rc, output = run_command_and_get_output(cmd)
+    assert rc == 0
+    assert 'Failed to get the version of the Cartridge. Your project path is invalid' in output


### PR DESCRIPTION
 ``cartridge version`` and ``cartridge --version`` commands
  now show Cartridge CLI and Cartridge versions. Moreover, they
  can show version of the project rocks.

<details> 
  <summary>Example (images) </summary>
 
![img2](https://sun9-50.userapi.com/impg/xqpjCsOKCbsEOAznq1hCziEs385BKszOLqDqPA/fpmAy80Lxyc.jpg?size=1286x1386&quality=96&sign=87a5e2e31c4304301d6ddc528f29962f&type=album)

</details>

Closes #526 