### PR TITLE
admin: fix run-dir path

### DIFF
--- a/cli/commands/admin.go
+++ b/cli/commands/admin.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"path/filepath"
 	"strings"
 
 	"github.com/apex/log"
@@ -62,6 +63,14 @@ func runAdminCommand(cmd *cobra.Command, args []string) error {
 
 	if err := flagSet.Parse(args); err != nil {
 		return err
+	}
+
+	if ctx.Running.RunDir != "" {
+		abspath, err := filepath.Abs(ctx.Running.RunDir)
+		if err != nil {
+			return err
+		}
+		ctx.Running.RunDir = abspath
 	}
 
 	// log level is usually set in rootCmd.PersistentPreRun

--- a/test/integration/admin/test_default.py
+++ b/test/integration/admin/test_default.py
@@ -80,6 +80,20 @@ def test_default_admin_func(cartridge_cmd, default_admin_running_instances, conn
         '• Probe "localhost:3301": OK',
     ]
 
+    # call --run-dir with relative path - OK
+    cmd = [
+        cartridge_cmd, 'admin',
+        '--name', project.name,
+        '--run-dir', './'+'/'.join(reversed(run_dir.split('/')[-1:-3:-1])),
+        'probe', '--uri', 'localhost:3301',
+    ]
+    rc, output = run_command_and_get_output(cmd, cwd='/'.join(run_dir.split('/')[0:-2:1]))
+    assert rc == 0
+
+    assert get_log_lines(output) == [
+        '• Probe "localhost:3301": OK',
+    ]
+
     # call w/ --uri localhost:3311 - fail
     cmd = [
         cartridge_cmd, 'admin',


### PR DESCRIPTION
From README.md in default cartridge template:

```
cartridge admin probe \
  --name void \
  --run-dir ./tmp/run \
  --uri localhost:3302
```

But this command will fails:

```
$  ../cartridge admin probe --name void --run-dir ./tmp/run --uri localhost:3302
   ⨯ Failed to connect to application instance: No available sockets found in: ./tmp/run
```

This patch allows you to use a relative path for the parameter
`--run-dir`