### PR TITLE
cd: update go version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
       - '*'
 
 env:
-  GO_VERSION: '1.18'
+  GO_VERSION: '1.20.4'
   GORELEASER_VERSION: v0.146.0
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: '1.18'
+  GO_VERSION: '1.20.4'
   PYTHON_VERSION: '3.x'
 
 jobs:


### PR DESCRIPTION
The previously used version of go had a number of known security issues. It is time to upgrade.

List of known issues:
```
+-------------------+---------------------------------------+----------------+
|        CVE        |         Infected Version              |  Fix Version   |
+-------------------+---------------------------------------+----------------+
| CVE-2023-24538    | < 1.19.8,1.20.0-0 ≤ Ver < 1.20.3      | 1.19.8,1.20.3  |
| CVE-2023-24540    | < 1.19.9,1.20.0-0 ≤ Ver < 1.20.4      | 1.19.9,1.20.4  |
| CVE-2022-30635    | < 1.17.12,1.18.0-0 ≤ Ver < 1.18.4     | 1.17.12,1.18.4 |
| CVE-2022-28131    | < 1.17.12,1.18.0 ≤ Ver < 1.18.4       | 1.17.12,1.18.4 |
| CVE-2022-30580    | < 1.17.11,1.18.0-0 ≤ Ver < 1.18.3     | 1.17.11,1.18.3 |
| CVE-2023-24534    | < 1.19.8,1.20.0-0 ≤ Ver < 1.20.3      | 1.19.8,1.20.3  |
| CVE-2022-41724    | < 1.19.6,1.20.0-0 ≤ Ver < 1.20.1      | 1.19.6,1.20.1  |
| CVE-2022-30633    | < 1.17.12,1.18.0-0 ≤ Ver < 1.18.4     | 1.17.12,1.18.4 |
| CVE-2022-30630    | < 1.17.12,1.18.0-0 ≤ Ver < 1.18.4     | 1.17.12,1.18.4 |
| CVE-2022-29804    | < 1.17.11,1.18.0 ≤ Ver < 1.18.3       | 1.17.11,1.18.3 |
| CVE-2023-24539    | < 1.19.9,1.20.0-0 ≤ Ver < 1.20.4      | 1.19.9,1.20.4  |
| CVE-2022-41725    | < 1.19.6,1.20.0-0 ≤ Ver < 1.20.1      | 1.19.6,1.20.1  |
| CVE-2023-29400    | < 1.19.9,1.20.0-0 ≤ Ver < 1.20.4      | 1.19.9,1.20.4  |
| CVE-2022-41722    | < 1.19.6,1.20.0-0 ≤ Ver < 1.20.1      | 1.19.6,1.20.1  |
| CVE-2022-32189    | < 1.17.13,1.18.0-0 ≤ Ver < 1.18.5     | 1.17.13,1.18.5 |
| CVE-2022-2880     | < 1.18.7,1.19.0-0 ≤ Ver < 1.19.2      | 1.18.7,1.19.2  |
| CVE-2022-30631    | < 1.17.12,1.18.0 ≤ Ver < 1.18.4       | 1.17.12,1.18.4 |
| CVE-2022-41716    | < 1.18.8,1.19.0-0 ≤ Ver < 1.19.3      | 1.18.8,1.19.3  |
| CVE-2022-2879     | < 1.18.7,1.19.0-0 ≤ Ver < 1.19.2      | 1.18.7,1.19.2  |
| CVE-2022-41715    | < 1.18.7,1.19.0-0 ≤ Ver < 1.19.2      | 1.18.7,1.19.2  |
| CVE-2023-24536    | < 1.19.8,1.20.0-0 ≤ Ver < 1.20.3      | 1.19.8,1.20.3  |
| CVE-2022-30634    | < 1.17.11,1.18.0-0 ≤ Ver < 1.18.3     | 1.17.11,1.18.3 |
| CVE-2022-30632    | < 1.17.12,1.18.0 ≤ Ver < 1.18.4       | 1.17.12,1.18.4 |
| CVE-2022-41720    | < 1.18.9,1.19.0-0 ≤ Ver < 1.19.4      | 1.18.9,1.19.4  |
| CVE-2023-24537    | < 1.19.8,1.20.0-0 ≤ Ver < 1.20.3      | 1.19.8,1.20.3  |
| CVE-2022-32148    | < 1.17.12,1.18.0-0 ≤ Ver < 1.18.4     | 1.17.12,1.18.4 |
| CVE-2023-24532    | < 1.19.7,1.20.0-0 ≤ Ver < 1.20.2      | 1.19.7,1.20.2  |
| CVE-2022-1705     | < 1.17.12,1.18.0-0 ≤ Ver < 1.18.4     | 1.17.12,1.18.4 |
| CVE-2022-1962     | < 1.17.12,1.18.0 ≤ Ver < 1.18.4       | 1.17.12,1.18.4 |
| CVE-2022-30636    | ≤ 1.18.3                              | 1.18.4         |
| CVE-2022-30629    | < 1.17.11,1.18.0-0 ≤ Ver < 1.18.3     | 1.17.11,1.18.3 |
+-------------------+---------------------------------------+----------------+
```