### PR TITLE
pack: add documentation for '--filename'

### DIFF
--- a/doc/commands/pack.rst
+++ b/doc/commands/pack.rst
@@ -73,6 +73,10 @@ be it RPM, DEB, TGZ, or a Docker image.
             -   The suffix of the resulting file or image name.
                 For example, a ``tar.gz`` distribution is named according to the pattern:
                 ``<name>-<version>[.<suffix>].<arch>.tar.gz``.
+        *   -   ``--filename``
+            -   Explicitly set a full name of the bundle.
+                For example, a bundle packed with ``--filename bundle_name.tar.gz`` is named
+                ``bundle_name.tar.gz``.
         *   -   ``--use-docker``
             -   Force Cartridge to build the application in Docker.
                 Enforced if you're building a Docker image.

--- a/doc/locale/ru/LC_MESSAGES/doc/commands/pack.po
+++ b/doc/locale/ru/LC_MESSAGES/doc/commands/pack.po
@@ -112,6 +112,18 @@ msgstr ""
 "Суффикс итогового имени файла или образа. Например, дистрибутив ``tar.gz`` "
 "именуется по следующему шаблону: ``<имя>-<версия>[.<суффикс>].<архитектура>.tar.gz``."
 
+msgid "``--filename``"
+msgstr "``--filename``"
+
+msgid ""
+"Explicitly set a full name of the bundle. "
+"For example, a bundle packed with ``--filename bundle_name.tar.gz`` is named "
+"``bundle_name.tar.gz``."
+msgstr ""
+"Явно задать полное имя пакета. "
+"Например, пакет, собранный с ``--filename bundle_name.tar.gz`` , имеет имя "
+"``bundle_name.tar.gz``."
+
 msgid "``--use-docker``"
 msgstr "``--use-docker``"
 


### PR DESCRIPTION
Added documentation for flag '--filename' (command pack).

Part of #703
