### PR TITLE
test: add isort in flake8 and fix imports order

### DIFF
--- a/test/clusterwide_conf.py
+++ b/test/clusterwide_conf.py
@@ -1,7 +1,7 @@
-import yaml
-import os
 import copy
+import os
 
+import yaml
 from utils import write_conf
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,37 +1,28 @@
-import py
-import tempfile
-import docker
 import os
-import subprocess
 import platform
 import shutil
-import yaml
+import subprocess
+import tempfile
+
+import docker
+import py
 import pytest
-
-from project import Project
-from project import remove_dependency
-from project import add_dependency_submodule
-from project import remove_all_dependencies, remove_project_file
-from project import replace_project_file
-from project import patch_cartridge_proc_titile
-
-from clusterwide_conf import ClusterwideConfig
-from clusterwide_conf import get_srv_conf, get_expelled_srv_conf
-from clusterwide_conf import get_rpl_conf
-from clusterwide_conf import get_topology_conf, get_one_file_conf
-
-from utils import Cli, Instance, ProjectWithTopology
-from utils import start_instances
-from utils import build_image
-
-from project import INIT_NO_CARTRIDGE_FILEPATH, INIT_IGNORE_SIGTERM_FILEPATH
-from project import INIT_ADMIN_FUNCS_FILEPATH
+import yaml
+from clusterwide_conf import (ClusterwideConfig, get_expelled_srv_conf,
+                              get_one_file_conf, get_rpl_conf, get_srv_conf,
+                              get_topology_conf)
+from project import (INIT_ADMIN_FUNCS_FILEPATH, INIT_IGNORE_SIGTERM_FILEPATH,
+                     INIT_NO_CARTRIDGE_FILEPATH, Project,
+                     add_dependency_submodule, patch_cartridge_proc_titile,
+                     remove_all_dependencies, remove_dependency,
+                     remove_project_file, replace_project_file)
+from utils import (Cli, Instance, ProjectWithTopology, build_image,
+                   start_instances)
 
 
 # ########
 # Fixtures
 # ########
-
 def get_tmpdir(request):
     tmpdir = py.path.local(tempfile.mkdtemp())
     request.addfinalizer(lambda: tmpdir.remove(rec=1))

--- a/test/e2e/test_deb.py
+++ b/test/e2e/test_deb.py
@@ -1,19 +1,14 @@
-import pytest
-import subprocess
 import os
 import shutil
+import subprocess
+
+import pytest
 import yaml
-
-from utils import Archive, find_archive
-from utils import tarantool_short_version, tarantool_enterprise_is_used
-from utils import build_image
-from utils import delete_image
-from utils import check_systemd_service
-from utils import ProjectContainer, run_command_on_container
-from utils import check_contains_regular_file
-
-from project import replace_project_file
-from project import INIT_CHECK_PASSED_PARAMS
+from project import INIT_CHECK_PASSED_PARAMS, replace_project_file
+from utils import (Archive, ProjectContainer, build_image,
+                   check_contains_regular_file, check_systemd_service,
+                   delete_image, find_archive, run_command_on_container,
+                   tarantool_enterprise_is_used, tarantool_short_version)
 
 
 # ########

--- a/test/e2e/test_docker.py
+++ b/test/e2e/test_docker.py
@@ -1,8 +1,8 @@
-import pytest
 import subprocess
 
-from utils import Image, find_image, delete_image
-from utils import InstanceContainer, examine_application_instance_container
+import pytest
+from utils import (Image, InstanceContainer, delete_image,
+                   examine_application_instance_container, find_image)
 
 
 # ########

--- a/test/e2e/test_rpm.py
+++ b/test/e2e/test_rpm.py
@@ -1,15 +1,12 @@
-import pytest
-import subprocess
 import os
 import shutil
+import subprocess
 
