### PR TITLE
Fix tarantool version regexp

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,7 +105,9 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        sdk-version: ["2.6.1-0-gcfe0d1a-r357"]
+        sdk-version:
+          - "2.8.2-r420"
+          - "2.10.0-beta1-r420"
       fail-fast: false
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,9 @@ jobs:
     strategy:
       matrix:
         tarantool-version: ["1.10", "2.6"]
+        nightly: [false]
+        include:
+        - {tarantool: "pre-release/series-2", nightly: true}
       fail-fast: false
     steps:
       - uses: actions/checkout@master
@@ -47,6 +50,7 @@ jobs:
         uses: tarantool/setup-tarantool@v1
         with:
           tarantool-version: '${{ matrix.tarantool-version }}'
+          nightly-build: ${{ matrix.nightly }}
 
       - name: Cache docker images
         uses: satackey/action-docker-layer-caching@v0.0.11

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
         tarantool-version: ["1.10", "2.6"]
         nightly: [false]
         include:
-        - {tarantool: "pre-release/series-2", nightly: true}
+        - {tarantool-version: "pre-release/series-2", nightly: true}
       fail-fast: false
     steps:
       - uses: actions/checkout@master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Cartridge errors in the ``replicasets`` command are now more readable.
+- Compatibility with new Tarantool release policy (2.10+).
 
 ## [2.10.0] - 2021-07-28
 

--- a/cli/common/tarantool.go
+++ b/cli/common/tarantool.go
@@ -18,7 +18,7 @@ var (
 )
 
 func init() {
-	tarantoolVersionRegexp = regexp.MustCompile(`\d+\.\d+\.\d+-\d+-\w+`)
+	tarantoolVersionRegexp = regexp.MustCompile(`\d+\.\d+\.\d+[-\w]*`)
 }
 
 // GetTarantoolDir returns Tarantool executable directory

--- a/cli/common/tarantool_test.go
+++ b/cli/common/tarantool_test.go
@@ -1,0 +1,58 @@
+package common
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTarantoolVersion(t *testing.T) {
+	assert := assert.New(t)
+
+	var err error
+
+	dir, err := ioutil.TempDir(os.TempDir(), "temp")
+	assert.Equal(err, nil)
+	defer os.RemoveAll(dir)
+
+	expectedTarantoolVersions := []string{
+		"2.10.0-beta1-0-g7da4b1438",
+		"2.10.0-beta1",
+		"2.10.0",
+
+		"2.8.1-0-ge2a1ec0c2-r399",
+		"2.8.1-0-ge2a1ec0c2-r399-macos",
+
+		"2.8.2-r420",
+		"2.8.2-r420-macos",
+
+		"2.10.0-beta1-r420",
+		"2.10.0-beta1-r420-macos",
+
+		"2.10.2-149-g1575f3c07-dev",
+		"3.0.0-alpha1-14-gxxxxxxxxx-dev",
+		"3.0.0-entrypoint-17-gxxxxxxxxx-dev",
+		"3.1.2-5-gxxxxxxxxx-dev",
+
+		"3.0.0-alpha1",
+		"3.0.0-alpha2",
+		"3.0.0-beta1",
+		"3.0.0-beta2",
+		"3.0.0-rc1",
+		"3.0.0-rc2",
+	}
+
+	for _, version := range expectedTarantoolVersions {
+		content := []byte(fmt.Sprintf("#!/bin/sh\necho %s", version))
+		err = ioutil.WriteFile(filepath.Join(dir, "tarantool"), content, 0777)
+		assert.Nil(err)
+
+		tarantoolVersion, err := GetTarantoolVersion(dir)
+		assert.Nil(err)
+		assert.Equal(tarantoolVersion, version)
+	}
+}

--- a/magefile.go
+++ b/magefile.go
@@ -107,7 +107,7 @@ func Lint() error {
 	}
 
 	fmt.Println("Running flake8...")
-	if err := sh.RunV(py3Exe, "-m", "flake8"); err != nil {
+	if err := sh.RunV(py3Exe, "-m", "flake8", "test"); err != nil {
 		return err
 	}
 

--- a/test/integration/pack/test_pack.py
+++ b/test/integration/pack/test_pack.py
@@ -104,7 +104,7 @@ def deb_archive(cartridge_cmd, tmpdir, light_project, request):
 
 @pytest.fixture(scope="session")
 def tarantool_versions():
-    min_deb_version = re.findall(r'\d+\.\d+\.\d+-\d+-\S+', tarantool_version())[0]
+    min_deb_version = re.findall(r'\d+\.\d+\.\d+[-\w]*', tarantool_version())[0]
     max_deb_version = str(int(re.findall(r'\d+', tarantool_version())[0]) + 1)
     min_rpm_version = re.findall(r'\d+\.\d+\.\d+', tarantool_version())[0]
     max_rpm_version = max_deb_version  # Their format is the same


### PR DESCRIPTION
According to the new release policy [1] tarantool version may have a
string suffix. This patch makes CLI aware of it.

[1] https://github.com/tarantool/tarantool/discussions/6182

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] ~~Documentation~~

Closes #619
