### PR TITLE
cd: publish to RWS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,31 +65,6 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - name: Install packages required for publishing script
-        run: |
-          sudo apt-get -y update
-          sudo apt-get install -y procmail awscli reprepro
-
-      - name: Build createrepo_c tool
-        run: |
-          git clone https://github.com/rpm-software-management/createrepo_c.git && cd createrepo_c/
-          git checkout 0.17.1
-          mkdir build && cd build
-          sudo apt install -y libbz2-dev cmake libmagic-dev \
-            libglib2.0-dev libcurl4-openssl-dev libxml2-dev \
-            libpython3-dev librpm-dev libssl-dev libsqlite3-dev \
-            liblzma-dev zlib1g-dev libzstd-dev doxygen
-          cmake .. -DWITH_ZCHUNK=OFF -DWITH_LIBMODULEMD=OFF
-          make -j $(nproc)
-          sudo make install
-          cd ../..
-
-      - name: Import GPG key
-        run: |
-          mkdir -p ~/.gnupg
-          echo 'digest-algo sha256' >> ~/.gnupg/gpg.conf
-          gpg --import <(echo "${{ secrets.GPG_KEY }}")
-
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
@@ -107,12 +82,8 @@ jobs:
           name: packages
           path: dist
 
-      - name: Publish packages to S3 repo
+      - name: Publish packages to RWS
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          GPG_SIGN_KEY: ${{ secrets.GPG_SIGN_KEY }}
-          S3_UPDATE_REPO_SCRIPT_URL: ${{ secrets.S3_UPDATE_REPO_SCRIPT_URL }}
-          S3_BUCKET: ${{ secrets.S3_BUCKET }}
-          S3_FOLDER: release/modules
-        run: mage publishS3
+          RWS_URL_PART: https://rws.tarantool.org/release/modules
+          RWS_AUTH: ${{ secrets.RWS_AUTH }}
+        run: mage publishRWS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,6 @@
 name: Release
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - master
@@ -41,7 +40,7 @@ jobs:
       - name: Set GoReleaser flags
         id: set-goreleaser-flags
         run: |
-          if ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }} ; then
+          if ${{ startsWith(github.ref, 'refs/tags') }} ; then
             echo "::set-output name=GORELEASER_FLAGS::--rm-dist --skip-validate"
           else
             echo "::set-output name=GORELEASER_FLAGS::--rm-dist --snapshot --skip-publish --skip-validate"
@@ -62,7 +61,7 @@ jobs:
   publish-s3:
     needs: create-packages
     runs-on: ubuntu-18.04
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags')
+    if: startsWith(github.ref, 'refs/tags')
     steps:
       - uses: actions/checkout@master
 
@@ -108,15 +107,6 @@ jobs:
           name: packages
           path: dist
 
-      - name: Set S3_FOLDER
-        id: set-s3-folder
-        run: |
-          if ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }} ; then
-            echo "::set-output name=S3_FOLDER::release/modules"
-          else
-            echo "::set-output name=S3_FOLDER::check/modules"
-          fi
-
       - name: Publish packages to S3 repo
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -124,5 +114,5 @@ jobs:
           GPG_SIGN_KEY: ${{ secrets.GPG_SIGN_KEY }}
           S3_UPDATE_REPO_SCRIPT_URL: ${{ secrets.S3_UPDATE_REPO_SCRIPT_URL }}
           S3_BUCKET: ${{ secrets.S3_BUCKET }}
-          S3_FOLDER: ${{ steps.set-s3-folder.outputs.S3_FOLDER }}
+          S3_FOLDER: release/modules
         run: mage publishS3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   create-packages:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
         with:
@@ -60,7 +60,7 @@ jobs:
 
   publish-s3:
     needs: create-packages
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags')
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     if: |
       github.event_name == 'push' ||
       github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login != 'tarantool'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         tarantool-version: ["1.10", "2.8", "2.x-latest"]
@@ -70,6 +70,10 @@ jobs:
           sudo systemctl disable tarantool@example || true
           sudo rm -rf /lib/systemd/system/tarantool@.service
 
