### PR TITLE
tests: make integration testing faster

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,7 @@ jobs:
     strategy:
       matrix:
         tarantool-version: ["1.10", "2.8", "2.x-latest"]
+        tests: ["other", "integration"]
       fail-fast: false
     steps:
       - uses: actions/checkout@master
@@ -97,18 +98,23 @@ jobs:
           sudo systemctl disable mono-xsp4.service || true
 
       - name: Linter
+        if: matrix.tests == 'other'
         run: mage lint
 
       - name: Unit tests
+        if: matrix.tests == 'other'
         run: mage unit
 
       - name: Integration tests
+        if: matrix.tests == 'integration'
         run: mage integration
 
       - name: Examples tests
+        if: matrix.tests == 'other'
         run: mage testExamples
 
       - name: e2e tests
+        if: matrix.tests == 'other'
         run: mage e2e
 
   tests-ee:
@@ -117,6 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        tests: ["other", "integration"]
         sdk-version: ["2.8.2-0-gfc96d10f5-r421"]
       fail-fast: false
     steps:
@@ -188,16 +195,21 @@ jobs:
           rpm --version
 
       - name: Linter
+        if: matrix.tests == 'other'
         run: mage lint
 
       - name: Unit tests
+        if: matrix.tests == 'other'
         run: mage unit
 
       - name: Integration tests
+        if: matrix.tests == 'integration'
         run: mage integration
 
       - name: Examples tests
+        if: matrix.tests == 'other'
         run: mage testExamples
 
       - name: e2e tests
+        if: matrix.tests == 'other'
         run: mage e2e

--- a/test/integration/admin/test_default.py
+++ b/test/integration/admin/test_default.py
@@ -1,22 +1,13 @@
-import subprocess
-
 import pytest
-from project import patch_cartridge_proc_titile
+from project import copy_project, patch_cartridge_proc_titile
 from utils import (get_admin_connection_params, get_log_lines,
                    run_command_and_get_output, start_instances)
 
 
 @pytest.fixture(scope="function")
-def default_admin_running_instances(cartridge_cmd, start_stop_cli, project_with_cartridge):
+def default_admin_running_instances(start_stop_cli, project_with_cartridge):
     project = project_with_cartridge
-
-    # build project
-    cmd = [
-        cartridge_cmd,
-        "build",
-    ]
-    process = subprocess.run(cmd, cwd=project.path)
-    assert process.returncode == 0, "Error during building the project"
+    copy_project("project_with_cartridge", project)
 
     # don't change process title
     patch_cartridge_proc_titile(project)

--- a/test/integration/cli/test_version.py
+++ b/test/integration/cli/test_version.py
@@ -1,7 +1,7 @@
 import subprocess
 
 import pytest
-from project import remove_project_file
+from project import copy_project, remove_project_file
 from utils import run_command_and_get_output
 
 
@@ -14,17 +14,9 @@ def test_version_command(cartridge_cmd, version_cmd):
 
 
 @pytest.mark.parametrize('version_cmd', ['version', '-v', '--version'])
-def test_version_command_with_project(project_with_cartridge, version_cmd, cartridge_cmd, tmpdir):
+def test_version_command_with_project(project_with_cartridge, version_cmd, cartridge_cmd):
     project = project_with_cartridge