-from utils import Archive, find_archive
-from utils import tarantool_short_version, tarantool_enterprise_is_used
-from utils import build_image
-from utils import delete_image
-from utils import check_systemd_service
-from utils import ProjectContainer, run_command_on_container
-from utils import check_contains_regular_file
+import pytest
+from utils import (Archive, ProjectContainer, build_image,
+                   check_contains_regular_file, check_systemd_service,
+                   delete_image, find_archive, run_command_on_container,
+                   tarantool_enterprise_is_used, tarantool_short_version)
 
 
 # ########

--- a/test/e2e/test_tgz.py
+++ b/test/e2e/test_tgz.py
@@ -1,19 +1,16 @@
-import os
-import subprocess
 import gzip
 import json
-import requests
+import os
+import subprocess
+
 import pytest
-
-from utils import tarantool_enterprise_is_used
-from utils import Archive, find_archive
-from utils import InstanceContainer
-from utils import examine_application_instance_container, run_command_on_container
-from utils import tarantool_short_version
-from utils import build_image
-from utils import delete_image
-
-from project import ROUTER_WITH_EVAL_FILEPATH, INIT_ROLES_RELOAD_ALLOWED_FILEPATH, replace_project_file
+import requests
+from project import (INIT_ROLES_RELOAD_ALLOWED_FILEPATH,
+                     ROUTER_WITH_EVAL_FILEPATH, replace_project_file)
+from utils import (Archive, InstanceContainer, build_image, delete_image,
+                   examine_application_instance_container, find_archive,
+                   run_command_on_container, tarantool_enterprise_is_used,
+                   tarantool_short_version)
 
 
 # ########

--- a/test/examples/test_getting_started.py
+++ b/test/examples/test_getting_started.py
@@ -1,12 +1,11 @@
 import subprocess
-import yaml
+
 import requests
-
-from utils import check_instances_running
-from utils import create_replicaset, wait_for_replicaset_is_healthy, get_replicaset_roles
-from utils import bootstrap_vshard
-
+import yaml
 from project import patch_cartridge_proc_titile
+from utils import (bootstrap_vshard, check_instances_running,
+                   create_replicaset, get_replicaset_roles,
+                   wait_for_replicaset_is_healthy)
 
 
 # #######

--- a/test/integration/admin/test_call.py
+++ b/test/integration/admin/test_call.py
@@ -1,8 +1,6 @@
 import pytest
-
-from utils import run_command_and_get_output
-from utils import get_log_lines
-from utils import get_admin_connection_params
+from utils import (get_admin_connection_params, get_log_lines,
+                   run_command_and_get_output)
 
 
 @pytest.mark.parametrize('connection_type', ['find-socket', 'connect', 'instance'])

--- a/test/integration/admin/test_common.py
+++ b/test/integration/admin/test_common.py
@@ -1,7 +1,7 @@
 import os
-import pytest
 import re
 
