### PR TITLE
Update Go to 1.17 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
       - '*'
 
 env:
-  GO_VERSION: 1.15
+  GO_VERSION: 1.17
   GORELEASER_VERSION: v0.146.0
 
 jobs:


### PR DESCRIPTION
After #628, package is built with Go 1.17 for test workflow.
At the same time, release workflow still uses Go 1.15.
This patch removes this inconsistency.

I didn't forget about

- Tests (run with Go 1.17 since #628)
- Changelog (have the entry since #628)
- Documentation (based on #628, there are no visible changes for a user)

Follows up #628
