### PR TITLE
cd: update go version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
       - '*'
 
 env:
-  GO_VERSION: '1.20.4'
+  GO_VERSION: '1.20.5'
   GORELEASER_VERSION: v0.146.0
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: '1.20.4'
+  GO_VERSION: '1.20.5'
   PYTHON_VERSION: '3.x'
 
 jobs:


### PR DESCRIPTION
The previous version of go had a number of security issues. Upgraded to 1.20.5.
