### PR TITLE
Fix markup whitespace

### DIFF
--- a/.github/workflows/push-translation.yml
+++ b/.github/workflows/push-translation.yml
@@ -3,7 +3,8 @@ name: Push translation sources
 on:
   pull_request:
     paths:
-      - '*.rst'
+      - 'doc/**/*.rst'
+      - 'doc/conf.py'
 jobs:
   push-translation-sources:
     runs-on: ubuntu-latest

--- a/doc/commands/start.rst
+++ b/doc/commands/start.rst
@@ -44,7 +44,9 @@ Flags
                 Another use case would be if your application's init script
                 generates errors, so Tarantool can handle them.
         *   -   ``--stateboard``
-            -   Start the application stateboard and the instances.
+            -   Start the application
+                :ref:`stateboard <cartridge-stateful_failover>`
+                and the instances.
                 Ignored if ``--stateboard-only`` is specified.
         *   -   ``--stateboard-only``
             -   Start only the application stateboard.
@@ -76,7 +78,7 @@ Flags
         *   -   ``--cfg``
             -   Path to the Cartridge instances configuration file.
                 Defaults to ``./instances.yml``.
-                ``cfg``is also a section of ``.cartridge.yml``.
+                ``cfg`` is also a section of ``.cartridge.yml``.
                 Learn more about
                 :doc:`instance paths </book/cartridge/cartridge_cli/instance-paths>`.
 
@@ -105,3 +107,4 @@ If the instance is started in the background, a notify socket path is passed add
 
 ``cartridge.cfg()`` uses  ``TARANTOOL_APP_NAME`` and ``TARANTOOL_INSTANCE_NAME``
 to read the instance's configuration from the file provided in ``TARANTOOL_CFG``.
+


### PR DESCRIPTION
Markup is broken on the [start](https://www.tarantool.io/en/doc/latest/book/cartridge/cartridge_cli/commands/start/) doc page:

<img width="510" alt="image" src="https://user-images.githubusercontent.com/42832629/178482623-02dbd4d1-c6da-4ef7-9222-ee710f358e15.png">

