### PR TITLE
template: luatest best practices

### DIFF
--- a/cli/create/templates/cartridge/test/integration/api_test.lua
+++ b/cli/create/templates/cartridge/test/integration/api_test.lua
@@ -2,30 +2,29 @@ local t = require('luatest')
 local g = t.group('integration_api')
 
 local helper = require('test.helper')
-local cluster = helper.cluster
 
-g.before_all(function()
-    g.cluster = helper.cluster
-    g.cluster:start()
+g.before_all(function(cg)
+    cg.cluster = helper.cluster
+    cg.cluster:start()
 end)
 
-g.after_all(function()
-    helper.stop_cluster(g.cluster)
+g.after_all(function(cg)
+    helper.stop_cluster(cg.cluster)
 end)
 
-g.before_each(function()
+g.before_each(function(cg) -- luacheck: no unused args
     -- helper.truncate_space_on_cluster(g.cluster, 'Set your space name here')
 end)
 
-g.test_sample = function()
-    local server = cluster.main_server
+g.test_sample = function(cg)
+    local server = cg.cluster.main_server
     local response = server:http_request('post', '/admin/api', {json = {query = '{ cluster { self { alias } } }'}})
     t.assert_equals(response.json, {data = { cluster = { self = { alias = 'api' } } }})
     t.assert_equals(server.net_box:eval('return box.cfg.memtx_dir'), server.workdir)
 end
 
-g.test_metrics = function()
-    local server = cluster.main_server
+g.test_metrics = function(cg)
+    local server = cg.cluster.main_server
     local response = server:http_request('get', '/metrics')
     t.assert_equals(response.status, 200)
     t.assert_equals(response.reason, "Ok")

--- a/cli/create/templates/cartridge/test/integration/api_test.lua
+++ b/cli/create/templates/cartridge/test/integration/api_test.lua
@@ -4,18 +4,18 @@ local g = t.group('integration_api')
 local helper = require('test.helper')
 local cluster = helper.cluster
 
-g.before_all = function()
+g.before_all(function()
     g.cluster = helper.cluster
     g.cluster:start()
-end
+end)
 
-g.after_all = function()
+g.after_all(function()
     helper.stop_cluster(g.cluster)
-end
+end)
 
-g.before_each = function()
+g.before_each(function()
     -- helper.truncate_space_on_cluster(g.cluster, 'Set your space name here')
-end
+end)
 
 g.test_sample = function()
     local server = cluster.main_server

--- a/cli/create/templates/cartridge/test/unit/sample_test.lua
+++ b/cli/create/templates/cartridge/test/unit/sample_test.lua
@@ -2,11 +2,11 @@ local t = require('luatest')
 local g = t.group('unit_sample')
 
 -- create your space here
-g.before_all(function() end)
+g.before_all(function(cg) end) -- luacheck: no unused args
 
 -- drop your space here
-g.after_all(function() end)
+g.after_all(function(cg) end) -- luacheck: no unused args
 
-g.test_sample = function()
+g.test_sample = function(cg) -- luacheck: no unused args
     t.assert_equals(type(box.cfg), 'table')
 end

--- a/test/integration/pack/test_pack_docker.py
+++ b/test/integration/pack/test_pack_docker.py
@@ -331,7 +331,7 @@ def test_image_specific_tarantool_versions(cartridge_cmd, project_without_depend
     project = project_without_dependencies
 
     tarantool_versions = [
-        {"input": "2", "expect": "Tarantool 2.10"},
+        {"input": "2", "expect": "Tarantool 2"},
         {"input": "2.8", "expect": "Tarantool 2.8.4-0-"},
         {"input": "2.8.1", "expect": "Tarantool 2.8.1-0-"},
         {"input": "2.10.0-beta1", "expect": "Tarantool 2.10.0-beta1"},


### PR DESCRIPTION
Setting before/after hooks through assignment is an outdated way of setting hooks with luatest. It is unsupported with modern hooks like before_test/after_test and doesn't support multiple hooks. Similar issue had been solved in tarantool/tarantool recently [1].

1. https://github.com/tarantool/tarantool/issues/8066

Test group entity is passed to each hook/test. Legacy approach is to use group as global variable, which should work for simple groups, but is invalid for parametrized ones. `cg` variable name was borrowed from luatest README (it is likely a "current group" abbreviation).