### PR TITLE
doc: add a short note how to build it locally

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,12 @@ Installation
 
             brew install cartridge-cli
 
+    *   Or build locally:
+
+        .. code-block:: bash
+
+           mage build
+
 5.  Check the installation:
 
     ..  code-block:: bash

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -50,6 +50,12 @@ Installation
 
             brew install cartridge-cli
 
+    *   Or build locally:
+
+        .. code-block:: bash
+
+           mage build
+
 5.  Check the installation:
 
     ..  code-block:: bash


### PR DESCRIPTION
It is useful, when other installation alternatives are not suitable:
say, on a Linux distribution not listed here.
