### PR TITLE
cd: fix completion scripts corruption

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,7 @@
 before:
   hooks:
     - go mod download
+    - mage genCompletion # generate completion scripts. In global hook to avoid parallel writing.
 
 env:
   - GO111MODULE=on
@@ -24,10 +25,6 @@ builds:
       - linux
     goarch:
       - amd64
-
-    hooks:
-      pre:
-        - mage genCompletion # generate completion scripts
 
 archives:
   -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Completion scripts corruption during package release.
+
 ## [2.12.11] - 2024-04-02
 
 ### Changed


### PR DESCRIPTION
The goreleaser tool runs builds and build hooks in parallel, which can sometimes cause multiple completion generation processes to write to the same file at the same time. To fix this, move the completion script generation outside of the "builds" section.
