### PR TITLE
Cartridge errors in the ``replicasets`` command are now more readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   instances includes stateboard.
 - Fixed incorrect error message when trying to
   ``cartridge replicasets bootstrap-vshard`` without a configured cluster
+- Cartridge errors in the ``replicasets`` command are now more readable.
 
 ### Changed
 

--- a/cli/replicasets/lua/bootstrap_vshard_body.lua
+++ b/cli/replicasets/lua/bootstrap_vshard_body.lua
@@ -6,4 +6,9 @@ if bootstrap_function == nil then
 end
 
 local ok, err = bootstrap_function()
+
+if err ~= nil then
+    err = err.err
+end
+
 assert(ok, tostring(err))

--- a/cli/replicasets/lua/edit_instance_body.lua
+++ b/cli/replicasets/lua/edit_instance_body.lua
@@ -6,4 +6,8 @@ local res, err = cartridge.admin_edit_topology({
     servers = servers,
 })
 
+if err ~= nil then
+    err = err.err
+end
+
 assert(err == nil, tostring(err))

--- a/cli/replicasets/lua/edit_replicasets_body_template.lua
+++ b/cli/replicasets/lua/edit_replicasets_body_template.lua
@@ -8,6 +8,10 @@ local res, err = cartridge.admin_edit_topology({
     replicasets = replicasets,
 })
 
+if err ~= nil then
+    err = err.err
+end
+
 assert(err == nil, tostring(err))
 
 local replicasets = res.replicasets

--- a/cli/replicasets/lua/get_topology_replicasets_body_template.lua
+++ b/cli/replicasets/lua/get_topology_replicasets_body_template.lua
@@ -5,6 +5,11 @@ local cartridge = require('cartridge')
 local topology_replicasets = {}
 
 local replicasets, err = cartridge.admin_get_replicasets()
+
+if err ~= nil then
+    err = err.err
+end
+
 assert(err == nil, tostring(err))
 
 for _, replicaset in pairs(replicasets) do

--- a/test/integration/replicasets/test_setup.py
+++ b/test/integration/replicasets/test_setup.py
@@ -267,7 +267,7 @@ def test_setup_bootstrap_vshard(project_with_instances, cartridge_cmd):
     assert rc == 1
 
     assert "router... CREATED" in output
-    assert "Bootstrapping vshard failed: Sharding config is empty" in output
+    assert "Sharding config is empty" in output
 
     assert_replicasets(rpl_cfg, admin_api_url)
     assert not is_vshard_bootstrapped(admin_api_url)


### PR DESCRIPTION
Closes #599 
