### PR TITLE
Remove bold formatting from a random line in docs

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -69,7 +69,7 @@ Linux
 ~~~~~
 
 The ``cartridge-cli`` RPM and DEB packages contain a Bash completion script,
- ``/etc/bash_completion.d/cartridge``.
+``/etc/bash_completion.d/cartridge``.
 
 To enable completion after ``cartridge-cli`` installation, open a new shell or
 source the completion file at ``/etc/bash_completion.d/cartridge``.


### PR DESCRIPTION
Indentation before the line made this line a definition,
and the line before it became a defined term.
