### PR TITLE
Update cartridge to 2.7.3 in application template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   (in the OCI Image Specification version 1.0.1 and prior, manifest and index
   documents are not self-describing and documents with a single digest could be
   interpreted as either a manifest or an index.)
+- Updated `cartridge` to `2.7.3` in application template.
+  Incompatibility with `tarantool` `2.10.0~beta2` or greater is fixed in `2.7.3`,
+  see https://github.com/tarantool/cartridge/commit/1649b40743bd05f2e71f2ce1ad5b5caf19f864d4
 
 ### Fixed
 

--- a/cli/create/templates/cartridge/{{ .Name | ToLower }}-scm-1.rockspec
+++ b/cli/create/templates/cartridge/{{ .Name | ToLower }}-scm-1.rockspec
@@ -8,7 +8,7 @@ dependencies = {
     'tarantool',
     'lua >= 5.1',
     'checks == 3.1.0-1',
-    'cartridge == 2.6.0-1',
+    'cartridge == 2.7.3-1',
     'metrics == 0.9.0-1',
     'cartridge-cli-extensions == 1.1.1-1',
 }

--- a/examples/getting-started-app/README.md
+++ b/examples/getting-started-app/README.md
@@ -689,7 +689,7 @@ dependencies = {
     'tarantool',
     'lua >= 5.1',
     'checks == 3.0.1-1',
-    'cartridge == 2.3.0-1',
+    'cartridge == 2.7.3-1',
     'ldecnumber == 1.1.3-1',
     'metrics == 0.9.0-1',
 }

