### PR TITLE
fix: remove unwanted char in version hash pattern

### DIFF
--- a/cli/pack/common.go
+++ b/cli/pack/common.go
@@ -23,9 +23,9 @@ var (
 		regexp.MustCompile(`^(?P<Major>\d+)\.(?P<Minor>\d+)$`),
 		regexp.MustCompile(`^(?P<Major>\d+)\.(?P<Minor>\d+)\.(?P<Patch>\d+)$`),
 		regexp.MustCompile(`^(?P<Major>\d+)\.(?P<Minor>\d+)\.(?P<Patch>\d+)-(?P<Count>\d+)$`),
-		regexp.MustCompile(`^(?P<Major>\d+)\.(?P<Minor>\d+)\.(?P<Patch>\d+)-(?P<Hash>g\w+)$`),
+		regexp.MustCompile(`^(?P<Major>\d+)\.(?P<Minor>\d+)\.(?P<Patch>\d+)-(?P<Hash>\w+)$`),
 		regexp.MustCompile(
-			`^(?P<Major>\d+)\.(?P<Minor>\d+)\.(?P<Patch>\d+)-(?P<Count>\d+)-(?P<Hash>g\w+)$`,
+			`^(?P<Major>\d+)\.(?P<Minor>\d+)\.(?P<Patch>\d+)-(?P<Count>\d+)-(?P<Hash>\w+)$`,
 		),
 	}
 )


### PR DESCRIPTION
It seems like first 'g' char in version hash is misspelling result and totally unwanted.

It was impossible to specify version like `1.1.1-1-pre`, it was possible only with 'g' char first -- `1.1.1-1-gpre`.
