### PR TITLE
connector: add fix for long socket paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- A unix domain socket pathname (used in cartridge-cli to connect to instances) longer
+  than the value defined by the system resulted in a connection error.
+  It now works fine or throws a human readable error if we can't work around this
+  limitation by connecting to an instance with a relative socket path.
+
 ### Added
 
 - Tarantool benchmark tool update (select and update operations):

--- a/cli/connector/connector.go
+++ b/cli/connector/connector.go
@@ -3,6 +3,8 @@ package connector
 import (
 	"fmt"
 	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -48,6 +50,19 @@ func Connect(connString string, opts Opts) (*Conn, error) {
 	conn := &Conn{}
 
 	connOpts := getConnOpts(connString, opts.Username, opts.Password)
+
+	if _, err := os.Stat(connOpts.Address); err == nil {
+		workDir, err := os.Getwd()
+		if err != nil {
+			return nil, err
+		}
+		os.Chdir(filepath.Dir(connOpts.Address))
+		connOpts.Address = "./" + filepath.Base(connOpts.Address)
+		defer os.Chdir(workDir)
+		if len(connOpts.Address) > 108 {
+			return nil, fmt.Errorf("Address is exceeding sun_path limit.(108 bytes)")
+		}
+	}
 
 	// connect to specified address
 	plainTextConn, err := net.Dial(connOpts.Network, connOpts.Address)


### PR DESCRIPTION
Now relative path is used instead of real for console socket. It is used to prevent console socket path from being too long.
Before if connection addres was too long it returned an error, now it works.

Needed for [that issue](https://github.com/tarantool/tt/issues/124)

I didn't forget about

- Tests (CI is still green)
- Changelog (Added)
- Documentation (not worth to mention)
