### PR TITLE
Set python version to 3.9 in the translation actions

### DIFF
--- a/.github/workflows/pull-translation.yml
+++ b/.github/workflows/pull-translation.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Setup Python environment
         uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
 
       - name: Setup Python requirements
         run: |

--- a/.github/workflows/push-translation.yml
+++ b/.github/workflows/push-translation.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Setup Python environment
         uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
 
       - name: Setup Python requirements
         run: |

--- a/.github/workflows/upload-translations.yml
+++ b/.github/workflows/upload-translations.yml
@@ -18,6 +18,8 @@ jobs:
 
     - name: Setup Python environment
       uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
 
     - name: Setup Python requirements
       run: |


### PR DESCRIPTION
Some translation workflows fail because of incompatibility with a new python version.

https://github.com/tarantool/cartridge-cli/runs/3994597525?check_suite_focus=true#step:7:26

To fix python version in the setup-python@v2 action:

```yaml
- name: Setup Python environment
  uses: actions/setup-python@v2
  with:
    python-version: '3.9'
```