### PR TITLE
doc: replace Cartridge CLI with tt CLI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,12 @@
 Cartridge Command Line Interface
 ================================
 
+.. important::
+
+    Cartridge CLI is deprecated in favor of `tt CLI <https://www.tarantool.io/en/doc/latest/reference/tooling/tt_cli/>`_.
+    Find the instructions on switching from Cartridge CLI to ``tt`` in
+    `Migration from Cartridge CLI to tt <https://www.tarantool.io/en/doc/latest/book/cartridge/cartridge_cli/migration-to-tt/>`_.
+
 ..  image:: https://img.shields.io/github/v/release/tarantool/cartridge-cli?include_prereleases&label=Release&labelColor=2d3532
     :alt: Cartridge CLI latest release on GitHub
     :target: https://github.com/tarantool/cartridge-cli/releases

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,6 +1,12 @@
 Cartridge Command Line Interface
 ================================
 
+.. important::
+
+    Cartridge CLI is deprecated in favor of `tt CLI <https://www.tarantool.io/en/doc/latest/reference/tooling/tt_cli/>`_.
+    Find the instructions on switching from Cartridge CLI to ``tt`` in
+    :doc:`Migration from Cartridge CLI to tt <migration-to-tt>`.
+
 Control your Tarantool application instances via the command line.
 
 ..  toctree::
@@ -8,6 +14,7 @@ Control your Tarantool application instances via the command line.
     :includehidden:
 
     lifecycle
+    migration-to-tt
     installation
     commands
     global-flags

--- a/doc/migration-to-tt.rst
+++ b/doc/migration-to-tt.rst
@@ -1,0 +1,56 @@
+Migration from Cartridge CLI to tt
+==================================
+
+.. note::
+
+    The migration instruction is also available in the
+    `tt repository <https://github.com/tarantool/tt/blob/master/doc/examples.md#transition-from-cartridge-cli-to-tt>`_
+    on GitHub.
+
+To start managing a Cartridge application with ``tt`` instead of Cartridge CLI,
+run ``tt init`` in the application directory:
+
+.. code-block::bash
+
+    $ tt init
+    • Found existing config '.cartridge.yml'
+    • Environment config is written to 'tt.yaml'
+
+This creates a ``tt`` environment based on the existing Cartridge configuration.
+Now you're ready to manage the application with ``tt``:
+
+.. code-block::bash
+
+    $ tt start
+    • Starting an instance [app:s1-master]...
+    • Starting an instance [app:s1-replica]...
+    • Starting an instance [app:s2-master]...
+    • Starting an instance [app:s2-replica]...
+    • Starting an instance [app:stateboard]...
+    • Starting an instance [app:router]...
+    $ tt status
+    INSTANCE           STATUS          PID
+    app:s1-replica     RUNNING         112645
+    app:s2-master      RUNNING         112646
+    app:s2-replica     RUNNING         112647
+    app:stateboard     RUNNING         112655
+    app:router         RUNNING         112656
+    app:s1-master      RUNNING         112644
+
+Commands difference
+-------------------
+
+Most Cartridge CLI commands look the same in ``tt``: ``cartridge start`` and
+``tt start``, ``cartridge create`` and ``tt create``, and so on. To migrate such
+calls, it is usually enough to replace the utility name. There can be slight differences
+in command flags and format. For details on ``tt`` commands, see the
+:ref:`tt commands reference <tt-commands>`.
+
+The following commands are different in ``tt``:
+
+*   Cartridge CLI commands ``admin``, ``bench``, ``failover``, ``repair``, ``replicasets``
+    are implemented as subcommands of ``tt cartridge``. Example, ``tt cartridge repair``.
+*   ``cartridge enter`` and ``cartridge connect`` are covered by ``tt connect``.
+*   The analog of ``cartridge gen completion`` is ``tt completion``
+*   ``cartridge log`` and ``cartridge pack docker`` functionality is not supported in ``tt``.
+


### PR DESCRIPTION
Add deprecation note on main doc page
Provide instructions on migration to ``tt`` CLI

I didn't forget about

- [x] Tests - no test: documentation update
- [x] Changelog - no changelog: documentation update
- [x] Documentation - doc update

Part of https://github.com/tarantool/doc/issues/3501