-
-    cmd = [
-        cartridge_cmd,
-        "build",
-        project.path
-    ]
-
-    process = subprocess.run(cmd, cwd=tmpdir)
-    assert process.returncode == 0
+    copy_project("project_with_cartridge", project)
 
     cmd = [
         cartridge_cmd, version_cmd,
@@ -40,17 +32,9 @@ def test_version_command_with_project(project_with_cartridge, version_cmd, cartr
 
 
 @pytest.mark.parametrize('version_cmd', ['version', '-v', '--version'])
-def test_version_command_with_rocks(project_with_cartridge, version_cmd, cartridge_cmd, tmpdir):
+def test_version_command_with_rocks(project_with_cartridge, version_cmd, cartridge_cmd):
     project = project_with_cartridge
-
-    cmd = [
-        cartridge_cmd,
-        "build",
-        project.path
-    ]
-
-    process = subprocess.run(cmd, cwd=tmpdir)
-    assert process.returncode == 0
+    copy_project("project_with_cartridge", project)
 
     cmd = [
         cartridge_cmd,
@@ -113,17 +97,9 @@ def test_version_command_invalid_path(cartridge_cmd, version_cmd):
 
 
 @pytest.mark.parametrize('version_cmd', ['version', '-v', '--version'])
-def test_duplicate_rocks(project_with_cartridge, cartridge_cmd, version_cmd, tmpdir):
+def test_duplicate_rocks(project_with_cartridge, cartridge_cmd, version_cmd):
     project = project_with_cartridge
-
-    cmd = [
-        cartridge_cmd,
-        "build",
-        project.path
-    ]
-
-    process = subprocess.run(cmd, cwd=tmpdir)
-    assert process.returncode == 0
+    copy_project("project_with_cartridge", project)
 
     # Cartridge already has graphql dependency
     cmd = [
@@ -147,15 +123,9 @@ def test_duplicate_rocks(project_with_cartridge, cartridge_cmd, version_cmd, tmp
 
 
 @pytest.mark.parametrize('version_cmd', ['version', '-v', '--version'])
-def test_duplicate_cartridge_no_rocks_flag(project_with_cartridge, cartridge_cmd, version_cmd, tmpdir):
+def test_duplicate_cartridge_no_rocks_flag(project_with_cartridge, cartridge_cmd, version_cmd):
     project = project_with_cartridge
-
-    cmd = [
-        cartridge_cmd, "build", project.path
-    ]
-
-    process = subprocess.run(cmd, cwd=tmpdir)
-    assert process.returncode == 0
+    copy_project("project_with_cartridge", project)
 
     # Install one more Cartridge
     cmd = [

--- a/test/integration/create/test_create.py
+++ b/test/integration/create/test_create.py
@@ -3,7 +3,7 @@ import stat
 import subprocess
 
 import pytest
-from project import Project
+from project import Project, copy_project
 from utils import recursive_listdir, run_command_and_get_output
 
 
@@ -13,11 +13,10 @@ def default_project(cartridge_cmd, module_tmpdir):
     return project
 
 
-def test_project(cartridge_cmd, default_project):
+def test_project(default_project):
     project = default_project
 
-    process = subprocess.run([cartridge_cmd, 'build'], cwd=project.path)
-    assert process.returncode == 0, "Error building project"
+    copy_project("default_project", project)
 
     process = subprocess.run(['./deps.sh'], cwd=project.path)
     assert process.returncode == 0, "Installing deps failed"
@@ -42,7 +41,7 @@ def test_project_recreation(cartridge_cmd, default_project):
 
     rc, output = run_command_and_get_output(cmd)
     assert rc == 1
-    assert "Application already exists in {}".format(project.path) in output
+    assert "Application already exists in {}".format(project.path[:-6]) in output
 
     # check that project directory wasn't deleted
     assert os.path.exists(project.path)

--- a/test/integration/repair/test_repair_reload.py
+++ b/test/integration/repair/test_repair_reload.py
@@ -2,7 +2,7 @@ import subprocess
 
 import pytest
 import requests
-from project import (patch_cartridge_proc_titile,
+from project import (copy_project, patch_cartridge_proc_titile,
                      patch_cartridge_returned_version)
 from utils import (check_instances_running, check_instances_stopped,
                    create_replicaset, run_command_and_get_output,
@@ -102,13 +102,7 @@ def test_repair_reload_set_leader(cartridge_cmd, start_stop_cli, project_with_ca
     project = project_with_cartridge
     cli = start_stop_cli
 
-    cmd = [
-        cartridge_cmd,
-        "build",
-        project.path
-    ]
-    process = subprocess.run(cmd, cwd=tmpdir)
-    assert process.returncode == 0, "Error during building the project"
+    copy_project("project_with_cartridge", project)
 
     # patch cartridge.cfg to don't change process title
     patch_cartridge_proc_titile(project)
@@ -180,13 +174,7 @@ def test_repair_reload_remove_instance(cartridge_cmd, start_stop_cli, project_wi
     project = project_with_cartridge
     cli = start_stop_cli
 
-    cmd = [
-        cartridge_cmd,
-        "build",
-        project.path
-    ]
-    process = subprocess.run(cmd, cwd=tmpdir)
-    assert process.returncode == 0, "Error during building the project"
+    copy_project("project_with_cartridge", project)
 
     # patch cartridge.cfg to don't change process title
     patch_cartridge_proc_titile(project)
@@ -268,13 +256,7 @@ def test_repair_reload_set_uri(cartridge_cmd, start_stop_cli, project_with_cartr
     project = project_with_cartridge
     cli = start_stop_cli
 
-    cmd = [
-        cartridge_cmd,
-        "build",
-        project.path
-    ]
-    process = subprocess.run(cmd, cwd=tmpdir)
-    assert process.returncode == 0, "Error during building the project"
+    copy_project("project_with_cartridge", project)
 
     # patch cartridge.cfg to don't change process title
     patch_cartridge_proc_titile(project)

--- a/test/integration/replicasets/test_setup.py
+++ b/test/integration/replicasets/test_setup.py
@@ -1,9 +1,8 @@
 import os
-import subprocess
 
 import yaml
 from integration.replicasets.utils import get_list_from_log_lines
-from project import patch_cartridge_proc_titile
+from project import copy_project, patch_cartridge_proc_titile
 from utils import (get_log_lines, get_replicasets, is_vshard_bootstrapped,
                    run_command_and_get_output, write_conf)
 
@@ -61,13 +60,7 @@ def test_default_application(cartridge_cmd, start_stop_cli, project_with_cartrid
     cli = start_stop_cli
     project = project_with_cartridge
 
-    # build project
-    cmd = [
-        cartridge_cmd,
-        "build",
-    ]
-    process = subprocess.run(cmd, cwd=project.path)
-    assert process.returncode == 0, "Error during building the project"
+    copy_project("project_with_cartridge", project)
 
     # don't change process title
     patch_cartridge_proc_titile(project)

--- a/test/make_preparations/test_build_projects.py
+++ b/test/make_preparations/test_build_projects.py
@@ -1,0 +1,48 @@
+import os
+import shutil
+import subprocess
+
+import pytest
+from project import Project
+
+
+@pytest.fixture(scope="module")
+def default_project(cartridge_cmd, module_tmpdir):
+    project = Project(cartridge_cmd, 'default-project', module_tmpdir, 'cartridge')
+    return project
+
+
+def test_make_project_with_cartridge(project_with_cartridge, cartridge_cmd, tmpdir):
+    project = project_with_cartridge
+    dir = os.getenv("CC_TEST_PREBUILT_PROJECTS")
+    if dir is None:
+        print("Directory for cartridge-cli integration tests prebuilt projects is not set.\n",
+              "Please set enviromental variable: CC_TEST_PREBUILT_PROJECTS")
+        assert dir is not None
+    path = dir + "/project_with_cartridge"
+
+    cmd = [
+        cartridge_cmd, "build", project.path
+    ]
+
+    process = subprocess.run(cmd, cwd=tmpdir)
+    assert process.returncode == 0
+    shutil.copytree(project.path, path)
+
+
+def test_make_default_project(default_project, cartridge_cmd, tmpdir):
+    project = default_project
+    dir = os.getenv("CC_TEST_PREBUILT_PROJECTS")
+    if dir is None:
+        print("Directory for cartridge-cli integration tests prebuilt projects is not set.\n",
+              "Please set enviromental variable: CC_TEST_PREBUILT_PROJECTS")
+        assert dir is not None
+    path = dir + "/default_project"
+
+    cmd = [
+        cartridge_cmd, "build", project.path
+    ]
+
+    process = subprocess.run(cmd, cwd=tmpdir)
+    assert process.returncode == 0
+    shutil.copytree(project.path, path)

--- a/test/project.py
+++ b/test/project.py
@@ -617,3 +617,9 @@ def set_and_return_whoami_on_build(rockspec_path, project_name, version):
             '''.format(project_name, version, who_am_i))
 
     return who_am_i
+
+
+def copy_project(project_name, project):
+    dir = os.getenv("CC_TEST_PREBUILT_PROJECTS")
+    shutil.copytree(dir + "/" + project_name, project.path + "/built")
+    project.path = project.path + "/built"


### PR DESCRIPTION
Separated integration tests from linter, unit, e2e and examples checks.
Result: ~15% faster testing.
Added pre-building of slow projects.
Total result: ~40-65% faster.
Closes #690 