+      # This server starts and listen on 8084 port that is used for tests
+      - name: Stop Mono server
+        run: sudo kill -9 $(sudo lsof -t -i tcp:8084) || true
+
       - name: Setup python
         uses: actions/setup-python@v2
         with:
@@ -86,6 +90,17 @@ jobs:
           mage --version
           tarantool --version
           rpm --version
+
+      - name: Log ports
+        run: sudo ss -tulw
+
+      - name: Stop and disable mono-xsp4 service
+        run: |
+          sudo systemctl stop mono-xsp4.service || true
+          sudo systemctl disable mono-xsp4.service || true
+
+      - name: Log ports
+        run: sudo ss -tulw
 
       - name: Linter
         run: mage lint
@@ -105,7 +120,7 @@ jobs:
   tests-ee:
     if: |
       github.event_name == 'push'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         sdk-version: ["2.8.2-0-gfc96d10f5-r421"]
@@ -156,6 +171,10 @@ jobs:
           SDK_PATH="$(realpath tarantool-enterprise)"
           echo "${SDK_PATH}" >> ${GITHUB_PATH}
           echo "TARANTOOL_SDK_PATH=${SDK_PATH}" >> ${GITHUB_ENV}
+
+      # This server starts and listen on 8084 port that is used for tests
+      - name: Stop Mono server
+        run: sudo kill -9 $(sudo lsof -t -i tcp:8084) || true
 
       - name: Setup python
         uses: actions/setup-python@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Updated `luacheck` to `0.26.0` in application template.
 - ``cartridge pack`` command now ignores the contents of ``run_dir``, ``data_dir``,
   ``log_dir`` directories (if default or set with ``.cartridge.yml``).
+- Change package release policy:
+  * drop EL6 (CentOS 6.x, RHEL 6.x, CloudLinux 6.x);
+  * drop Fedora 29;
+  * drop Ubuntu 14.04 (Trusty);
+  * drop Debian 8 (Jessie);
+  * add Fedora 31, 32, 33, 34, 35;
+  * add Ubuntu 21.04 (Hirsute).
 
 ### Fixed
 

--- a/magefile.publish.go
+++ b/magefile.publish.go
@@ -29,19 +29,21 @@ type Distro struct {
 }
 
 var targetDistros = []Distro{
-	{OS: "el", Dist: "6"},
 	{OS: "el", Dist: "7"},
 	{OS: "el", Dist: "8"},
-	{OS: "fedora", Dist: "29"},
 	{OS: "fedora", Dist: "30"},
+	{OS: "fedora", Dist: "31"},
+	{OS: "fedora", Dist: "32"},
+	{OS: "fedora", Dist: "33"},
+	{OS: "fedora", Dist: "34"},
+	{OS: "fedora", Dist: "35"},
 
-	{OS: "ubuntu", Dist: "trusty"},
 	{OS: "ubuntu", Dist: "xenial"},
 	{OS: "ubuntu", Dist: "bionic"},
 	{OS: "ubuntu", Dist: "eoan"},
 	{OS: "ubuntu", Dist: "focal"},
+	{OS: "ubuntu", Dist: "hirsute"},
 
-	{OS: "debian", Dist: "jessie"},
 	{OS: "debian", Dist: "stretch"},
 	{OS: "debian", Dist: "buster"},
 	{OS: "debian", Dist: "bullseye"},


### PR DESCRIPTION
Before merge, someone should set `RWS_AUTH` secret for GitHub Actions.

Change package release policy:
  * drop EL6 (CentOS 6.x, RHEL 6.x, CloudLinux 6.x);
  * drop Fedora 29;
  * drop Ubuntu 14.04 (Trusty);
  * drop Debian 8 (Jessie);
  * add Fedora 31, 32, 33, 34, 35;
  * add Ubuntu 21.04 (Hirsute).

Deprecate workflow_dispatch release flow.

After this patch, package will be published to RWS with curl instead of outdated [update-repo.sh script](https://github.com/tarantool/tarantool/blob/c9e3926e5ae82785c5eb494521c44ba522109e95/tools/update_repo.sh). You can use ``RWS_URL_PART=URL RWS_AUTH=USER:PWD mage PublishRWS`` to publish packages built with goreleaser.

I manually tested it with https://test-tarantool-rws.herokuapp.com/release/modules

Closes #679