### PR TITLE
Enable the translation of code comments

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -22,3 +22,4 @@ language = 'en'
 locale_dirs = ['./doc/locale']
 gettext_compact = False
 gettext_location = True
+gettext_additional_targets = ['literal-block']


### PR DESCRIPTION
Previously, Crowdin couldn't receive code-blocks for translation, and some code comments remained in English while the article text was translated into Russian. This fixes it.