### PR TITLE
Fix work with terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Bug that caused a typed command not to be displayed on the terminal after
+  exiting the "connect" console.
+
 ## [2.12.0] - 2022-03-30
 
 ### Changed

--- a/cli/connect/console.go
+++ b/cli/connect/console.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -133,6 +134,12 @@ func (console *Console) Run() error {
 	)
 
 	console.prompt.Run()
+
+	// Sets the terminal modes to “sane” values to workaround
+	// bug https://github.com/c-bata/go-prompt/issues/228
+	sttySane := exec.Command("stty", "sane")
+	sttySane.Stdin = os.Stdin
+	_ = sttySane.Run()
 
 	return nil
 }


### PR DESCRIPTION
The patch adds a workaround for the bug "Terminal does not display command after go-prompt exit" (https://github.com/c-bata/go-prompt/issues/228).