### PR TITLE
Adapt Cartridge CLI to new release policy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        tarantool-version: ["1.10", "2.7"]
+        tarantool-version: ["1.10", "2.8", "2.x-latest"]
       fail-fast: false
     steps:
       - uses: actions/checkout@master
@@ -44,9 +44,16 @@ jobs:
           git config --global user.name "Tar Antool"
 
       - name: Install Tarantool
+        if: matrix.tarantool-version != '2.x-latest'
         uses: tarantool/setup-tarantool@v1
         with:
           tarantool-version: '${{ matrix.tarantool-version }}'
+
+      - name: Install latest pre-release Tarantool 2.x
+        if: matrix.tarantool-version == '2.x-latest'
+        run: |
+          curl -L https://tarantool.io/pre-release/2/installer.sh | bash
+          sudo apt-get -y install tarantool
 
       - name: Cache docker images
         uses: satackey/action-docker-layer-caching@v0.0.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Removed unnecessary flags (``--rocks``, ``--project-path``) from ``cartridge help`` command.
 - Fixed project build with capital letters in the project name.
 - Fixed display of Docker image pull (``cartridge pack`` command with ``--verbose`` flag).
+- Added support for new Tarantool release policy.
 
 ### Added
 

--- a/cli/common/tarantool.go
+++ b/cli/common/tarantool.go
@@ -14,11 +14,100 @@ import (
 )
 
 var (
+	// Used for shallow validation of a version string.
 	tarantoolVersionRegexp *regexp.Regexp
+	// Used for thorough validation of a version string and to extract string version to a struct.
+	tarantoolVersionFullRegexp *regexp.Regexp
 )
 
 func init() {
 	tarantoolVersionRegexp = regexp.MustCompile(`\d+\.\d+\.\d+[-\w]*`)
+	// Part 1 is semVer X.Y.Z ,
+	// part 2 (optional) is a tag suffix for pre-release,
+	// part 3 is number of commits since tag and commit hash,
+	// part 4 (optional) is enterprise suffix,
+	// part 5 (optional) is development build suffix.
+	tarantoolVersionFullRegexp = regexp.MustCompile(
+		`^(?P<Major>\d+)\.(?P<Minor>\d+)?\.(?P<Patch>\d+)` +
+			`(?:-(?P<TagSuffix>alpha\d+|beta\d+|rc\d+|entrypoint))?` +
+			`-(?P<CommitsSinceTag>\d+)-(?P<CommitHashId>g[0-9a-f]+)` +
+			`(?:-(?P<EnterpriseSDKRevision>r\d+)(?:-(?P<EnterpriseIsOnMacOS>macos))?)?` +
+			`(?:-(?P<IsDevelopmentBuild>dev))?$`)
+}
+
+// findNamedMatches processes regexp with named capture groups
+// and transforms output to a map. If capture group is optional
+// and was not found, map value is empty string.
+func findNamedMatches(regex *regexp.Regexp, str string) map[string]string {
+	match := regex.FindStringSubmatch(str)
+
+	results := map[string]string{}
+	for i, name := range match {
+		// i == 0 is input string.
+		if i != 0 {
+			results[regex.SubexpNames()[i]] = name
+		}
+	}
+	return results
+}
+
+type TarantoolVersion struct {
+	Major                 uint64
+	Minor                 uint64
+	Patch                 uint64
+	TagSuffix             string
+	CommitsSinceTag       uint64
+	CommitHashId          string
+	EnterpriseSDKRevision string
+	EnterpriseIsOnMacOS   bool
+	IsDevelopmentBuild    bool
+}
+
+func atoiUint64(str string) (uint64, error) {
+	res, err := strconv.ParseUint(str, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("Failed to parse Tarantool version: cast to number error (%s)", err)
+	}
+	return res, nil
+}
+
+// ParseTarantoolVersion extracts Tarantool version string to a TarantoolVersion struct.
+func ParseTarantoolVersion(version string) (TarantoolVersion, error) {
+	var result TarantoolVersion
+	var err error
+
+	matches := findNamedMatches(tarantoolVersionFullRegexp, version)
+	if len(matches) == 0 {
+		return result, fmt.Errorf("Failed to parse Tarantool version: format is not valid")
+	}
+
+	if result.Major, err = atoiUint64(matches["Major"]); err != nil {
+		return result, err
+	}
+
+	if result.Minor, err = atoiUint64(matches["Minor"]); err != nil {
+		return result, err
+	}
+
+	if result.Patch, err = atoiUint64(matches["Patch"]); err != nil {
+		return result, err
+	}
+
+	result.TagSuffix = matches["TagSuffix"]
+
+	if result.CommitsSinceTag, err = atoiUint64(matches["CommitsSinceTag"]); err != nil {
+		return result, err
+	}
+
+	result.CommitHashId = matches["CommitHashId"]
+
+	result.EnterpriseSDKRevision = matches["EnterpriseSDKRevision"]
+
+	result.EnterpriseIsOnMacOS = (matches["EnterpriseIsOnMacOS"] != "")
+
+	result.IsDevelopmentBuild = (matches["IsDevelopmentBuild"] != "")
+
+	return result, nil
 }
 
 // GetTarantoolDir returns Tarantool executable directory

