### PR TITLE
Pack in docker (on macos) now using TARANTOOL_SDK_PATH version file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   ``cartridge pack``), using the ``--preinst`` and ``--postinst`` flags.
 - ``cartridge pack`` generates ``VERSION.lua`` file with the current
   version of project.
-
 - Ability to specify fd limit in the systemd unit template
   (command ``cartridge pack``) in the ``systemd-unit-params.yml`` file.
+- ``cartridge pack`` now uses the VERSION file from the
+  ``TARANTOOL_SDK_PATH`` environment variable
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Ability to specify fd limit in the systemd unit template
   (command ``cartridge pack``) in the ``systemd-unit-params.yml`` file.
 - ``cartridge pack`` now uses the VERSION file from the
-  ``TARANTOOL_SDK_PATH`` environment variable
+  ``TARANTOOL_SDK_PATH`` environment variable on building in Docker
 
 ### Fixed
 

--- a/cli/pack/app_dir.go
+++ b/cli/pack/app_dir.go
@@ -208,7 +208,16 @@ func generateVersionFile(appDirPath string, ctx *context.Ctx) error {
 
 	// Tarantool version
 	if ctx.Tarantool.TarantoolIsEnterprise {
-		tarantoolVersionFilePath := filepath.Join(ctx.Tarantool.TarantoolDir, "VERSION")
+		var tarantoolVersionFilePath string
+
+		if ctx.Build.InDocker {
+			tarantoolVersionFilePath = filepath.Join(ctx.Build.SDKPath, "VERSION")
+		} else {
+			tarantoolVersionFilePath = filepath.Join(ctx.Tarantool.TarantoolDir, "VERSION")
+		}
+
+		log.Warnf("%s", tarantoolVersionFilePath)
+
 		tarantoolVersionFile, err := os.Open(tarantoolVersionFilePath)
 		defer tarantoolVersionFile.Close()
 

--- a/cli/pack/app_dir.go
+++ b/cli/pack/app_dir.go
@@ -208,14 +208,12 @@ func generateVersionFile(appDirPath string, ctx *context.Ctx) error {
 
 	// Tarantool version
 	if ctx.Tarantool.TarantoolIsEnterprise {
-		var tarantoolVersionFilePath string
-
+		tarantoolVersionFileDir := ctx.Tarantool.TarantoolDir
 		if ctx.Build.InDocker {
-			tarantoolVersionFilePath = filepath.Join(ctx.Build.SDKPath, "VERSION")
-		} else {
-			tarantoolVersionFilePath = filepath.Join(ctx.Tarantool.TarantoolDir, "VERSION")
+			tarantoolVersionFileDir = ctx.Build.SDKPath
 		}
 
+		tarantoolVersionFilePath := filepath.Join(tarantoolVersionFileDir, "VERSION")
 		tarantoolVersionFile, err := os.Open(tarantoolVersionFilePath)
 		defer tarantoolVersionFile.Close()
 

--- a/cli/pack/app_dir.go
+++ b/cli/pack/app_dir.go
@@ -216,8 +216,6 @@ func generateVersionFile(appDirPath string, ctx *context.Ctx) error {
 			tarantoolVersionFilePath = filepath.Join(ctx.Tarantool.TarantoolDir, "VERSION")
 		}
 
-		log.Warnf("%s", tarantoolVersionFilePath)
-
 		tarantoolVersionFile, err := os.Open(tarantoolVersionFilePath)
 		defer tarantoolVersionFile.Close()
 

--- a/cli/pack/pack_test.go
+++ b/cli/pack/pack_test.go
@@ -1,0 +1,60 @@
+package pack
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tarantool/cartridge-cli/cli/context"
+)
+
+func TestGenerateVersionFileNameEE(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	var ctx context.Ctx
+
+	ctx.Project.Name = "myapp"
+	ctx.Pack.VersionRelease = "123"
+	ctx.Tarantool.TarantoolIsEnterprise = true
+	ctx.Build.InDocker = true
+
+	dir, err := ioutil.TempDir("", "__temporary_sdk")
+	if err != nil {
+		assert.Equal(err, nil)
+	}
+	defer os.RemoveAll(dir)
+
+	ctx.Build.SDKPath = dir
+	versionFileLines := []string{
+		"TARANTOOL=2.8.1-0-ge2a1ec0c2-r409",
+		"TARANTOOL_SDK=2.8.1-0-ge2a1ec0c2-r409",
+	}
+
+	tmpVersion := filepath.Join(dir, "VERSION")
+	if err := ioutil.WriteFile(tmpVersion, []byte(strings.Join(versionFileLines, "\n")), 0666); err != nil {
+		assert.Equal(nil, err)
+	}
+
+	err = generateVersionFile("", &ctx)
+	assert.Equal(nil, err)
+
+	content, err := ioutil.ReadFile("VERSION")
+	if err != nil {
+		assert.Equal(nil, err)
+	}
+
+	for i, line := range strings.Split(string(content), "\n")[:3] {
+		if i == 0 { // app name
+			assert.Equal(fmt.Sprintf("%s=%s", ctx.Project.Name, ctx.Pack.VersionRelease), line)
+		} else { // tarantool versions
+			assert.Equal(versionFileLines[i-1], line)
+		}
+	}
+
+	os.Remove("VERSION")
+}

--- a/cli/pack/pack_test.go
+++ b/cli/pack/pack_test.go
@@ -24,9 +24,7 @@ func TestGenerateVersionFileNameEE(t *testing.T) {
 	ctx.Build.InDocker = true
 
 	dir, err := ioutil.TempDir("", "__temporary_sdk")
-	if err != nil {
-		assert.Equal(err, nil)
-	}
+	assert.Equal(err, nil)
 	defer os.RemoveAll(dir)
 
 	ctx.Build.SDKPath = dir
@@ -36,25 +34,16 @@ func TestGenerateVersionFileNameEE(t *testing.T) {
 	}
 
 	tmpVersion := filepath.Join(dir, "VERSION")
-	if err := ioutil.WriteFile(tmpVersion, []byte(strings.Join(versionFileLines, "\n")), 0666); err != nil {
-		assert.Equal(nil, err)
-	}
+	err = ioutil.WriteFile(tmpVersion, []byte(strings.Join(versionFileLines, "\n")), 0666)
+	assert.Equal(nil, err)
 
 	err = generateVersionFile("", &ctx)
+	defer os.Remove("VERSION")
 	assert.Equal(nil, err)
 
 	content, err := ioutil.ReadFile("VERSION")
-	if err != nil {
-		assert.Equal(nil, err)
-	}
+	assert.Equal(nil, err)
 
-	for i, line := range strings.Split(string(content), "\n")[:3] {
-		if i == 0 { // app name
-			assert.Equal(fmt.Sprintf("%s=%s", ctx.Project.Name, ctx.Pack.VersionRelease), line)
-		} else { // tarantool versions
-			assert.Equal(versionFileLines[i-1], line)
-		}
-	}
-
-	os.Remove("VERSION")
+	expFileLines := append([]string{fmt.Sprintf("%s=%s", ctx.Project.Name, ctx.Pack.VersionRelease)}, versionFileLines...)
+	assert.Equal(expFileLines, strings.Split(string(content), "\n")[:3])
 }


### PR DESCRIPTION
``cartridge pack`` now uses the VERSION file from the
``TARANTOOL_SDK_PATH`` environment variable on 
building in Docker. Closes #580 
