### PR TITLE
pack: ignore data, run and log directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Updated `metrics` to `0.12.0` in application template.
 - Updated `luatest` to `0.5.6` in application template.
 - Updated `luacheck` to `0.26.0` in application template.
-
+- ``cartridge pack`` command now ignores the contents of ``run_dir``, ``data_dir``,
+  ``log_dir`` directories (if default or set with ``.cartridge.yml``).
 
 ### Fixed
 

--- a/cli/project/files.go
+++ b/cli/project/files.go
@@ -246,7 +246,7 @@ func SetLocalRunningPaths(ctx *context.Ctx) error {
 		GetAbs:          true,
 	})
 	if err != nil {
-		return fmt.Errorf("Failed to detect data dir: %s", err)
+		return fmt.Errorf("Failed to detect log dir: %s", err)
 	}
 
 	// set entrypoints

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -12,7 +12,7 @@ from clusterwide_conf import (ClusterwideConfig, get_expelled_srv_conf,
                               get_one_file_conf, get_rpl_conf, get_srv_conf,
                               get_topology_conf)
 from project import (INIT_ADMIN_FUNCS_FILEPATH, INIT_IGNORE_SIGTERM_FILEPATH,
-                     INIT_NO_CARTRIDGE_FILEPATH, Project,
+                     INIT_NO_CARTRIDGE_FILEPATH, RUNDIR_CLI_CONF, Project,
                      add_dependency_submodule, patch_cartridge_proc_titile,
                      remove_all_dependencies, remove_dependency,
                      remove_project_file, replace_project_file)
@@ -172,6 +172,24 @@ def project_without_dependencies(cartridge_cmd, short_tmpdir):
 
     # This is necessary, because default app config has parameter `stateboard: true`
     remove_project_file(project, '.cartridge.yml')
+
+    replace_project_file(project, 'init.lua', INIT_NO_CARTRIDGE_FILEPATH)
+    replace_project_file(project, 'stateboard.init.lua', INIT_NO_CARTRIDGE_FILEPATH)
+
+    return project
+
+
+##############################
+# Project custom rundir
+##############################
+# Same as "Project without dependencies", but with custom rundir
+@pytest.fixture(scope="function")
+def project_custom_rundir(cartridge_cmd, short_tmpdir):
+    project = Project(cartridge_cmd, 'empty-project', short_tmpdir, 'cartridge')
+
+    remove_all_dependencies(project)
+
+    replace_project_file(project, '.cartridge.yml', RUNDIR_CLI_CONF)
 
     replace_project_file(project, 'init.lua', INIT_NO_CARTRIDGE_FILEPATH)
     replace_project_file(project, 'stateboard.init.lua', INIT_NO_CARTRIDGE_FILEPATH)

--- a/test/files/rundir.cartridge.yml
+++ b/test/files/rundir.cartridge.yml
@@ -1,0 +1,1 @@
+run-dir: rundir

--- a/test/project.py
+++ b/test/project.py
@@ -14,6 +14,7 @@ INIT_PRINT_ENV_FILEPATH = os.path.join(FILES_DIR, 'init_print_environment.lua')
 INIT_ROLES_RELOAD_ALLOWED_FILEPATH = os.path.join(FILES_DIR, 'init_roles_reload_allowed.lua')
 INIT_CHECK_PASSED_PARAMS = os.path.join(FILES_DIR, 'init_check_passed_params.lua')
 ROUTER_WITH_EVAL_FILEPATH = os.path.join(FILES_DIR, 'router_with_eval.lua')
+RUNDIR_CLI_CONF = os.path.join(FILES_DIR, 'rundir.cartridge.yml')
 
 CLI_CONF = '.cartridge.yml'
 


### PR DESCRIPTION
Reworked by @DifferentialOrange

``cartridge pack`` command now ignores the contents of ``run_dir``,
``data_dir``, ``log_dir`` directories, if default directories used or
set with ``.cartridge.yml``. Since cartridge-cli do not store info on
flags between runs, if flags like ``--run-dir`` were used, contents
of these directories will not be ignored.

Closes #494