### PR TITLE
Update containerd version to 1.5.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
 - **Breaking**: change ``cartridge pack`` naming strategy:
   * RPM: `<app-name>-<version>[.<suffix>]-1.<arch>.rpm`,
   * DEB: `<app-name>_<version>[.<suffix>]-1_<arch>.deb`,
@@ -22,6 +24,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [2](https://www.debian.org/doc/manuals/debian-reference/ch02.en.html#_debian_package_file_names)],
   rpm policy [[1](http://ftp.rpm.org/max-rpm/ch-rpm-file-format.html)]).
   For example, dashes in RPM version (like `1.2.3-0`) is no longer supported.
+
+- Updated ``containerd`` version to 1.5.10 to fix the vulnerability bugs:
+  bug was found in containerd where containers launched through containerd’s
+  CRI implementation with a specially-crafted image configuration could gain
+  access to read-only copies of arbitrary files and directories on the host.
+  This may bypass any policy-based enforcement on container setup (including
+  a Kubernetes Pod Security Policy) and expose potentially sensitive
+  information. Kubernetes and crictl can both be configured to use containerd’s
+  CRI implementation.
+  CVE ID: CVE-2022-23648
+  GHSA ID: GHSA-crp2-qrr5-8pq7
 
 ## [2.11.0] - 2022-01-26
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/briandowns/spinner v1.11.1
 	github.com/c-bata/go-prompt v0.2.5
-	github.com/containerd/containerd v1.5.9 // indirect
+	github.com/containerd/containerd v1.5.10 // indirect
 	github.com/dave/jennifer v1.4.1
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/distribution v2.8.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -157,8 +157,8 @@ github.com/containerd/containerd v1.5.0-beta.1/go.mod h1:5HfvG1V2FsKesEGQ17k5/T7
 github.com/containerd/containerd v1.5.0-beta.3/go.mod h1:/wr9AVtEM7x9c+n0+stptlo/uBBoBORwEx6ardVcmKU=
 github.com/containerd/containerd v1.5.0-beta.4/go.mod h1:GmdgZd2zA2GYIBZ0w09ZvgqEq8EfBp/m3lcVZIvPHhI=
 github.com/containerd/containerd v1.5.0-rc.0/go.mod h1:V/IXoMqNGgBlabz3tHD2TWDoTJseu1FGOKuoA4nNb2s=
-github.com/containerd/containerd v1.5.9 h1:rs6Xg1gtIxaeyG+Smsb/0xaSDu1VgFhOCKBXxMxbsF4=
-github.com/containerd/containerd v1.5.9/go.mod h1:fvQqCfadDGga5HZyn3j4+dx56qj2I9YwBrlSdalvJYQ=
+github.com/containerd/containerd v1.5.10 h1:3cQ2uRVCkJVcx5VombsE7105Gl9Wrl7ORAO3+4+ogf4=
+github.com/containerd/containerd v1.5.10/go.mod h1:fvQqCfadDGga5HZyn3j4+dx56qj2I9YwBrlSdalvJYQ=
 github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.0.0-20190815185530-f2a389ac0a02/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.0.0-20191127005431-f65d91d395eb/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=


### PR DESCRIPTION
Vulnerable versions: >= 1.5.0, < 1.5.10

Impact:
A bug was found in containerd where containers launched through
containerd’s CRI implementation with a specially-crafted image
configuration could gain access to read-only copies of arbitrary
files and directories on the host. This may bypass any policy-based
enforcement on container setup (including a Kubernetes Pod Security Policy)
and expose potentially sensitive information. Kubernetes and crictl
can both be configured to use containerd’s CRI implementation.

CVE ID: CVE-2022-23648
GHSA ID: GHSA-crp2-qrr5-8pq7