--- a/examples/getting-started-app/README.md
+++ b/examples/getting-started-app/README.md
@@ -688,7 +688,7 @@ source  = {
 dependencies = {
     'tarantool',
     'lua >= 5.1',
-    'checks == 3.0.1-1',
+    'checks == 3.1.0-1',
     'cartridge == 2.7.3-1',
     'ldecnumber == 1.1.3-1',
     'metrics == 0.9.0-1',

--- a/examples/getting-started-app/README_RUS.md
+++ b/examples/getting-started-app/README_RUS.md
@@ -687,7 +687,7 @@ source  = {
 dependencies = {
     'tarantool',
     'lua >= 5.1',
-    'checks == 3.0.1-1',
+    'checks == 3.1.0-1',
     'cartridge == 2.7.3-1',
     'ldecnumber == 1.1.3-1',
     'metrics == 0.9.0-1',

--- a/examples/getting-started-app/README_RUS.md
+++ b/examples/getting-started-app/README_RUS.md
@@ -688,7 +688,7 @@ dependencies = {
     'tarantool',
     'lua >= 5.1',
     'checks == 3.0.1-1',
-    'cartridge == 2.3.0-1',
+    'cartridge == 2.7.3-1',
     'ldecnumber == 1.1.3-1',
     'metrics == 0.9.0-1',
 }

--- a/examples/getting-started-app/getting-started-app-scm-1.rockspec
+++ b/examples/getting-started-app/getting-started-app-scm-1.rockspec
@@ -8,7 +8,7 @@ dependencies = {
     'tarantool',
     'lua >= 5.1',
     'checks == 3.0.1-1',
-    'cartridge == 2.3.0-1',
+    'cartridge == 2.7.3-1',
     'ldecnumber == 1.1.3-1',
     'metrics == 0.9.0-1',
 }

--- a/examples/getting-started-app/getting-started-app-scm-1.rockspec
+++ b/examples/getting-started-app/getting-started-app-scm-1.rockspec
@@ -7,7 +7,7 @@ source  = {
 dependencies = {
     'tarantool',
     'lua >= 5.1',
-    'checks == 3.0.1-1',
+    'checks == 3.1.0-1',
     'cartridge == 2.7.3-1',
     'ldecnumber == 1.1.3-1',
     'metrics == 0.9.0-1',

--- a/test/integration/cli/test_version.py
+++ b/test/integration/cli/test_version.py
@@ -174,5 +174,5 @@ def test_duplicate_cartridge_no_rocks_flag(project_with_cartridge, cartridge_cmd
 
     rc, output = run_command_and_get_output(cmd)
     assert rc == 0
-    assert "Version:\t2.5.0-1, 2.6.0-1" in output
+    assert "Version:\t2.5.0-1, 2.7.3-1" in output
     assert "Found multiple versions of Cartridge in rocks manifest" in output

--- a/test/integration/connect/test_connect.py
+++ b/test/integration/connect/test_connect.py
@@ -39,7 +39,8 @@ def test_uri_piped(cartridge_cmd, project_with_instances):
         '--password', DEFAULT_CLUSTER_COOKIE,
     ]
 
-    assert_successful_piped_commands(project, cmd, exp_connect='%s.%s' % (project.name, router.name))
+    assert_successful_piped_commands(project, cmd, exp_connect='%s.%s' % (project.name, router.name),
+                                     remote_control=True)
 
 
 def test_socket_piped(cartridge_cmd, project_with_instances):
@@ -53,7 +54,8 @@ def test_socket_piped(cartridge_cmd, project_with_instances):
         cartridge_cmd, 'connect', console_sock_path,
     ]
 
-    assert_successful_piped_commands(project, cmd, exp_connect='%s.%s' % (project.name, router.name))
+    assert_successful_piped_commands(project, cmd, exp_connect='%s.%s' % (project.name, router.name),
+                                     remote_control=False)
 
 
 def test_socket_no_title(cartridge_cmd, project_with_instances_no_cartridge):
@@ -67,7 +69,7 @@ def test_socket_no_title(cartridge_cmd, project_with_instances_no_cartridge):
         cartridge_cmd, 'connect', console_sock_path,
     ]
 
-    assert_successful_piped_commands(project, cmd, exp_connect=console_sock_path)
+    assert_successful_piped_commands(project, cmd, exp_connect=console_sock_path, remote_control=False)
 
 
 def test_uri_instance_exited(cartridge_cmd, project_with_instances):

--- a/test/integration/connect/test_enter.py
+++ b/test/integration/connect/test_enter.py
@@ -24,7 +24,8 @@ def test_enter_piped(cartridge_cmd, project_with_instances):
         cartridge_cmd, 'enter', router.name,
     ]
 
-    assert_successful_piped_commands(project, cmd, exp_connect='%s.%s' % (project.name, router.name))
+    assert_successful_piped_commands(project, cmd, exp_connect='%s.%s' % (project.name, router.name),
+                                     remote_control=False)
 
 
 def test_instance_exited(cartridge_cmd, project_with_instances):

--- a/test/integration/create/test_create.py
+++ b/test/integration/create/test_create.py
@@ -107,7 +107,7 @@ dependencies = {
     'tarantool',
     'lua >= 5.1',
     'checks == 3.0.1-1',
-    'cartridge == 2.3.0-1',
+    'cartridge == 2.7.3-1',
     'metrics == 0.9.0-1',
 }
 build = {

--- a/test/integration/create/test_create.py
+++ b/test/integration/create/test_create.py
@@ -106,7 +106,7 @@ source  = {
 dependencies = {
     'tarantool',
     'lua >= 5.1',
-    'checks == 3.0.1-1',
+    'checks == 3.1.0-1',
     'cartridge == 2.7.3-1',
     'metrics == 0.9.0-1',
 }

--- a/test/integration/replicasets/test_expel.py
+++ b/test/integration/replicasets/test_expel.py
@@ -53,11 +53,13 @@ def test_expel(cartridge_cmd, project_with_vshard_replicasets):
     assert is_instance_expelled(admin_api_url, hot_replica.name)
 
 
-def test_expel_fails(cartridge_cmd, project_with_vshard_replicasets):
+def test_expel_leader(cartridge_cmd, project_with_vshard_replicasets):
     project = project_with_vshard_replicasets.project
     instances = project_with_vshard_replicasets.instances
 
-    # the replicaset leader can't be expelled if vshard is bootstrapped
+    # the replicaset leader can be expelled if vshard is bootstrapped
+    # since cartridge 2.7.0
+    # https://github.com/tarantool/cartridge/issues/1281
 
     # bootstrap vshard
     cmd = [
@@ -69,11 +71,10 @@ def test_expel_fails(cartridge_cmd, project_with_vshard_replicasets):
 
     hot_master = instances['hot-master']
 
-    # expel cold sotrage master
+    # expel cold storage master
     cmd = [
         cartridge_cmd, 'replicasets', 'expel', hot_master.name,
     ]
 
     rc, output = run_command_and_get_output(cmd, cwd=project.path)
-    assert rc == 1
-    assert "is the leader and can't be expelled" in output
+    assert rc == 0


### PR DESCRIPTION
Update `cartridge` to `2.7.3` in application template, tests and
examples. Incompatibility with `tarantool` `2.10.0~beta2` or greater is
fixed in `2.7.3`, see [1].

Fixes failing topology edit tests for `tarantool` `2.10.0~beta2` or
greater.

`checks` version `3.1.0` is used in application template, while tests
and examples runs with `3.0.1`. This patch makes versions consistent.

1. https://github.com/tarantool/cartridge/commit/1649b40743bd05f2e71f2ce1ad5b5caf19f864d4

I didn't forget about

- [x] Tests (fixed)
- [x] Changelog
- Documentation (no behavior changes)

Closes #671
