### PR TITLE
Add missing TYPE argument

### DIFF
--- a/doc/commands/pack/building-in-docker.rst
+++ b/doc/commands/pack/building-in-docker.rst
@@ -5,7 +5,9 @@ To build your application in Docker, run this:
 
 ..  code-block:: bash
 
-    cartridge pack --use-docker
+    cartridge pack TYPE --use-docker
+
+For ``TYPE``, indicate ``rpm``, ``deb``, or ``tgz``.
 
 You might want to perform application build in Docker
 if your distributable is intended for a system different than the one you use.

--- a/doc/locale/ru/LC_MESSAGES/doc/commands/pack/building-in-docker.po
+++ b/doc/locale/ru/LC_MESSAGES/doc/commands/pack/building-in-docker.po
@@ -5,8 +5,11 @@ msgstr "Сборка в Docker"
 msgid "To build your application in Docker, run this:"
 msgstr "Чтобы собрать приложение в Docker, выполните следующую команду:"
 
-msgid "cartridge pack --use-docker"
-msgstr "cartridge pack --use-docker"
+msgid "cartridge pack TYPE --use-docker"
+msgstr "cartridge pack TYPE --use-docker"
+
+msgid "For ``TYPE``, indicate ``rpm``, ``deb``, or ``tgz``."
+msgstr "Вместо ``TYPE`` укажите ``rpm``, ``deb`` или ``tgz``."
 
 msgid ""
 "You might want to perform application build in Docker if your distributable "


### PR DESCRIPTION
Resolves tarantool/doc#2948

The command `cartridge pack --use-docker` was misleading, running it led to an error. Must have been `cartridge pack TYPE --use-docker`, for example, `cartridge pack rpm --use-docker`.