### PR TITLE
code-health: set CI/CD Go version as string

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
       - '*'
 
 env:
-  GO_VERSION: 1.18
+  GO_VERSION: '1.18'
   GORELEASER_VERSION: v0.146.0
 
 jobs:
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '${{ env.GO_VERSION }}'
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Setup Mage
         run: |
@@ -68,7 +68,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '${{ env.GO_VERSION }}'
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Setup Mage
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: 1.18
+  GO_VERSION: '1.18'
   PYTHON_VERSION: '3.x'
 
 jobs:
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '${{ env.GO_VERSION }}'
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Setup Mage
         run: |
@@ -134,7 +134,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '${{ env.GO_VERSION }}'
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Setup Mage
         run: |


### PR DESCRIPTION
There is no reason to set Go version as a number: float value can lead to errors due to float precision, and in each place where the value is used it is converted to a string.

I didn't forget about

- Tests (CI is still green)
- Changelog (not worth to mention)
- Documentation (not worth to mention)