--- a/cli/common/tarantool_test.go
+++ b/cli/common/tarantool_test.go
@@ -56,3 +56,230 @@ func TestTarantoolVersion(t *testing.T) {
 		assert.Equal(tarantoolVersion, version)
 	}
 }
+
+type returnValueParseTarantoolVersion struct {
+	version TarantoolVersion
+	err     error
+}
+
+func TestParseTarantoolVersion(t *testing.T) {
+	assert := assert.New(t)
+
+	testCases := make(map[string]returnValueParseTarantoolVersion)
+
+	testCases["1.10.11-0-g543e2a1ec0"] = returnValueParseTarantoolVersion{
+		TarantoolVersion{
+			Major:                 1,
+			Minor:                 10,
+			Patch:                 11,
+			TagSuffix:             "",
+			CommitsSinceTag:       0,
+			CommitHashId:          "g543e2a1ec0",
+			EnterpriseSDKRevision: "",
+			EnterpriseIsOnMacOS:   false,
+			IsDevelopmentBuild:    false,
+		},
+		nil,
+	}
+
+	testCases["2.8.1-0-ge2a1ec0c2"] = returnValueParseTarantoolVersion{
+		TarantoolVersion{
+			Major:                 2,
+			Minor:                 8,
+			Patch:                 1,
+			TagSuffix:             "",
+			CommitsSinceTag:       0,
+			CommitHashId:          "ge2a1ec0c2",
+			EnterpriseSDKRevision: "",
+			EnterpriseIsOnMacOS:   false,
+			IsDevelopmentBuild:    false,
+		},
+		nil,
+	}
+
+	testCases["2.10.0-alpha1-0-g4b387d14a"] = returnValueParseTarantoolVersion{
+		TarantoolVersion{
+			Major:                 2,
+			Minor:                 10,
+			Patch:                 0,
+			TagSuffix:             "alpha1",
+			CommitsSinceTag:       0,
+			CommitHashId:          "g4b387d14a",
+			EnterpriseSDKRevision: "",
+			EnterpriseIsOnMacOS:   false,
+			IsDevelopmentBuild:    false,
+		},
+		nil,
+	}
+
+	testCases["2.10.0-beta1-0-g7da4b1438"] = returnValueParseTarantoolVersion{
+		TarantoolVersion{
+			Major:                 2,
+			Minor:                 10,
+			Patch:                 0,
+			TagSuffix:             "beta1",
+			CommitsSinceTag:       0,
+			CommitHashId:          "g7da4b1438",
+			EnterpriseSDKRevision: "",
+			EnterpriseIsOnMacOS:   false,
+			IsDevelopmentBuild:    false,
+		},
+		nil,
+	}
+
+	testCases["2.10.0-rc3-0-gc2438eeb1"] = returnValueParseTarantoolVersion{
+		TarantoolVersion{
+			Major:                 2,
+			Minor:                 10,
+			Patch:                 0,
+			TagSuffix:             "rc3",
+			CommitsSinceTag:       0,
+			CommitHashId:          "gc2438eeb1",
+			EnterpriseSDKRevision: "",
+			EnterpriseIsOnMacOS:   false,
+			IsDevelopmentBuild:    false,
+		},
+		nil,
+	}
+
+	testCases["2.10.1-entrypoint-0-gc2438eeb1"] = returnValueParseTarantoolVersion{
+		TarantoolVersion{
+			Major:                 2,
+			Minor:                 10,
+			Patch:                 1,
+			TagSuffix:             "entrypoint",
+			CommitsSinceTag:       0,
+			CommitHashId:          "gc2438eeb1",
+			EnterpriseSDKRevision: "",
+			EnterpriseIsOnMacOS:   false,
+			IsDevelopmentBuild:    false,
+		},
+		nil,
+	}
+
+	testCases["2.8.1-121-g94ad1c2ee"] = returnValueParseTarantoolVersion{
+		TarantoolVersion{
+			Major:                 2,
+			Minor:                 8,
+			Patch:                 1,
+			TagSuffix:             "",
+			CommitsSinceTag:       121,
+			CommitHashId:          "g94ad1c2ee",
+			EnterpriseSDKRevision: "",
+			EnterpriseIsOnMacOS:   false,
+			IsDevelopmentBuild:    false,
+		},
+		nil,
+	}
+
+	testCases["2.8.1-0-ge2a1ec0c2-r399"] = returnValueParseTarantoolVersion{
+		TarantoolVersion{
+			Major:                 2,
+			Minor:                 8,
+			Patch:                 1,
+			TagSuffix:             "",
+			CommitsSinceTag:       0,
+			CommitHashId:          "ge2a1ec0c2",
+			EnterpriseSDKRevision: "r399",
+			EnterpriseIsOnMacOS:   false,
+			IsDevelopmentBuild:    false,
+		},
+		nil,
+	}
+
+	testCases["2.8.1-0-ge2a1ec0c2-r399-macos"] = returnValueParseTarantoolVersion{
+		TarantoolVersion{
+			Major:                 2,
+			Minor:                 8,
+			Patch:                 1,
+			TagSuffix:             "",
+			CommitsSinceTag:       0,
+			CommitHashId:          "ge2a1ec0c2",
+			EnterpriseSDKRevision: "r399",
+			EnterpriseIsOnMacOS:   true,
+			IsDevelopmentBuild:    false,
+		},
+		nil,
+	}
+
+	testCases["2.10.1-23-g0c2e2a1ec-dev"] = returnValueParseTarantoolVersion{
+		TarantoolVersion{
+			Major:                 2,
+			Minor:                 10,
+			Patch:                 1,
+			TagSuffix:             "",
+			CommitsSinceTag:       23,
+			CommitHashId:          "g0c2e2a1ec",
+			EnterpriseSDKRevision: "",
+			EnterpriseIsOnMacOS:   false,
+			IsDevelopmentBuild:    true,
+		},
+		nil,
+	}
+
+	testCases["2.10.0-beta1-3-g4b17da438-dev"] = returnValueParseTarantoolVersion{
+		TarantoolVersion{
+			Major:                 2,
+			Minor:                 10,
+			Patch:                 0,
+			TagSuffix:             "beta1",
+			CommitsSinceTag:       3,
+			CommitHashId:          "g4b17da438",
+			EnterpriseSDKRevision: "",
+			EnterpriseIsOnMacOS:   false,
+			IsDevelopmentBuild:    true,
+		},
+		nil,
+	}
+
+	testCases["2.8.2"] = returnValueParseTarantoolVersion{
+		TarantoolVersion{},
+		fmt.Errorf("Failed to parse Tarantool version: format is not valid"),
+	}
+
+	testCases["2.10.0-beta1"] = returnValueParseTarantoolVersion{
+		TarantoolVersion{},
+		fmt.Errorf("Failed to parse Tarantool version: format is not valid"),
+	}
+
+	testCases["2.8.1-ge2a1ec0c2-0"] = returnValueParseTarantoolVersion{
+		TarantoolVersion{},
+		fmt.Errorf("Failed to parse Tarantool version: format is not valid"),
+	}
+
+	testCases["2.10.0-beta1-0"] = returnValueParseTarantoolVersion{
+		TarantoolVersion{},
+		fmt.Errorf("Failed to parse Tarantool version: format is not valid"),
+	}
+
+	testCases["2.8.2-r420"] = returnValueParseTarantoolVersion{
+		TarantoolVersion{},
+		fmt.Errorf("Failed to parse Tarantool version: format is not valid"),
+	}
+
+	testCases["2.8.2-r420-macos"] = returnValueParseTarantoolVersion{
+		TarantoolVersion{},
+		fmt.Errorf("Failed to parse Tarantool version: format is not valid"),
+	}
+
+	testCases["2.7.1.2-0-ge2a1ec0c2"] = returnValueParseTarantoolVersion{
+		TarantoolVersion{},
+		fmt.Errorf("Failed to parse Tarantool version: format is not valid"),
+	}
+
+	testCases["2.8.1-0-ge2a1ec0c2-macos"] = returnValueParseTarantoolVersion{
+		TarantoolVersion{},
+		fmt.Errorf("Failed to parse Tarantool version: format is not valid"),
+	}
+
+	for input, output := range testCases {
+		version, err := ParseTarantoolVersion(input)
+
+		if output.err == nil {
+			assert.Nil(err)
+			assert.Equal(output.version, version)
+		} else {
+			assert.Equal(output.err, err)
+		}
+	}
+}

