### PR TITLE
Remove outdated changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Cartridge errors in the ``replicasets`` command are now more readable.
-- Make Tarantool version check less strict, support `X.Y.Z` notation.
 - Removed unnecessary flags (``--rocks``, ``--project-path``) from ``cartridge help`` command.
 - Fixed project build with capital letters in the project name.
 - Fixed display of Docker image pull (``cartridge pack`` command with ``--verbose`` flag).


### PR DESCRIPTION
After PR #629, introduction of Tarantool version as a struct made
Tarantool version check strict (all existing Tarantool versions
are supported).

I didn't forget about

- Tests
- [x] Changelog
- Documentation


Follows up #619
