### PR TITLE
Describe local test run, fix some mage issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Tarantool benchmark tool (early alpha, API can be changed in the near future).
 - Ability to reverse search in ``cartridge enter`` and ``cartridge connect`` commands.
 - Added support for functionality from Golang 1.17.
+- Describe scenario of local test run.
 
 ## [2.10.0] - 2021-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed project build with capital letters in the project name.
 - Fixed display of Docker image pull (``cartridge pack`` command with ``--verbose`` flag).
 - Added support for new Tarantool release policy.
+- ``mage clean`` removes all generated code.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed display of Docker image pull (``cartridge pack`` command with ``--verbose`` flag).
 - Added support for new Tarantool release policy.
 - ``mage clean`` removes all generated code.
+- All mage test commands now depend on code generation step.
 
 ### Added
 

--- a/README.dev.md
+++ b/README.dev.md
@@ -1,0 +1,95 @@
+## How to run tests
+
+### Requirements
+
+1. Install [Go](https://go.dev/doc/install) 1.17.
+   ```bash
+   go version
+   ```
+
+2. Install [Python](https://www.python.org/downloads/) 3.x and [pip](https://pypi.org/project/pip/).
+   ```bash
+   python3 --version
+   pip3 --version
+   ```
+
+3. Install `unzip`, `rpm` and `cpio` packages.
+   ```bash
+   unzip -v
+   rpm --version
+   cpio --version
+   ```
+   
+4. Install [git](https://git-scm.com/downloads).
+   ```bash
+   git --version
+   ```
+      
+5. Install [docker](https://www.docker.com/get-started).
+   ```bash
+   docker --version
+   ```
+    
+6. Install [Tarantool](https://www.tarantool.io/en/download/os-installation/) (1.10 or 2.x version).
+   ```bash
+   tarantool --version
+   ```
+
+7. Install [mage](https://github.com/magefile/mage).
+   ```bash
+   mage --version
+   ```
+   If something went wrong, this may help.
+   ```bash
+   export PATH=$(go env GOPATH)/bin:$PATH
+   ```
+     
+8. Install [pytest](https://docs.pytest.org/en/6.2.x/getting-started.html).
+   ```bash
+   python3 -m pytest --version
+   ```
+
+9. Clone this repo.
+   ```bash
+   git clone git@github.com:tarantool/cartridge-cli.git
+   cd ./cartridge-cli
+   ```
+   
+10. To run tests, git user must be configured. For example,
+    ```bash
+    git config --global user.email "test@tarantool.io"
+    git config --global user.name "Tar Antool"
+    ```
+   
+11. Install pytest dependencies.
+    ```bash
+    pip3 install -r test/requirements.txt
+    ```
+    
+12. Install luacheck.
+    ```bash
+    tarantoolctl rocks install luacheck
+    ```
+
+All remaining dependencies (like code generation) will be invoked with mage if needed.
+
+### Test run
+
+To run all tests, call
+```bash
+mage test
+```
+
+You can run specific test sections.
+```bash
+# Static code analysis (including tests code).
+mage lint
+# Go unit tests.
+mage unit
+# pytest integration tests.
+mage integration
+# Run test example with pytest.
+mage testExamples
+# pytest end-to-end tests for packages.
+mage e2e
+```

--- a/magefile.go
+++ b/magefile.go
@@ -28,7 +28,7 @@ var packagePath = "./cli"
 var generateModePath = filepath.Join(packagePath, "codegen", "generate_code.go")
 var generatedFilesPath = fmt.Sprintf("./%s", filepath.Join(packagePath, "codegen", "static"))
 
-var generatedFSFile = "cartridge_vfsdata_gen.go"
+var generatedFSFile = "../../create/create_vfsdata_gen.go"
 var generatedModeFile = "create_cartrdige_template_filemodes_gen.go"
 
 var completionPath = "./completion"


### PR DESCRIPTION
To solve #658, I studied how current mage/CI pipeline of this repo works and met some issues, which was also fixed in this PR.

After PR #464 calling `mage clean` was broken. After execution of `mage generateGoCode` FSFile was created in path `cli/create/create_vfsdata_gen.go`, while `mage clean` tried to remove it from `cli/codegen/static/cartridge_vfsdata_gen.go` path.

Before this patch, calling `mage integration`, `mage testExamples` or `mage e2e` failed if `mage GenerateGoCode` hasn't been called yet (explicitly or as `mage lint`, `mage unit` or `mage build` dependency). Now all targets that require generated code explicitly depends on it.

[Documentation](https://magefile.org/dependencies/) says "Dependencies are guaranteed to run exactly once in a single execution of mage", but if there are several mage executions (like in this repo CI), dependencies will run multiple times. After this patch, Go code will not be rebuilt with `GenerateGoCode()` if build artifacts present, so CI will not do multiple deps calls. If you want to rebuild the code, call `mage clean` first.

At last, this path adds README.dev.md file with list of test requirements and short mage test commands descriptions. Scenario was validated in docker container.

Base image: `docker run -it --privileged cruizba/ubuntu-dind`

Commands:
```bash
export DEBIAN_FRONTEND=noninteractive
apt-get update

apt-get install -y wget
wget https://go.dev/dl/go1.17.5.linux-amd64.tar.gz
rm -rf /usr/local/go && tar -C /usr/local -xzf go1.17.5.linux-amd64.tar.gz
export PATH=$PATH:/usr/local/go/bin

apt-get install -y python3 pip
apt-get install -y unzip rpm cpio
apt-get install -y git
# docker already installed in dind

apt-get install -y curl
curl -L https://tarantool.io/OtKysgx/release/2.8/installer.sh | bash
apt-get install -y tarantool

git clone https://github.com/magefile/mage
cd mage
go run bootstrap.go
export PATH=$(go env GOPATH)/bin:$PATH

pip3 install pytest

git clone git@github.com:tarantool/cartridge-cli.git
cd ./cartridge-cli

git config --global user.email "test@tarantool.io"
git config --global user.name "Tar Antool"

pip3 install -r test/requirements.txt

tarantoolctl rocks install luacheck

mage test
```

I didn't forget about

- Tests (CI not fails, manually validated the guide)
- [x] Changelog
- [x] Documentation

Closes #658
