### PR TITLE
ci: clean up ports log

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,16 +91,10 @@ jobs:
           tarantool --version
           rpm --version
 
-      - name: Log ports
-        run: sudo ss -tulw
-
       - name: Stop and disable mono-xsp4 service
         run: |
           sudo systemctl stop mono-xsp4.service || true
           sudo systemctl disable mono-xsp4.service || true
-
-      - name: Log ports
-        run: sudo ss -tulw
 
       - name: Linter
         run: mage lint


### PR DESCRIPTION
This patch cleans up commands used to debug CI/CD in PR #680
