### PR TITLE
bench: load profile patch (select and update)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Tarantool benchmark tool update (select and update operations):
+  * option --insert has been added - sets percentage of insert operations to bench space.
+  * option --select has been added - sets percentage of select operations from bench space.
+  * option --update has been added - sets percentage of update operations in bench space.
+  * option --fill" has been added - sets number of records to pre-fill the space.
+
 ## [2.12.2] - 2022-06-05
 
 ### Changed

--- a/cli/bench/config.go
+++ b/cli/bench/config.go
@@ -12,6 +12,12 @@ import (
 var (
 	benchSpaceName             = "__benchmark_space__"
 	benchSpacePrimaryIndexName = "__bench_primary_key__"
+	PreFillingCount            = 1000000
+	getRandomTupleCommand      = fmt.Sprintf(
+		"box.space.%s.index.%s:random",
+		benchSpaceName,
+		benchSpacePrimaryIndexName,
+	)
 )
 
 // printConfig output formatted config parameters.
@@ -25,6 +31,10 @@ func printConfig(ctx context.BenchCtx, tarantoolConnection *tarantool.Connection
 	fmt.Printf("\tduration: %d seconds\n", ctx.Duration)
 	fmt.Printf("\tkey size: %d bytes\n", ctx.KeySize)
 	fmt.Printf("\tdata size: %d bytes\n", ctx.DataSize)
+	fmt.Printf("\tinsert: %d percentages\n", ctx.InsertCount)
+	fmt.Printf("\tselect: %d percentages\n", ctx.SelectCount)
+	fmt.Printf("\tupdate: %d percentages\n\n", ctx.UpdateCount)
+
 	fmt.Printf("Data schema\n")
 	w := tabwriter.NewWriter(os.Stdout, 1, 1, 1, ' ', 0)
 	fmt.Fprintf(w, "|\tkey\t|\tvalue\n")

--- a/cli/bench/requests.go
+++ b/cli/bench/requests.go
@@ -1,0 +1,73 @@
+package bench
+
+import (
+	"math/rand"
+	"reflect"
+
+	"github.com/FZambia/tarantool"
+	"github.com/tarantool/cartridge-cli/cli/common"
+)
+
+// insertOperation execute insert operation.
+func insertOperation(request *Request) {
+	_, err := request.tarantoolConnection.Exec(
+		tarantool.Insert(
+			benchSpaceName,
+			[]interface{}{
+				common.RandomString(request.ctx.KeySize),
+				common.RandomString(request.ctx.DataSize),
+			}))
+	request.results.incrementRequestsCounters(err)
+}
+
+// selectOperation execute select operation.
+func selectOperation(request *Request) {
+	_, err := request.tarantoolConnection.Exec(tarantool.Call(
+		getRandomTupleCommand,
+		[]interface{}{rand.Int()}))
+	request.results.incrementRequestsCounters(err)
+}
+
+// updateOperation execute update operation.
+func updateOperation(request *Request) {
+	getRandomTupleResponse, err := request.tarantoolConnection.Exec(
+		tarantool.Call(getRandomTupleCommand,
+			[]interface{}{rand.Int()}))
+	if err == nil {
+		data := getRandomTupleResponse.Data
+		if len(data) > 0 {
+			key := reflect.ValueOf(data[0]).Index(0).Elem().String()
+			_, err := request.tarantoolConnection.Exec(
+				tarantool.Update(
+					benchSpaceName,
+					benchSpacePrimaryIndexName,
+					[]interface{}{key},
+					[]tarantool.Op{tarantool.Op(
+						tarantool.OpAssign(
+							2,
+							common.RandomString(request.ctx.DataSize)))}))
+			request.results.incrementRequestsCounters(err)
+		}
+	}
+}
+
+// getNext return next operation in operations sequence.
+func (requestsSequence *RequestsSequence) getNext() Request {
+	// If at the moment the number of remaining requests = 0,
+	// then find a new generator, which requests count > 0.
+	// If new generator has requests count = 0, then repeat.
+	requestsSequence.findNewRequestsGeneratorMutex.Lock()
+	defer requestsSequence.findNewRequestsGeneratorMutex.Unlock()
+	for requestsSequence.currentCounter == 0 {
+		// Increase the index, which means logical switching to a new generator.
+		requestsSequence.currentRequestIndex++
+		requestsSequence.currentRequestIndex %= len(requestsSequence.requests)
+		// Get new generator by index.
+		nextRequestsGenerator := requestsSequence.requests[requestsSequence.currentRequestIndex]
+		// Get requests count for new operation.
+		requestsSequence.currentCounter = nextRequestsGenerator.count
+	}
+	// Logical taking of a single request.
+	requestsSequence.currentCounter--
+	return requestsSequence.requests[requestsSequence.currentRequestIndex].request
+}

--- a/cli/bench/types.go
+++ b/cli/bench/types.go
@@ -1,5 +1,12 @@
 package bench
 
+import (
+	"sync"
+
+	"github.com/FZambia/tarantool"
+	"github.com/tarantool/cartridge-cli/cli/context"
+)
+
 // Results describes set of benchmark results.
 type Results struct {
 	handledRequestsCount int     // Count of all executed requests.
@@ -7,4 +14,33 @@ type Results struct {
 	failedResultCount    int     // Count of failed request in all connections.
 	duration             float64 // Benchmark duration.
 	requestsPerSecond    int     // Cumber of requests per second - the main measured value.
+}
+
+// RequestOperaion describes insert, select or update operation in request.
+type RequestOperaion func(*Request)
+
+// Request describes various types of requests.
+type Request struct {
+	operation           RequestOperaion // insertOperation, selectOperation or updateOperation.
+	ctx                 context.BenchCtx
+	tarantoolConnection *tarantool.Connection
+	results             *Results
+}
+
+// RequestsGenerator data structure for abstraction of a renewable heap of identical requests.
+type RequestsGenerator struct {
+	request Request // Request with specified operation.
+	count   int     // Count of requests.
+}
+
+// RequestsSequence data structure for abstraction for the constant issuance of new requests.
+type RequestsSequence struct {
+	requests []RequestsGenerator
+	// currentRequestIndex describes what type of request will be issued by the sequence.
+	currentRequestIndex int
+	// currentCounter describes how many requests of the same type
+	// are left to issue from RequestsPool.
+	currentCounter int
+	// findNewRequestsGeneratorMutex provides goroutine-safe search for new generator.
+	findNewRequestsGeneratorMutex sync.Mutex
 }

--- a/cli/commands/bench.go
+++ b/cli/commands/bench.go
@@ -30,4 +30,10 @@ func init() {
 	benchCmd.Flags().IntVar(&ctx.Bench.Duration, "duration", 10, "Duration of benchmark test (seconds)")
 	benchCmd.Flags().IntVar(&ctx.Bench.KeySize, "keysize", 10, "Size of key part of benchmark data (bytes)")
 	benchCmd.Flags().IntVar(&ctx.Bench.DataSize, "datasize", 20, "Size of value part of benchmark data (bytes)")
+
+	benchCmd.Flags().IntVar(&ctx.Bench.InsertCount, "insert", 100, "percentage of inserts")
+	benchCmd.Flags().IntVar(&ctx.Bench.SelectCount, "select", 0, "percentage of selects")
+	benchCmd.Flags().IntVar(&ctx.Bench.UpdateCount, "update", 0, "percentage of updates")
+	benchCmd.Flags().IntVar(&ctx.Bench.PreFillingCount, "fill", bench.PreFillingCount, "number of records to pre-fill the space")
+
 }

--- a/cli/context/context.go
+++ b/cli/context/context.go
@@ -187,4 +187,8 @@ type BenchCtx struct {
 	Duration             int    // Duration describes test duration in seconds.
 	KeySize              int    // DataSize describes the size of key part of benchmark data (bytes).
 	DataSize             int    // DataSize describes the size of value part of benchmark data (bytes).
+	InsertCount          int    // InsertCount describes the number of insert operations as a percentage.
+	SelectCount          int    // SelectCount describes the number of select operations as a percentage.
+	UpdateCount          int    // UpdateCount describes the number of update operations as a percentage.
+	PreFillingCount      int    // PreFillingCount describes the number of records to pre-fill the space.
 }

--- a/test/integration/bench/test_bench.py
+++ b/test/integration/bench/test_bench.py
@@ -36,3 +36,11 @@ def test_bench(cartridge_cmd, request, tmpdir):
 
     rc, output = run_command_and_get_output(base_cmd, cwd=tmpdir)
     assert rc == 0
+
+    base_cmd = [cartridge_cmd, 'bench', '--duration=1', '--fill=1000']
+    rc, output = run_command_and_get_output(base_cmd, cwd=tmpdir)
+    assert rc == 0
+
+    base_cmd = [cartridge_cmd, 'bench', '--duration=1', '--insert=0', '--select=50', '--update=50']
+    rc, output = run_command_and_get_output(base_cmd, cwd=tmpdir)
+    assert rc == 0


### PR DESCRIPTION
Patch for load profile with additional select and update operations and with support for benchmark space pre-filling
```
user@cartridge-cli % ./cartridge bench --select=30 --update=30 --insert=40 --fill=100000
Tarantool 2.8.2 (Binary) f4897ffe-98dd-40fc-a6f2-21ca8bb52fe7  

Parameters:
        URL: 127.0.0.1:3301
        user: guest
        connections: 10
        simultaneous requests: 10
        duration: 10 seconds
        key size: 10 bytes
        data size: 20 bytes
        insert: 40 percentages
        select: 30 percentages
        update: 30 percentages

Data schema
| key                            | value
| ------------------------------ | ------------------------------
| random(10)                     | random(20)

The pre-filling of the space has started,
because the insert operation is not specified
or there was an explicit instruction for pre-filling
...
Pre-filling is finished

Benchmark start
...
Benchmark stop

Results:
        Success operations: 1430826
        Failed  operations: 0
        Request count: 1432454
        Time (seconds): 10.000640
        Requests per second: 143236
```

What has been done? Why? What problem is being solved?

I didn't forget about

- [ ] Tests
- [ ] Changelog
- [ ] Documentation

Closes #???
