### PR TITLE
enter: fix crash on `\q`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fixed support for instance names as application name and names with dots.
+- `cartridge enter` now does not crash on `\q` input.
 
 ## [2.12.4] - 2022-12-31
 

--- a/cli/connect/console.go
+++ b/cli/connect/console.go
@@ -212,6 +212,9 @@ func getExecutor(console *Console) prompt.Executor {
 			} else {
 				log.Fatalf("Failed to execute command: %s", err)
 			}
+		} else if len(results) == 0 {
+			log.Infof("Connection closed")
+			os.Exit(0)
 		} else {
 			data = results[0]
 		}


### PR DESCRIPTION
Fixed crash on \q input in cartridge enter.
In this case, instance returns an empty response,
add a check for this.

Closes #705
