### PR TITLE
ci: add license checker

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,6 +101,14 @@ jobs:
         if: matrix.tests == 'other'
         run: mage lint
 
+      - name: Build cartridge
+        run: mage build
+
+      - name: License checker
+        run: |
+          go install github.com/uw-labs/lichen@latest
+          mage checklicenses
+
       - name: Unit tests
         if: matrix.tests == 'other'
         run: mage unit
@@ -197,6 +205,14 @@ jobs:
       - name: Linter
         if: matrix.tests == 'other'
         run: mage lint
+
+      - name: Build cartridge
+        run: mage build
+
+      - name: License checker
+        run: |
+          go install github.com/uw-labs/lichen@latest
+          mage checklicenses
 
       - name: Unit tests
         if: matrix.tests == 'other'

--- a/.lichen.yaml
+++ b/.lichen.yaml
@@ -1,0 +1,10 @@
+allow:
+  - "MIT"
+  - "Apache-2.0"
+  - "BSD-3-Clause"
+  - "BSD-2-Clause"
+  - "MPL-2.0"
+  - "CC-BY-SA-4.0"
+override:
+  - path: "github.com/robfig/config"
+    licenses: ["MPL-2.0"]

--- a/README.dev.md
+++ b/README.dev.md
@@ -19,17 +19,17 @@
    rpm --version
    cpio --version
    ```
-   
+
 4. Install [git](https://git-scm.com/downloads).
    ```bash
    git --version
    ```
-      
+
 5. Install [docker](https://www.docker.com/get-started).
    ```bash
    docker --version
    ```
-    
+
 6. Install [Tarantool](https://www.tarantool.io/en/download/os-installation/) (1.10 or 2.x version).
    ```bash
    tarantool --version
@@ -43,7 +43,7 @@
    ```bash
    export PATH=$(go env GOPATH)/bin:$PATH
    ```
-     
+
 8. Install [pytest](https://docs.pytest.org/en/6.2.x/getting-started.html).
    ```bash
    python3 -m pytest --version
@@ -54,21 +54,26 @@
    git clone git@github.com:tarantool/cartridge-cli.git
    cd ./cartridge-cli
    ```
-   
+
 10. To run tests, git user must be configured. For example,
     ```bash
     git config --global user.email "test@tarantool.io"
     git config --global user.name "Tar Antool"
     ```
-   
+
 11. Install pytest dependencies.
     ```bash
     pip3 install -r test/requirements.txt
     ```
-    
+
 12. Install luacheck.
     ```bash
     tarantoolctl rocks install luacheck
+    ```
+
+13. Install lichen.
+    ```bash
+    go install github.com/uw-labs/lichen@latest
     ```
 
 All remaining dependencies (like code generation) will be invoked with mage if needed.

--- a/magefile.go
+++ b/magefile.go
@@ -124,6 +124,22 @@ func GenerateGoCode() error {
 	return nil
 }
 
+// Run license checker.
+func CheckLicenses() error {
+	fmt.Println("Running license checker...")
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+
+	if err := sh.RunV(home+"/go/bin/lichen", "--config", ".lichen.yaml", "cartridge"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // Run go vet and flake8
 func Lint() error {
 	mg.Deps(GenerateGoCode)
@@ -195,7 +211,7 @@ func E2e() error {
 
 // Run all tests
 func Test() {
-	mg.SerialDeps(Lint, Unit, Integration, TestExamples, E2e)
+	mg.SerialDeps(Lint, CheckLicenses, Unit, Integration, TestExamples, E2e)
 }
 
 // Build cartridge-cli executable


### PR DESCRIPTION
We need to check the licenses of modules that came from dependencies. CI should return an error if the licenses are not in the list:

BSD-2
MIT
Apache-2.0
BSD
MPL-2.0

I didn't forget about

- [not needed] Tests
- [not needed] Changelog
- [Done] Documentation

Closes #737
