### PR TITLE
Release 2.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.11.0] - 2022-01-26
 
 ### Changed
 - Updated ``containerd`` version to 1.5.8 to fix the vulnerability bugs:
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     If the Content-Type header changed between pulls of the same ambiguous
     document (with the same digest), the document may be interpreted differently,
     meaning that the digest alone is insufficient to unambiguously identify
-    the content of the image..)
+    the content of the image.)
 - Updated ``image-spec`` version to 1.0.2 to fix the vulnerability bug
   https://github.com/opencontainers/distribution-spec/security/advisories/GHSA-mc8v-mgrf-8f4m
   (in the OCI Image Specification version 1.0.1 and prior, manifest and index


### PR DESCRIPTION
### Changed:
- Updated ``containerd`` version to 1.5.8 to fix the vulnerability bugs:
  * https://github.com/advisories/GHSA-c2h3-6mxw-7mvq (container root
    directories and some plugins had insufficiently restricted
    permissions, allowing otherwise unprivileged Linux users to traverse
    directory contents
    and execute programs.)
  * https://github.com/opencontainers/image-spec/security/advisories/GHSA-77vh-xpmg-72qh
    https://github.com/opencontainers/distribution-spec/security/advisories/GHSA-mc8v-mgrf-8f4m
    (manifest and index documents are ambiguous without an accompanying Content-Type
    HTTP header. Versions of containerd prior to 1.4.12 and 1.5.8 treat
    the Content-Type header as trusted and deserialize the document
    according to that header.
    If the Content-Type header changed between pulls of the same
    ambiguous document (with the same digest), the document may be
    interpreted differently, meaning that the digest alone
    is insufficient to unambiguously identify the content of the image.)
- Updated ``image-spec`` version to 1.0.2 to fix the vulnerability bug
  https://github.com/opencontainers/distribution-spec/security/advisories/GHSA-mc8v-mgrf-8f4m
  (in the OCI Image Specification version 1.0.1 and prior, manifest
  and index documents are not self-describing and documents with
  a single digest could be interpreted as either a manifest or
  an index.)
- Updated `cartridge` to `2.7.3` in application template.
  Incompatibility with `tarantool` `2.10.0~beta2` or greater
  is fixed in `2.7.3`, see
  https://github.com/tarantool/cartridge/commit/1649b40743bd05f2e71f2ce1ad5b5caf19f864d4
- Updated `metrics` to `0.12.0` in application template.
- Updated `luatest` to `0.5.6` in application template.
- Updated `luacheck` to `0.26.0` in application template.
- ``cartridge pack`` command now ignores the contents of ``run_dir``,
  ``data_dir``, ``log_dir`` directories (if default or set
  with ``.cartridge.yml``).
- Change package release policy:
  * drop EL6 (CentOS 6.x, RHEL 6.x, CloudLinux 6.x);
  * drop Fedora 29;
  * drop Ubuntu 14.04 (Trusty);
  * drop Debian 8 (Jessie);
  * add Fedora 31, 32, 33, 34, 35;
  * add Ubuntu 21.04 (Hirsute).

### Fixed:
- Cartridge errors in the ``replicasets`` command are now more readable.
- Removed unnecessary flags (``--rocks``, ``--project-path``)
  from ``cartridge help`` command.
- Fixed project build with capital letters in the project name.
- Fixed display of Docker image pull (``cartridge pack`` command
  with ``--verbose`` flag).
- Added support for new Tarantool release policy.
- ``mage clean`` removes all generated code.
- All mage test commands now depend on code generation step.

### Added:
- Tarantool benchmark tool (early alpha, API can be changed
  in the near future).
- Ability to reverse search in ``cartridge enter`` and
  ``cartridge connect`` commands.
- Added support for functionality from Golang 1.17.
- Describe scenario of local test run.