### PR TITLE
Update installation docs

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -28,7 +28,7 @@ Installation
 
     ..  code-block:: bash
 
-        curl -L https://tarantool.io/installer.sh | sudo -E bash -s -- --repo-only
+        curl -L https://tarantool.io/release/2/installer.sh | sudo -E bash -s -- --repo-only
 
 4.  Install the ``cartridge-cli`` package:
 


### PR DESCRIPTION
Path to installer.sh now must include the version of Tarantool, because installer supports installing several versions.

Issue reported by @ahriman-ru
