### PR TITLE
Run post-build stage after cache update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Updated `cartridge` to `2.7.6` and `metrics` to `0.15.1` in application template.
 - Now file times are preserved when copying.
+- Now packing cache saves before post-build stage
 
 ## [2.12.3] - 2022-11-09
 

--- a/cli/pack/app_dir.go
+++ b/cli/pack/app_dir.go
@@ -98,14 +98,14 @@ func initAppDir(appDirPath string, ctx *context.Ctx) error {
 		return err
 	}
 
-	// post-build
-	if err := build.PostRun(ctx); err != nil {
-		return err
-	}
-
 	// Update cache in cartridge temp directory
 	if err := updateCache(cachePaths, ctx); err != nil {
 		log.Warnf("%s", err)
+	}
+
+	// post-build
+	if err := build.PostRun(ctx); err != nil {
+		return err
 	}
 
 	// generate VERSION file


### PR DESCRIPTION
At the moment, the packaging cache is updated after the post-build stage. So if folders such as node_modules, target, etc. are deleted at the post-build stage, they will not get into the cache.

In this commit, the packaging cache update stage runs before the post-build stage.

I didn't forget about

- [x] Tests
- [x] Changelog
- [ ] Documentation

