### PR TITLE
Replace x/sys for go 1.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,3 +42,5 @@ require (
 replace github.com/docker/docker/internal/testutil => gotest.tools/v3 v3.0.0
 
 replace github.com/c-bata/go-prompt => github.com/tarantool/go-prompt v0.2.6-tarantool
+
+replace golang.org/x/sys => golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2

--- a/go.sum
+++ b/go.sum
@@ -847,6 +847,8 @@ golang.org/x/sys v0.0.0-20210217105451-b926d437f341/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2 h1:c8PlLMqBbOHoqtjteWm5/kbe6rNY2pbRfbIMVnepueo=
+golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
This updates x/sys for the sdk and therefor adds support for go 1.17. More info here Homebrew/homebrew-core#83413

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Closes #???
