### PR TITLE
Fix displaying of pulling Docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Make Tarantool version check less strict, support `X.Y.Z` notation.
 - Removed unnecessary flags (``--rocks``, ``--project-path``) from ``cartridge help`` command.
 - Fixed project build with capital letters in the project name.
+- Fixed display of Docker image pull (``cartridge pack`` command with ``--verbose`` flag).
 
 ### Added
 


### PR DESCRIPTION
Removed blank lines and replaced with correct  when 
pulling Docker image in ``cartridge pack`` command 
with ``--verbose`` flag.

Closes #627 