+import pytest
 from utils import run_command_and_get_output
 
 simple_args = {

--- a/test/integration/admin/test_default.py
+++ b/test/integration/admin/test_default.py
@@ -1,12 +1,9 @@
-import pytest
 import subprocess
 
-from utils import run_command_and_get_output
-from utils import start_instances
-from utils import get_admin_connection_params
-from utils import get_log_lines
-
+import pytest
 from project import patch_cartridge_proc_titile
+from utils import (get_admin_connection_params, get_log_lines,
+                   run_command_and_get_output, start_instances)
 
 
 @pytest.fixture(scope="function")

--- a/test/integration/admin/test_help.py
+++ b/test/integration/admin/test_help.py
@@ -1,8 +1,6 @@
 import pytest
-
-from utils import run_command_and_get_output
-from utils import get_log_lines
-from utils import get_admin_connection_params
+from utils import (get_admin_connection_params, get_log_lines,
+                   run_command_and_get_output)
 
 
 @pytest.mark.parametrize('connection_type', ['find-socket', 'connect', 'instance'])

--- a/test/integration/admin/test_list.py
+++ b/test/integration/admin/test_list.py
@@ -1,8 +1,6 @@
 import pytest
-
-from utils import run_command_and_get_output
-from utils import get_log_lines
-from utils import get_admin_connection_params
+from utils import (get_admin_connection_params, get_log_lines,
+                   run_command_and_get_output)
 
 
 @pytest.mark.parametrize('connection_type', ['find-socket', 'connect', 'instance'])

--- a/test/integration/cli/test_completion.py
+++ b/test/integration/cli/test_completion.py
@@ -1,5 +1,5 @@
-import subprocess
 import os
+import subprocess
 
 
 def test_completion(cartridge_cmd, tmpdir):

--- a/test/integration/cli/test_version.py
+++ b/test/integration/cli/test_version.py
@@ -1,7 +1,8 @@
-import pytest
 import subprocess
-from utils import run_command_and_get_output
+
+import pytest
 from project import remove_project_file
+from utils import run_command_and_get_output
 
 
 @pytest.mark.parametrize('version_cmd', ['version', '-v', '--version'])

--- a/test/integration/connect/conftest.py
+++ b/test/integration/connect/conftest.py
@@ -1,14 +1,11 @@
 import os
 import subprocess
+
 import pytest
-
-from project import Project
-from project import patch_cartridge_proc_titile
-from project import remove_dependency
-from project import replace_project_file, remove_project_file
-from project import INIT_NO_CARTRIDGE_FILEPATH
-
-from utils import ProjectWithTopology, Instance
+from project import (INIT_NO_CARTRIDGE_FILEPATH, Project,
+                     patch_cartridge_proc_titile, remove_dependency,
+                     remove_project_file, replace_project_file)
+from utils import Instance, ProjectWithTopology
 
 
 @pytest.fixture(scope="session")

--- a/test/integration/connect/test_connect.py
+++ b/test/integration/connect/test_connect.py
@@ -1,8 +1,7 @@
-from integration.connect.utils import assert_successful_piped_commands
-from integration.connect.utils import assert_error
-from integration.connect.utils import assert_exited_piped_commands
-from integration.connect.utils import assert_session_push_commands
-
+from integration.connect.utils import (assert_error,
+                                       assert_exited_piped_commands,
+                                       assert_session_push_commands,
+                                       assert_successful_piped_commands)
 from utils import DEFAULT_CLUSTER_COOKIE
 
 

--- a/test/integration/connect/test_enter.py
+++ b/test/integration/connect/test_enter.py
@@ -1,7 +1,7 @@
-from integration.connect.utils import assert_successful_piped_commands
-from integration.connect.utils import assert_exited_piped_commands
-from integration.connect.utils import assert_session_push_commands
-from integration.connect.utils import assert_error
+from integration.connect.utils import (assert_error,
+                                       assert_exited_piped_commands,
+                                       assert_session_push_commands,
+                                       assert_successful_piped_commands)
 
 
 def test_bad_instance_name(cartridge_cmd, project_with_instances):

--- a/test/integration/create/test_create.py
+++ b/test/integration/create/test_create.py
@@ -1,11 +1,10 @@
-import subprocess
-import pytest
 import os
 import stat
+import subprocess
 
+import pytest
 from project import Project
-from utils import run_command_and_get_output
-from utils import recursive_listdir
+from utils import recursive_listdir, run_command_and_get_output
 
 
 @pytest.fixture(scope="module")

--- a/test/integration/failover/test_failover.py
+++ b/test/integration/failover/test_failover.py
@@ -1,12 +1,9 @@
 import os
+
 import yaml
-
-from integration.failover.utils import (
-    get_etcd2_failover_info,
-    get_eventual_failover_info,
-    get_stateboard_failover_info,
-)
-
+from integration.failover.utils import (get_etcd2_failover_info,
+                                        get_eventual_failover_info,
+                                        get_stateboard_failover_info)
 from utils import run_command_and_get_output
 
 

--- a/test/integration/failover/test_status.py
+++ b/test/integration/failover/test_status.py
@@ -1,10 +1,7 @@
-from integration.failover.utils import (
-    get_etcd2_failover_info,
-    get_eventual_failover_info,
-    get_stateboard_failover_info,
-    assert_mode_and_params_state,
-)
-
+from integration.failover.utils import (assert_mode_and_params_state,
+                                        get_etcd2_failover_info,
+                                        get_eventual_failover_info,
+                                        get_stateboard_failover_info)
 from utils import run_command_and_get_output
 
 

--- a/test/integration/failover/utils.py
+++ b/test/integration/failover/utils.py
@@ -1,9 +1,5 @@
 import requests
-
-from utils import (
-    get_admin_url,
-    get_response_data
-)
+from utils import get_admin_url, get_response_data
 
 
 def get_stateboard_failover_info():

--- a/test/integration/pack/test_pack.py
+++ b/test/integration/pack/test_pack.py
@@ -1,33 +1,28 @@
+import hashlib
 import os
-import subprocess
-import tarfile
+import platform
 import re
 import shutil
 import stat
-import platform
-import hashlib
-import yaml
+import subprocess
+import tarfile
+
 import pytest
-
-from utils import tarantool_enterprise_is_used
-from utils import Archive, find_archive
-from utils import recursive_listdir
-from utils import assert_distribution_dir_contents
-from utils import assert_filemodes
-from utils import assert_files_mode_and_owner_rpm
-from utils import validate_version_file
-from utils import check_package_files
-from utils import assert_tarantool_dependency_deb, assert_dependencies_deb
-from utils import assert_tarantool_dependency_rpm, assert_dependencies_rpm
-from utils import assert_pre_and_post_install_scripts_rpm, assert_pre_and_post_install_scripts_deb
-from utils import run_command_and_get_output
-from utils import get_rockspec_path
-from utils import tarantool_version
-from utils import extract_app_files, extract_rpm, extract_deb
-from utils import clear_project_rocks_cache, get_rocks_cache_path
-from utils import check_param_in_unit_files
-
-from project import set_and_return_whoami_on_build, replace_project_file, remove_project_file
+import yaml
+from project import (remove_project_file, replace_project_file,
+                     set_and_return_whoami_on_build)
+from utils import (Archive, assert_dependencies_deb, assert_dependencies_rpm,
+                   assert_distribution_dir_contents, assert_filemodes,
+                   assert_files_mode_and_owner_rpm,
+                   assert_pre_and_post_install_scripts_deb,
+                   assert_pre_and_post_install_scripts_rpm,
+                   assert_tarantool_dependency_deb,
+                   assert_tarantool_dependency_rpm, check_package_files,
+                   check_param_in_unit_files, clear_project_rocks_cache,
+                   extract_app_files, extract_deb, extract_rpm, find_archive,
+                   get_rocks_cache_path, get_rockspec_path, recursive_listdir,
+                   run_command_and_get_output, tarantool_enterprise_is_used,
+                   tarantool_version, validate_version_file)
 
 
 # ########

--- a/test/integration/pack/test_pack_docker.py
+++ b/test/integration/pack/test_pack_docker.py
@@ -1,21 +1,16 @@
-import pytest
 import os
 import re
+import shutil
 import subprocess
 import tarfile
 import time
-import shutil
 
-from utils import tarantool_version
-from utils import tarantool_enterprise_is_used
-from utils import recursive_listdir
-from utils import assert_distribution_dir_contents
-from utils import assert_filemodes
-from utils import run_command_and_get_output
-from utils import Image, find_image, delete_image
-from utils import wait_for_container_start
-
+import pytest
 from project import INIT_PRINT_ENV_FILEPATH, replace_project_file
+from utils import (Image, assert_distribution_dir_contents, assert_filemodes,
+                   delete_image, find_image, recursive_listdir,
+                   run_command_and_get_output, tarantool_enterprise_is_used,
+                   tarantool_version, wait_for_container_start)
 
 
 # #######

--- a/test/integration/repair/test_repair.py
+++ b/test/integration/repair/test_repair.py
@@ -1,11 +1,9 @@
 import os
 import re
+
 import pytest
-
-from utils import run_command_and_get_output
-from utils import get_logs
-
 from clusterwide_conf import write_instances_topology_conf
+from utils import get_logs, run_command_and_get_output
 
 APPNAME = 'myapp'
 OTHER_APP_NAME = 'other-app'

--- a/test/integration/repair/test_repair_diverged_config.py
+++ b/test/integration/repair/test_repair_diverged_config.py
@@ -1,22 +1,14 @@
 import os
+
 import pytest
-
-from utils import run_command_and_get_output
-from utils import get_logs
-from utils import assert_ok_for_all_instances
-from utils import assert_ok_for_instances_group
-from clusterwide_conf import assert_conf_not_changed
-
-from clusterwide_conf import get_srv_conf
-from clusterwide_conf import get_rpl_conf
-from clusterwide_conf import get_topology_conf
-from clusterwide_conf import get_conf_with_new_uri
-from clusterwide_conf import get_conf_with_removed_instance
-from clusterwide_conf import get_conf_with_new_leader
-from clusterwide_conf import ClusterwideConfig
-from clusterwide_conf import write_instances_topology_conf
-from clusterwide_conf import assert_conf_changed
-
+from clusterwide_conf import (ClusterwideConfig, assert_conf_changed,
+                              assert_conf_not_changed,
+                              get_conf_with_new_leader, get_conf_with_new_uri,
+                              get_conf_with_removed_instance, get_rpl_conf,
+                              get_srv_conf, get_topology_conf,
+                              write_instances_topology_conf)
+from utils import (assert_ok_for_all_instances, assert_ok_for_instances_group,
+                   get_logs, run_command_and_get_output)
 
 APPNAME = 'myapp'
 

--- a/test/integration/repair/test_repair_list_topology.py
+++ b/test/integration/repair/test_repair_list_topology.py
@@ -1,13 +1,10 @@
-import os
 import copy
+import os
 
-from utils import run_command_and_get_output
-from utils import get_logs
-from utils import assert_ok_for_instances_group
-from clusterwide_conf import assert_conf_not_changed
-
-from clusterwide_conf import write_instances_topology_conf
-
+from clusterwide_conf import (assert_conf_not_changed,
+                              write_instances_topology_conf)
+from utils import (assert_ok_for_instances_group, get_logs,
+                   run_command_and_get_output)
 
 APPNAME = 'myapp'
 OTHER_APP_NAME = 'other-app'

--- a/test/integration/repair/test_repair_reload.py
+++ b/test/integration/repair/test_repair_reload.py
@@ -1,16 +1,12 @@
 import subprocess
-import requests
+
 import pytest
-
-from utils import check_instances_running
-from utils import check_instances_stopped
-from utils import write_conf
-from utils import create_replicaset
-from utils import run_command_and_get_output
-from utils import wait_for_replicaset_is_healthy
-
-from project import patch_cartridge_proc_titile
-from project import patch_cartridge_returned_version
+import requests
+from project import (patch_cartridge_proc_titile,
+                     patch_cartridge_returned_version)
+from utils import (check_instances_running, check_instances_stopped,
+                   create_replicaset, run_command_and_get_output,
+                   wait_for_replicaset_is_healthy, write_conf)
 
 
 def get_replicaset(admin_api_url, replicaset_uuid):

--- a/test/integration/repair/test_repair_remove_instance.py
+++ b/test/integration/repair/test_repair_remove_instance.py
@@ -1,17 +1,12 @@
-import os
 import copy
+import os
+
 import pytest
-
-from utils import run_command_and_get_output
-from utils import get_logs
-from utils import assert_ok_for_all_instances
-from utils import assert_for_instances_group
-
-from clusterwide_conf import write_instances_topology_conf
-from clusterwide_conf import assert_conf_changed
-from clusterwide_conf import assert_conf_not_changed
-from clusterwide_conf import get_conf_with_removed_instance
-
+from clusterwide_conf import (assert_conf_changed, assert_conf_not_changed,
+                              get_conf_with_removed_instance,
+                              write_instances_topology_conf)
+from utils import (assert_for_instances_group, assert_ok_for_all_instances,
+                   get_logs, run_command_and_get_output)
 
 APPNAME = 'myapp'
 OTHER_APP_NAME = 'other-app'

--- a/test/integration/repair/test_repair_set_leader.py
+++ b/test/integration/repair/test_repair_set_leader.py
@@ -1,15 +1,11 @@
-import os
 import copy
+import os
+
 import pytest
-
-from utils import run_command_and_get_output
-from utils import get_logs
-from utils import assert_for_instances_group
-from utils import assert_ok_for_all_instances
-
-from clusterwide_conf import write_instances_topology_conf
-from clusterwide_conf import assert_conf_changed
-from clusterwide_conf import assert_conf_not_changed
+from clusterwide_conf import (assert_conf_changed, assert_conf_not_changed,
+                              write_instances_topology_conf)
+from utils import (assert_for_instances_group, assert_ok_for_all_instances,
+                   get_logs, run_command_and_get_output)
 
 APPNAME = 'myapp'
 OTHER_APP_NAME = 'other-app'

--- a/test/integration/repair/test_repair_set_uri.py
+++ b/test/integration/repair/test_repair_set_uri.py
@@ -1,16 +1,11 @@
 import os
+
 import pytest
-
-from utils import run_command_and_get_output
-from utils import get_logs
-from utils import assert_ok_for_all_instances
-from utils import assert_for_instances_group
-
-from clusterwide_conf import write_instances_topology_conf
-from clusterwide_conf import assert_conf_changed
-from clusterwide_conf import assert_conf_not_changed
-from clusterwide_conf import get_conf_with_new_uri
-
+from clusterwide_conf import (assert_conf_changed, assert_conf_not_changed,
+                              get_conf_with_new_uri,
+                              write_instances_topology_conf)
+from utils import (assert_for_instances_group, assert_ok_for_all_instances,
+                   get_logs, run_command_and_get_output)
 
 APPNAME = 'myapp'
 OTHER_APP_NAME = 'other-app'

--- a/test/integration/replicasets/conftest.py
+++ b/test/integration/replicasets/conftest.py
@@ -1,15 +1,12 @@
-import subprocess
-import pytest
 import os
+import subprocess
 
-from utils import run_command_and_get_output
-from utils import ProjectWithTopology, Replicaset, Instance
-
-from project import Project
-from project import patch_cartridge_proc_titile
-from project import configure_vshard_groups
-from project import add_custom_roles
-from project import patch_cartridge_version_in_rockspec, remove_project_file
+import pytest
+from project import (Project, add_custom_roles, configure_vshard_groups,
+                     patch_cartridge_proc_titile,
+                     patch_cartridge_version_in_rockspec, remove_project_file)
+from utils import (Instance, ProjectWithTopology, Replicaset,
+                   run_command_and_get_output)
 
 
 @pytest.fixture(scope="session", params=["new-cartridge", "old-cartridge"])

--- a/test/integration/replicasets/test_bootstrap_vshard.py
+++ b/test/integration/replicasets/test_bootstrap_vshard.py
@@ -1,6 +1,5 @@
-from utils import run_command_and_get_output
-from utils import get_log_lines
-from utils import is_vshard_bootstrapped
+from utils import (get_log_lines, is_vshard_bootstrapped,
+                   run_command_and_get_output)
 
 
 def test_bootstrap(cartridge_cmd, project_with_vshard_replicasets):

--- a/test/integration/replicasets/test_expel.py
+++ b/test/integration/replicasets/test_expel.py
@@ -1,6 +1,5 @@
-from utils import run_command_and_get_output
-from utils import get_log_lines
-from utils import is_instance_expelled
+from utils import (get_log_lines, is_instance_expelled,
+                   run_command_and_get_output)
 
 
 def test_bad_instance_name(cartridge_cmd, project_with_vshard_replicasets):

--- a/test/integration/replicasets/test_failover_priority.py
+++ b/test/integration/replicasets/test_failover_priority.py
@@ -1,9 +1,6 @@
-from utils import get_replicasets
-from utils import get_log_lines
-from utils import run_command_and_get_output
-
-from integration.replicasets.utils import get_replicaset_by_alias
-from integration.replicasets.utils import get_list_from_log_lines
+from integration.replicasets.utils import (get_list_from_log_lines,
+                                           get_replicaset_by_alias)
+from utils import get_log_lines, get_replicasets, run_command_and_get_output
 
 
 def test_bad_replicaset_name(cartridge_cmd, project_with_vshard_replicasets):

--- a/test/integration/replicasets/test_join.py
+++ b/test/integration/replicasets/test_join.py
@@ -1,8 +1,5 @@
-from utils import get_replicasets
-from utils import run_command_and_get_output
-from utils import get_log_lines
-
 from integration.replicasets.utils import get_replicaset_by_alias
+from utils import get_log_lines, get_replicasets, run_command_and_get_output
 
 
 def assert_join_instances_logs(output, replicaset_alias, instances):

--- a/test/integration/replicasets/test_list_replicasets.py
+++ b/test/integration/replicasets/test_list_replicasets.py
@@ -1,9 +1,6 @@
 import pytest
-
-from utils import run_command_and_get_output
-from utils import write_conf
-
 from integration.replicasets.utils import set_instance_zone
+from utils import run_command_and_get_output, write_conf
 
 
 def test_default_application(cartridge_cmd, default_project_with_instances):

--- a/test/integration/replicasets/test_roles.py
+++ b/test/integration/replicasets/test_roles.py
@@ -1,9 +1,7 @@
-from utils import run_command_and_get_output
-from utils import get_replicasets, get_known_roles
-from utils import get_log_lines
-
-from integration.replicasets.utils import get_list_from_log_lines
-from integration.replicasets.utils import get_replicaset_by_alias
+from integration.replicasets.utils import (get_list_from_log_lines,
+                                           get_replicaset_by_alias)
+from utils import (get_known_roles, get_log_lines, get_replicasets,
+                   run_command_and_get_output)
 
 
 def assert_add_roles_log(output, replicaset_alias, roles_to_add, res_roles_list):

--- a/test/integration/replicasets/test_set_weight.py
+++ b/test/integration/replicasets/test_set_weight.py
@@ -1,8 +1,5 @@
-from utils import get_replicasets
-from utils import get_log_lines
-from utils import run_command_and_get_output
-
 from integration.replicasets.utils import get_replicaset_by_alias
+from utils import get_log_lines, get_replicasets, run_command_and_get_output
 
 
 def test_bad_replicaset_name(cartridge_cmd, project_with_vshard_replicasets):

--- a/test/integration/replicasets/test_setup.py
+++ b/test/integration/replicasets/test_setup.py
@@ -1,16 +1,11 @@
 import os
 import subprocess
+
 import yaml
-
-from utils import run_command_and_get_output
-from utils import get_log_lines
-from utils import write_conf
-from utils import get_replicasets
-from utils import is_vshard_bootstrapped
-
 from integration.replicasets.utils import get_list_from_log_lines
-
 from project import patch_cartridge_proc_titile
+from utils import (get_log_lines, get_replicasets, is_vshard_bootstrapped,
+                   run_command_and_get_output, write_conf)
 
 
 def assert_setup_logs(output, rpl_conf_path, created_rpls=[], updated_rpls=[], ok_rpls=[], vshard_bootstrapped=False):

--- a/test/integration/replicasets/test_vshard_groups.py
+++ b/test/integration/replicasets/test_vshard_groups.py
@@ -1,8 +1,6 @@
-from utils import run_command_and_get_output
-from utils import get_log_lines
-from utils import get_vshard_group_names
-
 from integration.replicasets.utils import get_list_from_log_lines
+from utils import (get_log_lines, get_vshard_group_names,
+                   run_command_and_get_output)
 
 
 def test_list_groups(cartridge_cmd, project_with_instances):

--- a/test/integration/running/test_clean.py
+++ b/test/integration/running/test_clean.py
@@ -1,9 +1,6 @@
 import os
 
-from utils import write_conf
-from utils import check_instances_running
-from utils import check_instances_stopped
-
+from utils import check_instances_running, check_instances_stopped, write_conf
 
 FILES_TO_BE_DELETED = ['log', 'workdir', 'console-sock', 'notify-sock', 'pid']
 

--- a/test/integration/running/test_log.py
+++ b/test/integration/running/test_log.py
@@ -1,8 +1,5 @@
-from utils import check_instances_running
-
 from project import patch_init_to_log_lines
-from utils import write_conf
-
+from utils import check_instances_running, write_conf
 
 DEFAULT_LAST_N_LINES = 15  # see cli/commands/log.go
 LOG_LINES = ["I am log line number {}".format(i) for i in range(DEFAULT_LAST_N_LINES-1)]

--- a/test/integration/running/test_running.py
+++ b/test/integration/running/test_running.py
@@ -1,15 +1,14 @@
 import os
-import shutil
-import pytest
 import re
+import shutil
 from platform import system
 
-from utils import check_instances_running, check_instances_stopped
-from utils import STATUS_NOT_STARTED, STATUS_RUNNING, STATUS_STOPPED
-from utils import write_conf
-
-from project import patch_init_to_send_statuses
-from project import patch_init_to_send_ready_after_timeout
+import pytest
+from project import (patch_init_to_send_ready_after_timeout,
+                     patch_init_to_send_statuses)
+from utils import (STATUS_NOT_STARTED, STATUS_RUNNING, STATUS_STOPPED,
+                   check_instances_running, check_instances_stopped,
+                   write_conf)
 
 
 # #####

--- a/test/project.py
+++ b/test/project.py
@@ -1,12 +1,10 @@
 import os
 import re
-import subprocess
 import shutil
+import subprocess
 
-from utils import create_project
-from utils import recursive_listdir
-from utils import tarantool_enterprise_is_used
-
+from utils import (create_project, recursive_listdir,
+                   tarantool_enterprise_is_used)
 
 FILES_DIR = 'test/files'
 INIT_NO_CARTRIDGE_FILEPATH = os.path.join(FILES_DIR, 'init_no_cartridge.lua')

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -5,6 +5,7 @@ rpmfile==0.1.4
 docker
 flake8==3.8.1
 flake8-unused-arguments==0.0.6
+flake8-isort==4.0.0
 psutil==5.7.0
 pyyaml==5.4
 tenacity==6.1.0

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,19 +1,19 @@
-import os
-import subprocess
-import rpmfile
-import re
-import sys
-import psutil
 import glob
-import json
-import requests
-import tenacity
-import time
-import yaml
-import tarfile
 import gzip
+import json
+import os
+import re
 import shutil
+import subprocess
+import sys
+import tarfile
+import time
 
+import psutil
+import requests
+import rpmfile
+import tenacity
+import yaml
 from docker import APIClient
 
 __tarantool_version = None


### PR DESCRIPTION
Imports order generated with `isort` util. Closes #422 