--- a/cli/common/tarantool_test.go
+++ b/cli/common/tarantool_test.go
@@ -283,3 +283,47 @@ func TestParseTarantoolVersion(t *testing.T) {
 		}
 	}
 }
+
+type returnValueGetMinimalRequiredVersion struct {
+	res string
+	err error
+}
+
+func TestGetTarantoolMinVersion(t *testing.T) {
+	assert := assert.New(t)
+
+	testCases := map[string]returnValueGetMinimalRequiredVersion{
+		"3.0.0-rc1-0-g7da4b1438":    {res: "3.0.0~rc1", err: nil},
+		"2.10.0-beta1-0-g7da4b1438": {res: "2.10.0~beta1", err: nil},
+		"2.10.0-0-g7da4b1438":       {res: "2.10.0", err: nil},
+		"2.9.0-alpha1-0-g7da4b1438": {res: "2.9.0~alpha1", err: nil},
+		"2.8.2-0-gfc96d10f5":        {res: "2.8.2.0", err: nil},
+		"1.10.11-21-g543e2a1ec0":    {res: "1.10.11.21", err: nil},
+
+		"2.10.1-entrypoint-0-gc2438eeb1": {
+			res: "",
+			err: fmt.Errorf("Can't compute minimal required version for an entrypoint build"),
+		},
+		"2.10.1-23-g0c2e2a1ec-dev": {
+			res: "",
+			err: fmt.Errorf("Can't compute minimal required version for a development build"),
+		},
+		"2.10.0-beta1-3-g4b17da438-dev": {
+			res: "",
+			err: fmt.Errorf("Can't compute minimal required version for a development build"),
+		},
+	}
+
+	for version, output := range testCases {
+		ver, verErr := ParseTarantoolVersion(version)
+		assert.Nil(verErr)
+
+		res, err := GetMinimalRequiredVersion(ver)
+		if output.err == nil {
+			assert.Nil(err)
+			assert.Equal(output.res, res)
+		} else {
+			assert.Equal(output.err, err)
+		}
+	}
+}

