### PR TITLE
Fix using tarantoolctl in tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     if: |
       github.event_name == 'push' ||
       github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login != 'tarantool'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         tarantool-version: ["1.10", "2.8", "2.x-latest"]
@@ -128,7 +128,7 @@ jobs:
   tests-ee:
     if: |
       github.event_name == 'push'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         tests: ["other", "integration"]


### PR DESCRIPTION
The problem is that on Ubuntu 22.04 luarocks v3 from the `tarantool-common` package is installed, but tarantoolctl from tarantool 1.10 uses luarocks v2.
See [1] for more details.

[1] https://github.com/tarantool/tarantool/issues/5429#issuecomment-1336162554
