### PR TITLE
Add missing whitespace

### DIFF
--- a/doc/commands/start.rst
+++ b/doc/commands/start.rst
@@ -78,7 +78,7 @@ Flags
         *   -   ``--cfg``
             -   Path to the Cartridge instances configuration file.
                 Defaults to ``./instances.yml``.
-                ``cfg``is also a section of ``.cartridge.yml``.
+                ``cfg`` is also a section of ``.cartridge.yml``.
                 Learn more about
                 :doc:`instance paths </book/cartridge/cartridge_cli/instance-paths>`.
 

--- a/doc/locale/ru/LC_MESSAGES/doc/commands/start.po
+++ b/doc/locale/ru/LC_MESSAGES/doc/commands/start.po
@@ -166,7 +166,7 @@ msgstr "``--cfg``"
 
 msgid ""
 "Path to the Cartridge instances configuration file. Defaults to "
-"``./instances.yml``. ``cfg``is also a section of ``.cartridge.yml``. Learn "
+"``./instances.yml``. ``cfg`` is also a section of ``.cartridge.yml``. Learn "
 "more about :doc:`instance paths </book/cartridge/cartridge_cli/instance-"
 "paths>`."
 msgstr ""


### PR DESCRIPTION
Markup is broken on the [start](https://www.tarantool.io/en/doc/latest/book/cartridge/cartridge_cli/commands/start/) doc page:

<img width="700" alt="image" src="https://user-images.githubusercontent.com/42832629/178483077-5245dd6e-9254-473c-a8b5-3d5118887d7d.png">

