### PR TITLE
Preserve file times when copying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Updated `cartridge` to `2.7.6` and `metrics` to `0.15.1` in application template.
+- Now file times are preserved when copying.
 
 ## [2.12.3] - 2022-11-09
 

--- a/cli/pack/app_dir.go
+++ b/cli/pack/app_dir.go
@@ -176,7 +176,7 @@ func copyPathFromCache(cachedPath string, destPath string, pathFromRoot string) 
 		cachedPath = filepath.Join(cachedPath, baseDestPath)
 	}
 
-	if err := copy.Copy(cachedPath, destPath); err != nil {
+	if err := copy.Copy(cachedPath, destPath, copy.Options{PreserveTimes: true}); err != nil {
 		return fmt.Errorf("Failed to copy path %s from cache to project directory: %s", destPath, err)
 	}
 
@@ -315,7 +315,7 @@ func updateCache(paths CachePaths, ctx *context.Ctx) error {
 		// temporary directory with application files do not contain
 		// such packages, because they were copied from the directory
 		// in the same way.
-		if err := copy.Copy(copyPath, cacheDir); err != nil {
+		if err := copy.Copy(copyPath, cacheDir, copy.Options{PreserveTimes: true}); err != nil {
 			log.Warnf("Failed copy %s to cache: %s", copyPath, err)
 		}
 
@@ -351,6 +351,7 @@ func copyProjectFiles(dst string, ctx *context.Ctx) error {
 	}
 
 	err := copy.Copy(ctx.Project.Path, dst, copy.Options{
+		PreserveTimes: true,
 		Skip: func(src string) (bool, error) {
 			if strings.HasPrefix(src, fmt.Sprintf("%s/", ctx.Cli.CartridgeTmpDir)) {
 				return true, nil

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/magefile/mage v1.11.0
 	github.com/mattn/go-isatty v0.0.12
 	github.com/mitchellh/mapstructure v1.4.1
-	github.com/otiai10/copy v1.2.0
+	github.com/otiai10/copy v1.7.1
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/robfig/config v0.0.0-20141207224736-0f78529c8c7e
 	github.com/shirou/gopsutil v3.21.2+incompatible
@@ -60,7 +60,7 @@ require (
 	github.com/tklauser/numcpus v0.2.1 // indirect
 	github.com/vmihailenco/tagparser v0.1.2 // indirect
 	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 // indirect
-	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect
+	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
 	golang.org/x/tools v0.1.5 // indirect
 	google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a // indirect
 	google.golang.org/grpc v1.39.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -539,13 +539,13 @@ github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mo
 github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqiriPsEqVhc+svHE=
 github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3ogry1nUQF8Evvo=
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
-github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=
-github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
+github.com/otiai10/copy v1.7.1 h1:SOSQHrLZhfpeL5djcKMDPVdYQbEiNYFNPdmdffR8tXs=
+github.com/otiai10/copy v1.7.1/go.mod h1:hsfX19wcn0UWIHUQ3/4fHuehhk2UyArQ9dVFAn3FczI=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
 github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
-github.com/otiai10/mint v1.3.1 h1:BCmzIS3n71sGfHB5NMNDB3lHYPz8fWSkCAErHed//qc=
-github.com/otiai10/mint v1.3.1/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
+github.com/otiai10/mint v1.4.0 h1:umwcf7gbpEwf7WFzqmWwSv0CzbeMsae2u9ZvpP8j2q4=
+github.com/otiai10/mint v1.4.0/go.mod h1:gifjb2MYOoULtKLqUAEILUG/9KONW6f7YsJ6vQLTlFI=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=


### PR DESCRIPTION
Before this commit, file copy operations updated the modification time of the copied files.
It caused a cache invalidation for [cargo](https://doc.rust-lang.org/stable/cargo/).

- Update github.com/otiai10/copy to 1.7.1
- use copy.Copy with `PreserveTimes: true` option

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Closes #???
