### PR TITLE
703. More flexible cartridge pack artifact naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Ability to explicitly set a full name of the bundle created by ``cartridge pack``.
+  (flag `--filename`)
+
 ### Fixed
 
 - Bug that caused a typed command not to be displayed on the terminal after

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Loosed ``cartridge pack`` `--version` and `--suffix` verification,
+  so it will log a warning instead of returning an error if non-valid string is passed
+  (in terms or RPM/DEB standards).
 ### Added
 
 - Ability to explicitly set a full name of the bundle created by ``cartridge pack``.

--- a/cli/commands/pack.go
+++ b/cli/commands/pack.go
@@ -30,6 +30,7 @@ func init() {
 	addSpecFlag(packCmd)
 
 	packCmd.Flags().StringVar(&ctx.Pack.Version, "version", "", versionUsage)
+	packCmd.Flags().StringVar(&ctx.Pack.Filename, "filename", "", filenameUsage)
 	packCmd.Flags().StringVar(&ctx.Pack.Suffix, "suffix", "", suffixUsage)
 	packCmd.Flags().StringSliceVar(&ctx.Pack.ImageTags, "tag", []string{}, tagUsage)
 

--- a/cli/commands/usage.go
+++ b/cli/commands/usage.go
@@ -67,6 +67,8 @@ script for the RPM and DEB packages.`
 script for the RPM and DEB packages.`
 
 	UnitParamsFileUsage = `Path to the file that contains systemd unit params`
+
+	filenameUsage = `Explicitly set filename of the bundle`
 )
 
 // RUNNING

--- a/cli/context/context.go
+++ b/cli/context/context.go
@@ -102,6 +102,7 @@ type PackCtx struct {
 	ResImageTags    []string
 
 	Version           string
+	Filename          string
 	Release           string
 	Arch              string
 	Suffix            string

--- a/cli/pack/common.go
+++ b/cli/pack/common.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/apex/log"
 	"github.com/tarantool/cartridge-cli/cli/common"
 	"github.com/tarantool/cartridge-cli/cli/context"
 	"github.com/tarantool/cartridge-cli/cli/project"
@@ -97,11 +98,11 @@ func buildVersionWithSuffix(ctx *context.Ctx) error {
 	switch ctx.Pack.Type {
 	case RpmType:
 		if !packageVerAllowed[RpmType].MatchString(suffix) {
-			return fmt.Errorf("Dashes are not allowed in RPM --suffix")
+			log.Warnf("Dashes are not allowed in RPM --suffix")
 		}
 	case DebType:
 		if !packageVerAllowed[DebType].MatchString(suffix) {
-			return fmt.Errorf("DEB --suffix must satisfy [-a-zA-Z0-9.+:~]+")
+			log.Warnf("DEB --suffix must satisfy [-a-zA-Z0-9.+:~]+")
 		}
 	}
 
@@ -136,11 +137,11 @@ func detectVersion(ctx *context.Ctx) error {
 		switch ctx.Pack.Type {
 		case RpmType:
 			if !packageVerAllowed[RpmType].MatchString(ctx.Pack.Version) {
-				return fmt.Errorf("Dashes are not allowed in RPM --version")
+				log.Warnf("Dashes are not allowed in RPM --version")
 			}
 		case DebType:
 			if !packageVerAllowed[DebType].MatchString(ctx.Pack.Version) {
-				return fmt.Errorf("DEB --version must satisfy [-a-zA-Z0-9.+:]+")
+				log.Warnf("DEB --version must satisfy [-a-zA-Z0-9.+:]+")
 			}
 		}
 	}

--- a/cli/pack/common.go
+++ b/cli/pack/common.go
@@ -265,6 +265,13 @@ func checkTagVersionSuffix(ctx *context.Ctx) error {
 	return nil
 }
 
+func checkFilename(ctx *context.Ctx) bool {
+	if ctx.Pack.Filename != "" {
+		return true
+	}
+	return false
+}
+
 const (
 	tagVersionSuffixErr = `You can specify only --version (and --suffix) or --tag options`
 )

--- a/cli/pack/pack.go
+++ b/cli/pack/pack.go
@@ -152,7 +152,11 @@ func Run(ctx *context.Ctx) error {
 		if err != nil {
 			return err
 		}
-		ctx.Pack.ResPackagePath = filepath.Join(curDir, getPackageFullname(ctx))
+		if checkFilename(ctx) {
+			ctx.Pack.ResPackagePath = filepath.Join(curDir, ctx.Pack.Filename)
+		} else {
+			ctx.Pack.ResPackagePath = filepath.Join(curDir, getPackageFullname(ctx))
+		}
 	} else {
 		// set result image fullname
 		ctx.Pack.ResImageTags = getImageTags(ctx)

--- a/test/integration/pack/test_pack.py
+++ b/test/integration/pack/test_pack.py
@@ -344,6 +344,29 @@ def test_git_version_result_filename(cartridge_cmd, project_without_dependencies
 
 
 @pytest.mark.parametrize('pack_format', ['tgz'])
+def test_filename_flag(cartridge_cmd, project_without_dependencies, tmpdir, pack_format):
+    project = project_without_dependencies
+
+    # Project is initialized as a git repo with version tag `0.1.0`.
+    repo = git.Repo(project.path)
+    assert not repo.bare
+
+    git_version = repo.git.describe('--tags', '--long')
+    assert git_version.startswith('0.1.0-0')
+    expected_filename = "linux_0.1.0-0_company.tar.gz"
+
+    cmd = [
+        cartridge_cmd,
+        "pack", pack_format,
+        "--filename", expected_filename,
+        project.path,
+    ]
+    process = subprocess.run(cmd, cwd=tmpdir)
+    assert process.returncode == 0
+    assert expected_filename in os.listdir(tmpdir)
+
+
+@pytest.mark.parametrize('pack_format', ['tgz'])
 def test_git_invalid_versions(cartridge_cmd, project_without_dependencies, tmpdir, pack_format):
     project = project_without_dependencies
 


### PR DESCRIPTION
Added --filename flag to pack command, it allows to explicitly set name of the pack.
Also relaxed --version validation.