### PR TITLE
build: use go embed for lua files

### DIFF
--- a/cli/admin/common.go
+++ b/cli/admin/common.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	_ "embed"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -18,6 +19,9 @@ import (
 	"github.com/tarantool/cartridge-cli/cli/context"
 	"github.com/tarantool/cartridge-cli/cli/project"
 )
+
+//go:embed lua/eval_func_get_res_body_template.lua
+var evalFuncGetResBodyTmpl string
 
 type ArgSpec struct {
 	Usage string

--- a/cli/cluster/membership.go
+++ b/cli/cluster/membership.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	_ "embed"
 	"fmt"
 
 	"github.com/apex/log"
@@ -9,6 +10,12 @@ import (
 	"github.com/tarantool/cartridge-cli/cli/context"
 	"github.com/vmihailenco/msgpack/v5"
 )
+
+//go:embed lua/get_membership_instances_body.lua
+var getMembershipInstancesBody string
+
+//go:embed lua/probe_instances_body.lua
+var probeInstancesBody string
 
 type MembershipInstance struct {
 	URI string

--- a/cli/codegen/generate_code.go
+++ b/cli/codegen/generate_code.go
@@ -1,85 +1,12 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
 	"github.com/apex/log"
 	"github.com/dave/jennifer/jen"
 )
-
-type generateLuaCodeOpts struct {
-	PackageName  string
-	FileName     string
-	PackagePath  string
-	VariablesMap map[string]string
-}
-
-var luaCodeFiles = []generateLuaCodeOpts{
-	{
-		PackageName: "admin",
-		FileName:    "cli/admin/lua_code_gen.go",
-		VariablesMap: map[string]string{
-			"adminListFuncBodyTmpl":  "cli/admin/lua/admin_list_func_body_template.lua",
-			"evalFuncGetResBodyTmpl": "cli/admin/lua/eval_func_get_res_body_template.lua",
-		},
-	},
-	{
-		PackageName: "connect",
-		FileName:    "cli/connect/lua_code_gen.go",
-		VariablesMap: map[string]string{
-			"evalFuncBody":           "cli/connect/lua/eval_func_body.lua",
-			"getSuggestionsFuncBody": "cli/connect/lua/get_suggestions_func_body.lua",
-			"getTitleFuncBody":       "cli/connect/lua/get_title_func_body.lua",
-		},
-	},
-	{
-		PackageName: "connector",
-		FileName:    "cli/connector/lua_code_gen.go",
-		VariablesMap: map[string]string{
-			"callFuncTmpl": "cli/connector/lua/call_func_template.lua",
-			"evalFuncTmpl": "cli/connector/lua/eval_func_template.lua",
-		},
-	},
-	{
-		PackageName: "repair",
-		FileName:    "cli/repair/lua_code_gen.go",
-		VariablesMap: map[string]string{
-			"reloadClusterwideConfigFuncBody": "cli/repair/lua/reload_clusterwide_config_func_body.lua",
-		},
-	},
-	{
-		PackageName: "replicasets",
-		FileName:    "cli/replicasets/lua_code_gen.go",
-		VariablesMap: map[string]string{
-			"bootstrapVshardBody":                  "cli/replicasets/lua/bootstrap_vshard_body.lua",
-			"getClusterIsHealthyBody":              "cli/replicasets/lua/get_cluster_is_healthy_body.lua",
-			"editInstanceBody":                     "cli/replicasets/lua/edit_instance_body.lua",
-			"editReplicasetsBodyTemplate":          "cli/replicasets/lua/edit_replicasets_body_template.lua",
-			"formatTopologyReplicasetFuncTemplate": "cli/replicasets/lua/format_topology_replicaset_func_template.lua",
-			"getKnownRolesBody":                    "cli/replicasets/lua/get_known_roles_body.lua",
-			"getKnownVshardGroupsBody":             "cli/replicasets/lua/get_known_vshard_groups_body.lua",
-			"getTopologyReplicasetsBodyTemplate":   "cli/replicasets/lua/get_topology_replicasets_body_template.lua",
-		},
-	},
-	{
-		PackageName: "cluster",
-		FileName:    "cli/cluster/lua_code_gen.go",
-		VariablesMap: map[string]string{
-			"getMembershipInstancesBody": "cli/cluster/lua/get_membership_instances_body.lua",
-			"probeInstancesBody":         "cli/cluster/lua/probe_instances_body.lua",
-		},
-	},
-	{
-		PackageName: "failover",
-		FileName:    "cli/failover/lua_code_gen.go",
-		VariablesMap: map[string]string{
-			"manageFailoverBody":    "cli/failover/lua/manage_failover_body.lua",
-			"getFailoverParamsBody": "cli/failover/lua/get_failover_params_body.lua",
-		},
-	},
-}
 
 /* generateFileModeFile generates a file with map like this:
 
@@ -88,6 +15,7 @@ var FileModes = map[string]int{
 	...
 }
 */
+
 func generateFileModeFile(path string, filename string) error {
 	f := jen.NewFile("static")
 	f.Comment("This file is generated! DO NOT EDIT\n")
@@ -137,26 +65,6 @@ func getFileModes(root string) (map[string]int, error) {
 	return fileModeMap, nil
 }
 
-func generateLuaCodeVar() error {
-	for _, opts := range luaCodeFiles {
-		f := jen.NewFile(opts.PackageName)
-		f.Comment("This file is generated! DO NOT EDIT\n")
-
-		for key, val := range opts.VariablesMap {
-			content, err := ioutil.ReadFile(val)
-			if err != nil {
-				return err
-			}
-
-			f.Var().Id(key).Op("=").Lit(string(content))
-		}
-
-		f.Save(opts.FileName)
-	}
-
-	return nil
-}
-
 func main() {
 	err := generateFileModeFile(
 		"cli/create/templates/cartridge",
@@ -165,9 +73,5 @@ func main() {
 
 	if err != nil {
 		log.Errorf("Error while generating file modes: %s", err)
-	}
-
-	if err := generateLuaCodeVar(); err != nil {
-		log.Errorf("Error while generating lua code string variables: %s", err)
 	}
 }

--- a/cli/connect/console.go
+++ b/cli/connect/console.go
@@ -2,6 +2,7 @@ package connect
 
 import (
 	"bufio"
+	_ "embed"
 	"fmt"
 	"io"
 	"os"
@@ -20,6 +21,15 @@ import (
 	"github.com/tarantool/cartridge-cli/cli/common"
 	"github.com/tarantool/cartridge-cli/cli/connector"
 )
+
+//go:embed lua/eval_func_body.lua
+var evalFuncBody string
+
+//go:embed lua/get_suggestions_func_body.lua
+var getSuggestionsFuncBody string
+
+//go:embed lua/get_title_func_body.lua
+var getTitleFuncBody string
 
 type EvalFunc func(console *Console, funcBodyFmt string, args ...interface{}) (interface{}, error)
 

--- a/cli/connector/eval_plain_text.go
+++ b/cli/connector/eval_plain_text.go
@@ -3,6 +3,7 @@ package connector
 import (
 	"bufio"
 	"bytes"
+	_ "embed"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -16,6 +17,12 @@ import (
 	"github.com/tarantool/cartridge-cli/cli/templates"
 	"gopkg.in/yaml.v2"
 )
+
+//go:embed lua/call_func_template.lua
+var callFuncTmpl string
+
+//go:embed lua/eval_func_template.lua
+var evalFuncTmpl string
 
 const (
 	startOfYamlOutput = "---\n"

--- a/cli/failover/manage.go
+++ b/cli/failover/manage.go
@@ -1,6 +1,7 @@
 package failover
 
 import (
+	_ "embed"
 	"fmt"
 	"strings"
 
@@ -8,6 +9,9 @@ import (
 	"github.com/tarantool/cartridge-cli/cli/connector"
 	"github.com/tarantool/cartridge-cli/cli/context"
 )
+
+//go:embed lua/manage_failover_body.lua
+var manageFailoverBody string
 
 type FailoverOpts map[string]interface{}
 type ProviderParams map[string]interface{}

--- a/cli/failover/status.go
+++ b/cli/failover/status.go
@@ -1,6 +1,7 @@
 package failover
 
 import (
+	_ "embed"
 	"fmt"
 	"reflect"
 	"sort"
@@ -13,6 +14,9 @@ import (
 	"github.com/tarantool/cartridge-cli/cli/context"
 	"github.com/tarantool/cartridge-cli/cli/project"
 )
+
+//go:embed lua/get_failover_params_body.lua
+var getFailoverParamsBody string
 
 func Status(ctx *context.Ctx) error {
 	if err := project.FillCtx(ctx); err != nil {

--- a/cli/repair/patch.go
+++ b/cli/repair/patch.go
@@ -1,6 +1,7 @@
 package repair
 
 import (
+	_ "embed"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,6 +13,9 @@ import (
 	"github.com/tarantool/cartridge-cli/cli/context"
 	"github.com/tarantool/cartridge-cli/cli/project"
 )
+
+//go:embed lua/reload_clusterwide_config_func_body.lua
+var reloadClusterwideConfigFuncBody string
 
 const (
 	confapplierWishStateTimeout = 10

--- a/cli/replicasets/lua_templates.go
+++ b/cli/replicasets/lua_templates.go
@@ -1,0 +1,27 @@
+package replicasets
+
+import _ "embed"
+
+//go:embed lua/bootstrap_vshard_body.lua
+var bootstrapVshardBody string
+
+//go:embed lua/get_cluster_is_healthy_body.lua
+var getClusterIsHealthyBody string
+
+//go:embed lua/edit_instance_body.lua
+var editInstanceBody string
+
+//go:embed lua/edit_replicasets_body_template.lua
+var editReplicasetsBodyTemplate string
+
+//go:embed lua/format_topology_replicaset_func_template.lua
+var formatTopologyReplicasetFuncTemplate string
+
+//go:embed lua/get_known_roles_body.lua
+var getKnownRolesBody string
+
+//go:embed lua/get_known_vshard_groups_body.lua
+var getKnownVshardGroupsBody string
+
+//go:embed lua/get_topology_replicasets_body_template.lua
+var getTopologyReplicasetsBodyTemplate string


### PR DESCRIPTION
Using codegen for embeding lua files can be replaced with build-in
`embed` module.


