### PR TITLE
Fix issues in cartridge app tests template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Improved tests in ``cartridge create`` template:
+  * Tests are reduced to the form corresponding to luatest documentation
+  * ``before_suit`` now remove ``.xlog`` and ``.snap`` files
+
 ### Changed
 
 - Removed setting `cluster_cookie` on `cartridge.cfg` in application template

--- a/cli/create/templates/cartridge/test/helper.lua
+++ b/cli/create/templates/cartridge/test/helper.lua
@@ -60,9 +60,9 @@ function helper.stop_cluster(cluster)
 end
 
 t.before_suite(function()
-    box.cfg()
     fio.rmtree(helper.datadir)
     fio.mktree(helper.datadir)
+    box.cfg({work_dir = helper.datadir})
 end)
 
 return helper

--- a/cli/create/templates/cartridge/test/unit/sample_test.lua
+++ b/cli/create/templates/cartridge/test/unit/sample_test.lua
@@ -2,10 +2,10 @@ local t = require('luatest')
 local g = t.group('unit_sample')
 
 -- create your space here
-g.before_all = function() end
+g.before_all = (function() end)
 
 -- drop your space here
-g.after_all = function() end
+g.after_all = (function() end)
 
 g.test_sample = function()
     t.assert_equals(type(box.cfg), 'table')

--- a/cli/create/templates/cartridge/test/unit/sample_test.lua
+++ b/cli/create/templates/cartridge/test/unit/sample_test.lua
@@ -2,10 +2,10 @@ local t = require('luatest')
 local g = t.group('unit_sample')
 
 -- create your space here
-g.before_all = (function() end)
+g.before_all(function() end)
 
 -- drop your space here
-g.after_all = (function() end)
+g.after_all(function() end)
 
 g.test_sample = function()
     t.assert_equals(type(box.cfg), 'table')

--- a/cli/create/templates/cartridge/test/unit/sample_test.lua
+++ b/cli/create/templates/cartridge/test/unit/sample_test.lua
@@ -1,13 +1,11 @@
 local t = require('luatest')
 local g = t.group('unit_sample')
 
-g.before_all = function()
-    -- create your space here
-end
+-- create your space here
+g.before_all = function() end
 
-g.after_all = function()
-    -- drop your space here
-end
+-- drop your space here
+g.after_all = function() end
 
 g.test_sample = function()
     t.assert_equals(type(box.cfg), 'table')


### PR DESCRIPTION
Improved tests in ``cartridge create`` template:
* Tests are reduced to the form corresponding to luatest documentation
* ``before_suit`` now remove ``.xlog`` and ``.snap`` files

Closes #546 
