### PR TITLE
Fixed an incorrect error message when trying to bootstrap vshard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   stopping stateboard too, but ``cartridge stop`` stops all
   instances includes stateboard.
 - Fixed incorrect error message when trying to
-  ``cartridge replicasets bootstrap-vshard`` with out a configured cluster
+  ``cartridge replicasets bootstrap-vshard`` without a configured cluster
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   arguments, e.g. ``cartridge stop router`` doesn't lead to
   stopping stateboard too, but ``cartridge stop`` stops all
   instances includes stateboard.
+- Fixed incorrect error message when trying to
+  ``cartridge replicasets bootstrap-vshard`` with out a configured cluster
 
 ### Changed
 

--- a/cli/cluster/instances.go
+++ b/cli/cluster/instances.go
@@ -53,8 +53,12 @@ func ConnectToSomeJoinedInstance(ctx *context.Ctx) (*connector.Conn, error) {
 	}
 
 	joinedInstanceName, err := GetJoinedInstanceName(instancesConf, ctx)
-	if err != nil || joinedInstanceName == "" {
+	if err != nil {
 		return nil, fmt.Errorf("Failed to find some instance joined to cluster: %s", err)
+	}
+
+	if joinedInstanceName == "" {
+		return nil, fmt.Errorf("No instances joined to cluster found")
 	}
 
 	conn, err := ConnectToInstance(joinedInstanceName, ctx)

--- a/cli/replicasets/common.go
+++ b/cli/replicasets/common.go
@@ -1,1 +1,0 @@
-package replicasets

--- a/cli/replicasets/membership.go
+++ b/cli/replicasets/membership.go
@@ -1,1 +1,0 @@
-package replicasets

--- a/test/integration/replicasets/test_bootstrap_vshard.py
+++ b/test/integration/replicasets/test_bootstrap_vshard.py
@@ -46,3 +46,16 @@ def test_no_vshard_roles_avaliable(cartridge_cmd, project_with_replicaset_no_rol
     assert rc == 1
 
     assert 'No remotes with role "vshard-router" available' in output
+
+
+def test_boostrap_vshard_without_setup(cartridge_cmd, project_with_instances):
+    project = project_with_instances.project
+
+    # bootstrap vshard without joined instances
+    cmd = [
+        cartridge_cmd, 'replicasets', 'bootstrap-vshard',
+    ]
+
+    rc, output = run_command_and_get_output(cmd, cwd=project.path)
+    assert rc == 1
+    assert "No joined to cluster instances found" in output

--- a/test/integration/replicasets/test_bootstrap_vshard.py
+++ b/test/integration/replicasets/test_bootstrap_vshard.py
@@ -58,4 +58,4 @@ def test_boostrap_vshard_without_setup(cartridge_cmd, project_with_instances):
 
     rc, output = run_command_and_get_output(cmd, cwd=project.path)
     assert rc == 1
-    assert "No joined to cluster instances found" in output
+    assert "No instances joined to cluster found" in output

--- a/test/integration/replicasets/test_list_replicasets.py
+++ b/test/integration/replicasets/test_list_replicasets.py
@@ -50,7 +50,7 @@ def test_no_joined_instances(cartridge_cmd, project_with_instances):
 
     rc, output = run_command_and_get_output(cmd, cwd=project.path)
     assert rc == 1
-    assert "No joined to cluster instances found" in output
+    assert "No instances joined to cluster found" in output
 
 
 def test_list(cartridge_cmd, project_with_instances):

--- a/test/integration/replicasets/test_list_replicasets.py
+++ b/test/integration/replicasets/test_list_replicasets.py
@@ -50,7 +50,7 @@ def test_no_joined_instances(cartridge_cmd, project_with_instances):
 
     rc, output = run_command_and_get_output(cmd, cwd=project.path)
     assert rc == 1
-    assert "Failed to find some instance joined to cluster" in output
+    assert "No joined to cluster instances found" in output
 
 
 def test_list(cartridge_cmd, project_with_instances):


### PR DESCRIPTION
Fixed an incorrect error message when trying to bootstrap 
vshard with out a configured cluster. Closes #595 