--- a/cli/common/utils.go
+++ b/cli/common/utils.go
@@ -34,28 +34,20 @@ type PackDependency struct {
 
 type PackDependencies []PackDependency
 
-func (deps *PackDependencies) AddTarantool(tarantoolVersion string) error {
-	tarantoolMinVersion := tarantoolVersion
-	tarantoolMaxVersion, err := GetNextMajorVersion(tarantoolMinVersion)
-	if err != nil {
-		return fmt.Errorf("Failed to get next major version of Tarantool %s", err)
-	}
-
+func (deps *PackDependencies) AddTarantool(minVersion, maxVersion string) {
 	*deps = append(*deps, PackDependency{
 		Name: "tarantool",
 		Relations: []DepRelation{
 			{
 				Relation: ">=",
-				Version:  tarantoolMinVersion,
+				Version:  minVersion,
 			},
 			{
 				Relation: "<",
-				Version:  tarantoolMaxVersion,
+				Version:  maxVersion,
 			},
 		},
 	})
-
-	return nil
 }
 
 var bufSize int64 = 10000

--- a/cli/project/dockerfiles_test.go
+++ b/cli/project/dockerfiles_test.go
@@ -92,10 +92,10 @@ ENV PATH="/usr/share/tarantool/sdk:${PATH}"
 
 	// Tarantool Opensource 2.1
 	ctx.Tarantool.TarantoolIsEnterprise = false
-	ctx.Tarantool.TarantoolVersion = "2.1.42"
+	ctx.Tarantool.TarantoolVersion = "2.1.42-0-g1fa53afe3"
 
 	expLayers = `### Install opensource Tarantool
-RUN curl -L https://tarantool.io/installer.sh | VER=2.1 bash \
+RUN curl -L https://tarantool.io/installer.sh | VER=2.1 bash -s -- --type release \
     && yum -y install tarantool-devel
 `
 
@@ -105,10 +105,36 @@ RUN curl -L https://tarantool.io/installer.sh | VER=2.1 bash \
 
 	// Tarantool Opensource 1.10
 	ctx.Tarantool.TarantoolIsEnterprise = false
-	ctx.Tarantool.TarantoolVersion = "1.10.42"
+	ctx.Tarantool.TarantoolVersion = "1.10.42-0-gfa53a1fe3"
 
 	expLayers = `### Install opensource Tarantool
-RUN curl -L https://tarantool.io/installer.sh | VER=1.10 bash \
+RUN curl -L https://tarantool.io/installer.sh | VER=1.10 bash -s -- --type release \
+    && yum -y install tarantool-devel
+`
+
+	layers, err = getInstallTarantoolLayers(&ctx)
+	assert.Nil(err)
+	assert.Equal(expLayers, layers)
+
+	// Tarantool Opensource 2.10 pre-release
+	ctx.Tarantool.TarantoolIsEnterprise = false
+	ctx.Tarantool.TarantoolVersion = "2.10.0-beta1-0-g7da4b1438"
+
+	expLayers = `### Install opensource Tarantool
+RUN curl -L https://tarantool.io/installer.sh | VER=2 bash -s -- --type pre-release \
+    && yum -y install tarantool-devel
+`
+
+	layers, err = getInstallTarantoolLayers(&ctx)
+	assert.Nil(err)
+	assert.Equal(expLayers, layers)
+
+	// Tarantool Opensource 2.10
+	ctx.Tarantool.TarantoolIsEnterprise = false
+	ctx.Tarantool.TarantoolVersion = "2.10.3-0-gb14387da4"
+
+	expLayers = `### Install opensource Tarantool
+RUN curl -L https://tarantool.io/installer.sh | VER=2 bash -s -- --type release \
     && yum -y install tarantool-devel
 `
 
@@ -218,7 +244,7 @@ func TestGetBuildImageDockerfileTemplateOpensource(t *testing.T) {
 
 	// Tarantool Opensource 1.10 w/o --build-from
 	ctx.Tarantool.TarantoolIsEnterprise = false
-	ctx.Tarantool.TarantoolVersion = "1.10.42"
+	ctx.Tarantool.TarantoolVersion = "1.10.42-0-gfa53a1fe3"
 	ctx.Build.DockerFrom = ""
 
 	expLayers = `FROM centos:7
@@ -227,7 +253,7 @@ func TestGetBuildImageDockerfileTemplateOpensource(t *testing.T) {
 RUN yum install -y git-core gcc gcc-c++ make cmake unzip
 
 ### Install opensource Tarantool
-RUN curl -L https://tarantool.io/installer.sh | VER=1.10 bash \
+RUN curl -L https://tarantool.io/installer.sh | VER=1.10 bash -s -- --type release \
     && yum -y install tarantool-devel
 
 ### Wrap user
@@ -254,7 +280,7 @@ RUN yum install -y zip
 	writeDockerfile(f, baseDockerfileContent)
 
 	ctx.Tarantool.TarantoolIsEnterprise = false
-	ctx.Tarantool.TarantoolVersion = "1.10.42"
+	ctx.Tarantool.TarantoolVersion = "1.10.42-0-gfa53a1fe3"
 	ctx.Build.DockerFrom = f.Name()
 
 	expLayers = `FROM centos:7
@@ -264,7 +290,7 @@ RUN yum install -y zip
 RUN yum install -y git-core gcc gcc-c++ make cmake unzip
 
 ### Install opensource Tarantool
-RUN curl -L https://tarantool.io/installer.sh | VER=1.10 bash \
+RUN curl -L https://tarantool.io/installer.sh | VER=1.10 bash -s -- --type release \
     && yum -y install tarantool-devel
 
 ### Wrap user
@@ -417,7 +443,7 @@ func TestGetRuntimeImageDockerfileTemplateOpensource(t *testing.T) {
 
 	// Tarantool Opensource 1.10 w/o --from
 	ctx.Tarantool.TarantoolIsEnterprise = false
-	ctx.Tarantool.TarantoolVersion = "1.10.42"
+	ctx.Tarantool.TarantoolVersion = "1.10.42-0-gfa53a1fe3"
 	ctx.Pack.DockerFrom = ""
 
 	expLayers = `FROM centos:7
@@ -428,7 +454,7 @@ RUN groupadd -r -g {{ .TarantoolGID }} tarantool \
         -c "Tarantool Server" tarantool
 
 ### Install opensource Tarantool
-RUN curl -L https://tarantool.io/installer.sh | VER=1.10 bash \
+RUN curl -L https://tarantool.io/installer.sh | VER=1.10 bash -s -- --type release \
     && yum -y install tarantool-devel
 
 ### Prepare for runtime
@@ -463,7 +489,7 @@ RUN yum install -y zip
 	writeDockerfile(f, baseDockerfileContent)
 
 	ctx.Tarantool.TarantoolIsEnterprise = false
-	ctx.Tarantool.TarantoolVersion = "1.10.42"
+	ctx.Tarantool.TarantoolVersion = "1.10.42-0-gfa53a1fe3"
 	ctx.Pack.DockerFrom = f.Name()
 
 	expLayers = `FROM centos:7

--- a/test/e2e/test_deb.py
+++ b/test/e2e/test_deb.py
@@ -7,8 +7,8 @@ import yaml
 from project import INIT_CHECK_PASSED_PARAMS, replace_project_file
 from utils import (Archive, ProjectContainer, build_image,
                    check_contains_regular_file, check_systemd_service,
-                   delete_image, find_archive, run_command_on_container,
-                   tarantool_enterprise_is_used, tarantool_short_version)
+                   delete_image, find_archive, get_tarantool_installer_cmd,
+                   run_command_on_container, tarantool_enterprise_is_used)
 
 
 # ########
@@ -84,10 +84,11 @@ def container_with_installed_deb(docker_client, deb_archive_with_cartridge,
 
     dockerfile_layers = ["FROM jrei/systemd-ubuntu"]
     if not tarantool_enterprise_is_used():
+        tarantool_install_cmd = get_tarantool_installer_cmd("apt-get")
         dockerfile_layers.append('''RUN apt-get update && apt-get install -y curl \
             && DEBIAN_FRONTEND="noninteractive" apt-get -y install tzdata \
-            && curl -L https://tarantool.io/installer.sh | VER={} bash
-        '''.format(tarantool_short_version()))
+            && {}
+        '''.format(tarantool_install_cmd))
     else:
         dockerfile_layers.append("RUN apt-get update")
 

--- a/test/e2e/test_rpm.py
+++ b/test/e2e/test_rpm.py
@@ -5,8 +5,8 @@ import subprocess
 import pytest
 from utils import (Archive, ProjectContainer, build_image,
                    check_contains_regular_file, check_systemd_service,
-                   delete_image, find_archive, run_command_on_container,
-                   tarantool_enterprise_is_used, tarantool_short_version)
+                   delete_image, find_archive, get_tarantool_installer_cmd,
+                   run_command_on_container, tarantool_enterprise_is_used)
 
 
 # ########
@@ -65,9 +65,8 @@ def container_with_installed_rpm(docker_client, rpm_archive_with_cartridge,
 
     dockerfile_layers = ["FROM centos:7"]
     if not tarantool_enterprise_is_used():
-        dockerfile_layers.append('''RUN curl -L \
-            https://tarantool.io/installer.sh | VER={} bash
-        '''.format(tarantool_short_version()))
+        installer_cmd = get_tarantool_installer_cmd("yum")
+        dockerfile_layers.append(f"RUN {installer_cmd}")
     else:
         dockerfile_layers.append("RUN yum update -y")
 

--- a/test/e2e/test_tgz.py
+++ b/test/e2e/test_tgz.py
@@ -9,8 +9,8 @@ from project import (INIT_ROLES_RELOAD_ALLOWED_FILEPATH,
                      ROUTER_WITH_EVAL_FILEPATH, replace_project_file)
 from utils import (Archive, InstanceContainer, build_image, delete_image,
                    examine_application_instance_container, find_archive,
-                   run_command_on_container, tarantool_enterprise_is_used,
-                   tarantool_short_version)
+                   get_tarantool_installer_cmd, run_command_on_container,
+                   tarantool_enterprise_is_used)
 
 
 # ########
@@ -49,10 +49,8 @@ def instance_container_with_unpacked_tgz(docker_client, tmpdir, tgz_archive_with
 
     dockerfile_layers = ["FROM centos:7"]
     if not tarantool_enterprise_is_used():
-        dockerfile_layers.append('''RUN curl -L \
-            https://tarantool.io/installer.sh | VER={} bash
-        '''.format(tarantool_short_version()))
-
+        tarantool_installer = get_tarantool_installer_cmd("yum")
+        dockerfile_layers.append(f"RUN {tarantool_installer}")
     with open(os.path.join(build_path, 'Dockerfile'), 'w') as f:
         f.write('\n'.join(dockerfile_layers))
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -1421,3 +1421,20 @@ def tarantool_dict_version():
     assert ver['IsDevelopmentBuild'] is False
 
     return ver
+
+
+def get_tarantool_installer_cmd(package_manager):
+    ver = tarantool_dict_version()
+
+    tarantool_type = "release"
+    if (ver['Major'] == 2 and ver['Minor'] <= 8) or ver['Major'] < 2:
+        short_version = f"{ver['Major']}.{ver['Minor']}"
+    else:
+        short_version = f"{ver['Major']}"
+
+        if ver['TagSuffix'] is not None:
+            tarantool_type = "pre-release"
+
+    return f"curl -L https://tarantool.io/installer.sh | \
+        VER={short_version} bash -s --  --type {tarantool_type} \
+        && {package_manager} install -y tarantool"


### PR DESCRIPTION
Reworked version by @DifferentialOrange 

Add struct type for Tarantool version and parsing utility. Struct can be
used to build dependency requirements instead of version string.

Add Tarantool dependency to rpm or deb package only if it is not set up
by user explicitly with --deps or --deps-file. Use version struct
to build minimal and maximal requirements for packages based on new
version policy. Old version policy (2.8 and less) cases are considered
separately. Version struct parsing is strict so "lazy" versions without
number of commits since tag and commit hash (like "2.8.0") are no longer
supported since real Tarantool packages always have them. Use
struct-based approach in integration tests, migrate them to new version
policy.

Tarantool download through the [installer](https://tarantool.io/installer.sh) has changed along with
the announcement of the new release policy. cartridge pack docker
command uses an installer to install Tarantool.

Closes #619